### PR TITLE
Class C support for 0.0.10

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -163,7 +163,9 @@ OMNICORE_H = \
   mastercore_script.h \
   mastercore_sp.h \
   mastercore_tx.h \
-  mastercore_version.h
+  mastercore_version.h \
+  omnicore_encoding.h \
+  omnicore_utils.h
 
 OMNICORE_CPP = \
   mastercore.cpp \
@@ -174,7 +176,9 @@ OMNICORE_CPP = \
   mastercore_script.cpp \
   mastercore_sp.cpp \
   mastercore_tx.cpp \
-  mastercore_version.cpp
+  mastercore_version.cpp \
+  omnicore_encoding.cpp \
+  omnicore_utils.cpp
 
 BITCOIN_CORE_H += \
   $(OMNICORE_H)

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1177,7 +1177,8 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
           GetScriptPushes(wtx.vout[i].scriptPubKey, temp_op_return_script_data);
           if (temp_op_return_script_data.size() > 0) {
               if (temp_op_return_script_data[0].size() > 8) {
-                  if ("6f6d6e69" == temp_op_return_script_data[0].substr(0,8)) {
+                  if(("6f6d0000" == temp_op_return_script_data[0].substr(0,8)) ||
+                     ("6f6d0001" == temp_op_return_script_data[0].substr(0,8))) { // only v0/v1 txs are live, add 6f6d0002 to parse a v2 tx when one goes live
                       hasOmniBytes = true;
                   }
               }
@@ -2615,7 +2616,7 @@ int mastercore::ClassAgnostic_send(const string &senderAddress, const string &re
 {
     // Determine the class to send the transaction via - default is Class C
     int omniTxClass = OMNI_CLASS_C;
-    if(data.size()>nMaxDatacarrierBytes-4) omniTxClass = OMNI_CLASS_B;
+    if(data.size()>nMaxDatacarrierBytes-2) omniTxClass = OMNI_CLASS_B;
 
     // Prepare the transaction - first setup some vars
     CWallet *wallet = pwalletMain;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1500,7 +1500,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
               if (op_return_script_data[0].size() > 8) {
                   std::string payload = op_return_script_data[0].substr(8,op_return_script_data[0].size()-8); // strip out marker
                   packet_size=(payload.size())/2; // get packet byte size - hex so always a multiple of 2
-                  if(packet_size < MIN_PACKET_SIZE_CLASS_C) return -111;
+                  if(packet_size < MIN_PAYLOAD_SIZE) return -111;
                   memcpy(single_pkt, &ParseHex(payload)[0], packet_size); // load the packet ready to set mp tx info
               }
           }

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1478,8 +1478,8 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       // ### CLASS C SPECIFIC PARSING ###
       if (omniClass == OMNI_CLASS_C) {
           if (op_return_script_data.size() > 0) {
-              if (op_return_script_data[0].size() > 8) {
-                  std::string payload = op_return_script_data[0].substr(8,op_return_script_data[0].size()-8); // strip out marker
+              if (op_return_script_data[0].size() > 4) {
+                  std::string payload = op_return_script_data[0].substr(4,op_return_script_data[0].size()-4); // strip out marker
                   packet_size=(payload.size())/2; // get packet byte size - hex so always a multiple of 2
                   if(packet_size < MIN_PAYLOAD_SIZE) return -111;
                   memcpy(single_pkt, &ParseHex(payload)[0], packet_size); // load the packet ready to set mp tx info

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -114,9 +114,9 @@ static uint64_t exodus_balance;
 
 static boost::filesystem::path MPPersistencePath;
 
-const int msc_debug_parser_data = 1;
-const int msc_debug_parser= 1;
-const int msc_debug_verbose=1;
+const int msc_debug_parser_data = 0;
+const int msc_debug_parser= 0;
+const int msc_debug_verbose=0;
 const int msc_debug_verbose2=0;
 const int msc_debug_verbose3=0;
 const int msc_debug_vin   = 0;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2662,7 +2662,7 @@ int mastercore::ClassAgnostic_send(const string &senderAddress, const string &re
     CCoinControl coinControl;
     vector< pair<CScript, int64_t> > vecSend;
     bool fallBackToClassB = false;
-    if(data.size()>nMaxDatacarrierBytes) fallBackToClassB = true; // OP_RETURN data size limited to nMaxDatacarrierBytes bytes, if over this send via multisig
+    if(data.size()>nMaxDatacarrierBytes-4) fallBackToClassB = true; // OP_RETURN data size limited to nMaxDatacarrierBytes bytes (and we need 4 for the marker), if size is over this send via multisig
     CWalletTx wtxNew; // prepare a new transaction
     int64_t nFeeRet = 0;
     std::string strFailReason;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -114,9 +114,9 @@ static uint64_t exodus_balance;
 
 static boost::filesystem::path MPPersistencePath;
 
-const int msc_debug_parser_data = 0;
-const int msc_debug_parser= 0;
-const int msc_debug_verbose=0;
+const int msc_debug_parser_data = 1;
+const int msc_debug_parser= 1;
+const int msc_debug_verbose=1;
 const int msc_debug_verbose2=0;
 const int msc_debug_verbose3=0;
 const int msc_debug_vin   = 0;
@@ -1125,6 +1125,11 @@ int TXExodusFundraiser(const CTransaction &wtx, const string &sender, int64_t Ex
 static bool isAllowedOutputType(int whichType, int nBlock)
 {
   int p2shAllowed = 0;
+  int opReturnAllowed = 0;
+
+  if (OP_RETURN_BLOCK <= nBlock || isNonMainNet()) {
+    opReturnAllowed = 1;
+  }
 
   if (P2SH_BLOCK <= nBlock || isNonMainNet()) {
     p2shAllowed = 1;
@@ -1132,7 +1137,7 @@ static bool isAllowedOutputType(int whichType, int nBlock)
   // validTypes:
   // 1) Pay to pubkey hash
   // 2) Pay to Script Hash (IFF p2sh is allowed)
-  if ((TX_PUBKEYHASH == whichType) || (p2shAllowed && (TX_SCRIPTHASH == whichType))) {
+  if ((TX_PUBKEYHASH == whichType) || (p2shAllowed && (TX_SCRIPTHASH == whichType)) || (opReturnAllowed && (TX_NULL_DATA == whichType))) {
     return true;
   } else {
     return false;
@@ -1147,543 +1152,378 @@ static bool isAllowedOutputType(int whichType, int nBlock)
 // RETURNS: >0 if 1 or more payments have been made
 int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigned int idx, CMPTransaction *mp_tx, unsigned int nTime)
 {
-string strSender;
-// class A: data & address storage -- combine them into a structure or something
-vector<string>script_data;
-vector<string>address_data;
-// vector<uint64_t>value_data;
-vector<int64_t>value_data;
-int64_t ExodusValues[MAX_BTC_OUTPUTS]= { 0 };
-int64_t TestNetMoneyValues[MAX_BTC_OUTPUTS] = { 0 };  // new way to get funded on TestNet, send TBTC to moneyman address
-string strReference;
-unsigned char single_pkt[MAX_PACKETS * PACKET_SIZE];
-unsigned int packet_size = 0;
-int fMultisig = 0;
-int marker_count = 0, getmoney_count = 0;
-// class B: multisig data storage
-vector<string>multisig_script_data;
-uint64_t inAll = 0;
-uint64_t outAll = 0;
-uint64_t txFee = 0;
+  string strSender;
+  vector<string>script_data;
+  vector<string>address_data;
+  vector<int64_t>value_data;
+  vector<string>multisig_script_data;
+  vector<string>op_return_script_data;
+  CScript op_return_script;
+  int64_t ExodusValues[MAX_BTC_OUTPUTS] = { 0 };
+  int64_t TestNetMoneyValues[MAX_BTC_OUTPUTS] = { 0 };  // new way to get funded on TestNet, send TBTC to moneyman address
+  string strReference;
+  unsigned char single_pkt[MAX_PACKETS * PACKET_SIZE];
+  unsigned int packet_size = 0;
+  int fMultisig = 0;
+  bool fOPReturn = false;
+  int marker_count = 0, getmoney_count = 0;
+  bool hasOmniBytes = false;
+  uint64_t inAll = 0;
+  uint64_t outAll = 0;
+  uint64_t txFee = 0;
+  int omniClass = 0;
+  mp_tx->Set(wtx.GetHash(), nBlock, idx, nTime);
 
-            mp_tx->Set(wtx.GetHash(), nBlock, idx, nTime);
 
-            // quickly go through the outputs & ensure there is a marker (a send to the Exodus address)
-            for (unsigned int i = 0; i < wtx.vout.size(); i++)
-            {
-            CTxDestination dest;
-            string strAddress;
-
-              outAll += wtx.vout[i].nValue;
-
-              if (ExtractDestination(wtx.vout[i].scriptPubKey, dest))
-              {
-                strAddress = CBitcoinAddress(dest).ToString();
-
-                if (exodus_address == strAddress)
-                {
+  // ### EXODUS MARKER IDENTIFICATION ### - quickly go through the outputs & ensure there is a marker (a send to the Exodus address)
+  for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+      txnouttype outType;
+      if (!getOutputType(wtx.vout[i].scriptPubKey, outType)) continue; //unable to get an output type, ignore
+      if (outType == TX_PUBKEYHASH) { // look for exodus marker
+          CTxDestination dest;
+          string strAddress;
+          outAll += wtx.vout[i].nValue;
+          if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
+              strAddress = CBitcoinAddress(dest).ToString();
+              if (exodus_address == strAddress) {
                   ExodusValues[marker_count++] = wtx.vout[i].nValue;
-                }
-                else if (isNonMainNet() && (getmoney_testnet == strAddress))
-                {
+              } else if (isNonMainNet() && (getmoney_testnet == strAddress)) {
                   TestNetMoneyValues[getmoney_count++] = wtx.vout[i].nValue;
-                }
               }
-            }
-            if ((isNonMainNet() && getmoney_count))
-            {
-            }
-            else if (!marker_count)
-            {
-              return -1;
-            }
-
-            file_log("____________________________________________________________________________________________________________________________________\n");
-            file_log("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime).c_str(),
-             idx, wtx.GetHash().GetHex().c_str());
-
-            // now save output addresses & scripts for later use
-            // also determine if there is a multisig in there, if so = Class B
-            for (unsigned int i = 0; i < wtx.vout.size(); i++)
-            {
-            CTxDestination dest;
-            string strAddress;
-
-              if (ExtractDestination(wtx.vout[i].scriptPubKey, dest))
-              {
-                txnouttype whichType;
-                bool validType = false;
-                if (!getOutputType(wtx.vout[i].scriptPubKey, whichType)) validType=false;
-                if (isAllowedOutputType(whichType, nBlock)) validType=true;
-
-                strAddress = CBitcoinAddress(dest).ToString();
-
-                if ((exodus_address != strAddress) && (validType))
-                {
-                  if (msc_debug_parser_data) file_log("saving address_data #%d: %s:%s\n", i, strAddress.c_str(), wtx.vout[i].scriptPubKey.ToString().c_str());
-
-                  // saving for Class A processing or reference
-                  GetScriptPushes(wtx.vout[i].scriptPubKey, script_data);
-                  address_data.push_back(strAddress);
-                  value_data.push_back(wtx.vout[i].nValue);
-                }
+          }
+      }
+      if (outType == TX_NULL_DATA) { // look for 'omni' bytes
+          vector<string>temp_op_return_script_data;
+          GetScriptPushes(wtx.vout[i].scriptPubKey, temp_op_return_script_data);
+          if (temp_op_return_script_data.size() > 0) {
+              if (temp_op_return_script_data[0].size() > 8) {
+                  if ("6f6d6e69" == temp_op_return_script_data[0].substr(0,8)) {
+                      hasOmniBytes = true;
+                  }
               }
-              else
-              {
-              // a multisig ?
+          }
+      }
+  }
+  if ((isNonMainNet() && getmoney_count)) {} else if ((!marker_count) && (!hasOmniBytes)) { return -1; } // no Exodus/omni marker, not a valid Omni transaction
+  file_log("____________________________________________________________________________________________________________________________________\n");
+  file_log("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime).c_str(), idx, wtx.GetHash().GetHex().c_str());
+
+
+  // ### DATA POPULATION ### - save output addresses, scripts, multsig and op_return data and determine tx class
+  for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+      CTxDestination dest;
+      string strAddress;
+      txnouttype whichType;
+      bool validType = false;
+      if (!getOutputType(wtx.vout[i].scriptPubKey, whichType)) validType=false;
+      if (isAllowedOutputType(whichType, nBlock)) validType=true;
+      if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
+          strAddress = CBitcoinAddress(dest).ToString();
+          if ((exodus_address != strAddress) && (validType)) {
+              if (msc_debug_parser_data) file_log("saving address_data #%d: %s:%s\n", i, strAddress.c_str(), wtx.vout[i].scriptPubKey.ToString().c_str());
+              // saving for Class A processing or reference
+              GetScriptPushes(wtx.vout[i].scriptPubKey, script_data);
+              address_data.push_back(strAddress);
+              value_data.push_back(wtx.vout[i].nValue);
+          }
+      } else {
+          if ((whichType == TX_NULL_DATA) && (validType)) {
+              fOPReturn = true;
+              GetScriptPushes(wtx.vout[i].scriptPubKey, op_return_script_data); // only one OP_RETURN output permitted per tx
+              string debug_op_string;
+              if (op_return_script_data.size() > 0) debug_op_string=op_return_script_data[0];
+              if (msc_debug_parser_data) file_log("Class C transaction detected: %s parsed to %s at vout %d\n", wtx.GetHash().GetHex().c_str(), debug_op_string.c_str(), i);
+          } else { // likeky a multisig
               txnouttype type;
               std::vector<CTxDestination> vDest;
               int nRequired;
+              if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired)) ++fMultisig;
+          }
+      }
+  }
+  if (msc_debug_parser_data) file_log(" address_data.size=%lu\n script_data.size=%lu\n value_data.size=%lu\n", address_data.size(), script_data.size(), value_data.size());
 
-                if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired))
-                {
-                  ++fMultisig;
-                }
+
+  // ### CLASS IDENTIFICATION ###
+  if (fOPReturn) omniClass = OMNI_CLASS_C; // the presence of an OP_RETURN output will enfore parsing as class C
+  if ((!fOPReturn) && (fMultisig)) omniClass = OMNI_CLASS_B; // no OP_RETURN output and the presence of multsig outputs will enforce parsing as class B
+  if (omniClass == 0) omniClass = OMNI_CLASS_A; // no class set, default to Class A
+
+
+  // ### SENDER IDENTIFICATION ### - collect input amounts and identify sender via "largest input by sum"
+  int inputs_errors = 0;  // several types of erroroneous MP TX inputs
+  map <string, uint64_t> inputs_sum_of_values;
+  for (unsigned int i = 0; i < wtx.vin.size(); i++) {
+      if (msc_debug_vin) file_log("vin=%d:%s\n", i, wtx.vin[i].scriptSig.ToString().c_str());
+      CTransaction txPrev;
+      uint256 hashBlock;
+      if (!GetTransaction(wtx.vin[i].prevout.hash, txPrev, hashBlock, true)) { return -101; } // get the vin's previous transaction
+      unsigned int n = wtx.vin[i].prevout.n;
+      CTxDestination source;
+      txnouttype whichType;
+      inAll += txPrev.vout[n].nValue;
+      if (ExtractDestination(txPrev.vout[n].scriptPubKey, source)) { // extract the destination of the previous transaction's vout[n] and check it's allowed type
+          if (!getOutputType(txPrev.vout[n].scriptPubKey, whichType)) { ++inputs_errors; break; }
+          if (!isAllowedOutputType(whichType, nBlock)) { ++inputs_errors; break; }
+          CBitcoinAddress addressSource(source);
+          inputs_sum_of_values[addressSource.ToString()] += txPrev.vout[n].nValue;
+      }
+      else ++inputs_errors;
+      if (msc_debug_vin) file_log("vin=%d:%s\n", i, wtx.vin[i].ToString().c_str());
+  }
+  if (inputs_errors) { return -101; } // not a valid Omni TX, disallowed inputs invalidate the transaction
+  txFee = inAll - outAll; // miner fee
+  uint64_t nMax = 0;
+  for(map<string, uint64_t>::iterator my_it = inputs_sum_of_values.begin(); my_it != inputs_sum_of_values.end(); ++my_it) { // find largest by sum
+      uint64_t nTemp = my_it->second;
+      if (nTemp > nMax) {
+          strSender = my_it->first;
+          if (msc_debug_exo) file_log("looking for The Sender: %s , nMax=%lu, nTemp=%lu\n", strSender.c_str(), nMax, nTemp);
+          nMax = nTemp;
+      }
+  }
+  if (!strSender.empty()) {
+      if (msc_debug_verbose) file_log("The Sender: %s : His Input Sum of Values= %lu.%08lu ; fee= %lu.%08lu\n", strSender.c_str(), nMax / COIN, nMax % COIN, txFee/COIN, txFee%COIN);
+  } else {
+      file_log("The sender is still EMPTY !!! txid: %s\n", wtx.GetHash().GetHex().c_str());
+      return -5;
+  }
+
+
+  // ### CHECK FOR ANY REQUIRED EXODUS CROWDSALE PAYMENTS ###
+  int64_t BTC_amount = ExodusValues[0];
+  if (isNonMainNet()) { if (MONEYMAN_TESTNET_BLOCK <= nBlock) BTC_amount = TestNetMoneyValues[0]; }
+  if (RegTest()) { if (MONEYMAN_REGTEST_BLOCK <= nBlock) BTC_amount = TestNetMoneyValues[0]; }
+  if (0 < BTC_amount && !bRPConly) (void) TXExodusFundraiser(wtx, strSender, BTC_amount, nBlock, nTime);
+
+
+  // ### POPULATE MULTISIG SCRIPT DATA ###
+  for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+      CTxDestination address;
+      if (ExtractDestination(wtx.vout[i].scriptPubKey, address)) {} else { // if true it's a plain pay-to-pubkeyhash output
+          txnouttype type;
+          std::vector<CTxDestination> vDest;
+          int nRequired;
+          if (msc_debug_script) file_log("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
+          if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired)) {
+              if (msc_debug_script) file_log(" >> multisig: ");
+              BOOST_FOREACH(const CTxDestination &dest, vDest) {
+                  CBitcoinAddress address = CBitcoinAddress(dest);
+                  CKeyID keyID;
+                  if (!address.GetKeyID(keyID)) { } // TODO: add an error handler
+                  if (msc_debug_script) file_log("%s ; ", address.ToString().c_str());
               }
-            }
+              if (msc_debug_script) file_log("\n");
+              // ignore first public key, as it should belong to the sender
+              // and it be used to avoid the creation of unspendable dust
+              GetScriptPushes(wtx.vout[i].scriptPubKey, multisig_script_data, true);
+          }
+      }
+  }
 
-            if (msc_debug_parser_data)
-            {
-              file_log("address_data.size=%lu\n", address_data.size());
-              file_log("script_data.size=%lu\n", script_data.size());
-              file_log("value_data.size=%lu\n", value_data.size());
-            }
 
-            int inputs_errors = 0;  // several types of erroroneous MP TX inputs
-            map <string, uint64_t> inputs_sum_of_values;
-            // now go through inputs & identify the sender, collect input amounts
-            // go through inputs, find the largest per Mastercoin protocol, the Sender
-            for (unsigned int i = 0; i < wtx.vin.size(); i++)
-            {
-            CTxDestination address;
+  // ### PREPARE A FEW VARS ###
+  string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
+  prepareObfuscatedHashes(strSender, strObfuscatedHashes);
+  unsigned char packets[MAX_PACKETS][32];
+  int mdata_count = 0;  // multisig data count
 
-            if (msc_debug_vin) file_log("vin=%d:%s\n", i, wtx.vin[i].scriptSig.ToString().c_str());
 
-            CTransaction txPrev;
-            uint256 hashBlock;
-            if (!GetTransaction(wtx.vin[i].prevout.hash, txPrev, hashBlock, true))  // get the vin's previous transaction 
-            {
-              return -101;
-            }
-
-            unsigned int n = wtx.vin[i].prevout.n;
-
-            CTxDestination source;
-
-            uint64_t nValue = txPrev.vout[n].nValue;
-            txnouttype whichType;
-
-              inAll += nValue;
-
-              if (ExtractDestination(txPrev.vout[n].scriptPubKey, source))  // extract the destination of the previous transaction's vout[n]
-              {
-                // we only allow pay-to-pubkeyhash, pay-to-scripthash & probably pay-to-pubkey (?)
-                {
-                  if (!getOutputType(txPrev.vout[n].scriptPubKey, whichType)) ++inputs_errors;
-                  if (!isAllowedOutputType(whichType, nBlock)) ++inputs_errors;
-
-                  if (inputs_errors) break;
-                }
-
-                CBitcoinAddress addressSource(source);              // convert this to an address
-
-                inputs_sum_of_values[addressSource.ToString()] += nValue;
+  // ### CLASS A PARSING ###
+  if (omniClass == OMNI_CLASS_A) {
+      string strScriptData;
+      string strDataAddress;
+      string strRefAddress;
+      unsigned char dataAddressSeq = 0xFF;
+      unsigned char seq = 0xFF;
+      int64_t dataAddressValue = 0;
+      for (unsigned k = 0; k<script_data.size();k++) { // Step 1, locate the data packet
+          txnouttype whichType;
+          if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+          if (!isAllowedOutputType(whichType, nBlock)) break;
+          string strSub = script_data[k].substr(2,16); // retrieve bytes 1-9 of packet for peek & decode comparison
+          seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
+          if (("0000000000000001" == strSub) || ("0000000000000002" == strSub)) { // peek & decode comparison
+              if (strScriptData.empty()) { // confirm we have not already located a data address
+                  strScriptData = script_data[k].substr(2*1,2*PACKET_SIZE_CLASS_A); // populate data packet
+                  strDataAddress = address_data[k]; // record data address
+                  dataAddressSeq = seq; // record data address seq num for reference matching
+                  dataAddressValue = value_data[k]; // record data address amount for reference matching
+                  if (msc_debug_parser_data) file_log("Data Address located - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
+              } else { // invalidate - Class A cannot be more than one data packet - possible collision, treat as default (BTC payment)
+                  strDataAddress = ""; //empty strScriptData to block further parsing
+                  if (msc_debug_parser_data) file_log("Multiple Data Addresses found (collision?) Class A invalidated, defaulting to BTC payment\n");
+                  break;
               }
-              else ++inputs_errors;
-
-              if (msc_debug_vin) file_log("vin=%d:%s\n", i, wtx.vin[i].ToString().c_str());
-            } // end of inputs for loop
-
-            txFee = inAll - outAll; // this is the fee paid to miners for this TX
-
-            if (inputs_errors)  // not a valid MP TX
-            {
-              return -101;
-            }
-
-            // largest by sum of values
-            uint64_t nMax = 0;
-            for(map<string, uint64_t>::iterator my_it = inputs_sum_of_values.begin(); my_it != inputs_sum_of_values.end(); ++my_it)
-            {
-            uint64_t nTemp = my_it->second;
-
-                if (nTemp > nMax)
-                {
-                  strSender = my_it->first;
-                  if (msc_debug_exo) file_log("looking for The Sender: %s , nMax=%lu, nTemp=%lu\n", strSender.c_str(), nMax, nTemp);
-                  nMax = nTemp;
-                }
-            }
-
-            if (!strSender.empty())
-            {
-              if (msc_debug_verbose) file_log("The Sender: %s : His Input Sum of Values= %lu.%08lu ; fee= %lu.%08lu\n",
-               strSender.c_str(), nMax / COIN, nMax % COIN, txFee/COIN, txFee%COIN);
-            }
-            else
-            {
-              file_log("The sender is still EMPTY !!! txid: %s\n", wtx.GetHash().GetHex().c_str());
-              return -5;
-            }
-            
-            //This calculates exodus fundraiser for each tx within a given block
-            int64_t BTC_amount = ExodusValues[0];
-            if (isNonMainNet())
-            {
-              if (MONEYMAN_TESTNET_BLOCK <= nBlock) BTC_amount = TestNetMoneyValues[0];
-            }
-
-            if (RegTest()) 
-            { 
-              if (MONEYMAN_REGTEST_BLOCK <= nBlock) BTC_amount = TestNetMoneyValues[0];
-            }
-
-//            file_log("%s() amount = %ld , nBlock = %d, line %d, file: %s\n", __FUNCTION__, BTC_amount, nBlock, __LINE__, __FILE__);
-
-            if (0 < BTC_amount && !bRPConly) (void) TXExodusFundraiser(wtx, strSender, BTC_amount, nBlock, nTime);
-
-            // go through the outputs
-            for (unsigned int i = 0; i < wtx.vout.size(); i++)
-            {
-            CTxDestination address;
-
-              // if TRUE -- non-multisig
-              if (ExtractDestination(wtx.vout[i].scriptPubKey, address))
-              {
+          }
+      }
+      if (!strDataAddress.empty()) { // Step 2, try to locate address with seqnum = DataAddressSeq+1 (also verify Step 1, we should now have a valid data packet)
+          unsigned char expectedRefAddressSeq = dataAddressSeq + 1;
+          for (unsigned k = 0; k<script_data.size();k++) { // loop through outputs
+              txnouttype whichType;
+              if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+              if (!isAllowedOutputType(whichType, nBlock)) break;
+              seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
+              if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (expectedRefAddressSeq == seq)) { // found reference address with matching sequence number
+                  if (strRefAddress.empty()) { // confirm we have not already located a reference address
+                      strRefAddress = address_data[k]; // set ref address
+                      if (msc_debug_parser_data) file_log("Reference Address located via seqnum - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
+                  } else { // can't trust sequence numbers to provide reference address, there is a collision with >1 address with expected seqnum
+                      strRefAddress = ""; // blank ref address
+                      if (msc_debug_parser_data) file_log("Reference Address sequence number collision, will fall back to evaluating matching output amounts\n");
+                      break;
+                  }
               }
-              else
-              {
-                // probably a multisig -- get them
-
-        txnouttype type;
-        std::vector<CTxDestination> vDest;
-        int nRequired;
-
-        // CScript is a std::vector
-        if (msc_debug_script) file_log("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
-
-        if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired))
-        {
-          if (msc_debug_script) file_log(" >> multisig: ");
-            BOOST_FOREACH(const CTxDestination &dest, vDest)
-            {
-            CBitcoinAddress address = CBitcoinAddress(dest);
-            CKeyID keyID;
-
-            if (!address.GetKeyID(keyID))
-            {
-            // TODO: add an error handler
-            }
-
-              // base_uint is a superclass of dest, size(), GetHex() is the same as ToString()
-//              file_log("%s size=%d (%s); ", address.ToString().c_str(), keyID.size(), keyID.GetHex().c_str());
-              if (msc_debug_script) file_log("%s ; ", address.ToString().c_str());
-
-            }
-          if (msc_debug_script) file_log("\n");
-
-          // ignore first public key, as it should belong to the sender
-          // and it be used to avoid the creation of unspendable dust
-          GetScriptPushes(wtx.vout[i].scriptPubKey, multisig_script_data, true);
-        }
-              }
-            } // end of the outputs' for loop
-
-          string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
-          prepareObfuscatedHashes(strSender, strObfuscatedHashes);
-
-          unsigned char packets[MAX_PACKETS][32];
-          int mdata_count = 0;  // multisig data count
-          if (!fMultisig)
-          {
-              // ---------------------------------- Class A parsing ---------------------------
-
-              // Init vars
-              string strScriptData;
-              string strDataAddress;
-              string strRefAddress;
-              unsigned char dataAddressSeq = 0xFF;
-              unsigned char seq = 0xFF;
-              int64_t dataAddressValue = 0;
-
-              // Step 1, locate the data packet
-              for (unsigned k = 0; k<script_data.size();k++) // loop through outputs
-              {
+          }
+          if (strRefAddress.empty()) { // Step 3, if we still don't have a reference address, see if we can locate an address with matching output amounts
+              for (unsigned k = 0; k<script_data.size();k++) { // loop through outputs
                   txnouttype whichType;
                   if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
                   if (!isAllowedOutputType(whichType, nBlock)) break;
-                  string strSub = script_data[k].substr(2,16); // retrieve bytes 1-9 of packet for peek & decode comparison
-                  seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
-
-                  if (("0000000000000001" == strSub) || ("0000000000000002" == strSub)) // peek & decode comparison
-                  {
-                      if (strScriptData.empty()) // confirm we have not already located a data address
-                      {
-                          strScriptData = script_data[k].substr(2*1,2*PACKET_SIZE_CLASS_A); // populate data packet
-                          strDataAddress = address_data[k]; // record data address
-                          dataAddressSeq = seq; // record data address seq num for reference matching
-                          dataAddressValue = value_data[k]; // record data address amount for reference matching
-                          if (msc_debug_parser_data) file_log("Data Address located - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
-                      }
-                      else
-                      {
-                          // invalidate - Class A cannot be more than one data packet - possible collision, treat as default (BTC payment)
-                          strDataAddress = ""; //empty strScriptData to block further parsing
-                          if (msc_debug_parser_data) file_log("Multiple Data Addresses found (collision?) Class A invalidated, defaulting to BTC payment\n");
-                          break;
-                      }
-                  }
-              }
-
-              // Step 2, see if we can locate an address with a seqnum +1 of DataAddressSeq
-              if (!strDataAddress.empty()) // verify Step 1, we should now have a valid data packet, if so continue parsing
-              {
-                  unsigned char expectedRefAddressSeq = dataAddressSeq + 1;
-                  for (unsigned k = 0; k<script_data.size();k++) // loop through outputs
-                  {
-                      txnouttype whichType;
-                      if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-                      if (!isAllowedOutputType(whichType, nBlock)) break;
-
-                      seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
-
-                      if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (expectedRefAddressSeq == seq)) // found reference address with matching sequence number
-                      {
-                          if (strRefAddress.empty()) // confirm we have not already located a reference address
-                          {
-                              strRefAddress = address_data[k]; // set ref address
-                              if (msc_debug_parser_data) file_log("Reference Address located via seqnum - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
-                          }
-                          else
-                          {
-                              // can't trust sequence numbers to provide reference address, there is a collision with >1 address with expected seqnum
-                              strRefAddress = ""; // blank ref address
-                              if (msc_debug_parser_data) file_log("Reference Address sequence number collision, will fall back to evaluating matching output amounts\n");
-                              break;
-                          }
-                      }
-                  }
-                  // Step 3, if we still don't have a reference address, see if we can locate an address with matching output amounts
-                  if (strRefAddress.empty())
-                  {
-                      for (unsigned k = 0; k<script_data.size();k++) // loop through outputs
-                      {
-                          txnouttype whichType;
-                          if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-                          if (!isAllowedOutputType(whichType, nBlock)) break;
-
-                          if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (dataAddressValue == value_data[k])) // this output matches data output, check if matches exodus output
-                          {
-                              for (int exodus_idx=0;exodus_idx<marker_count;exodus_idx++)
-                              {
-                                  if (value_data[k] == ExodusValues[exodus_idx]) //this output matches data address value and exodus address value, choose as ref
-                                  {
-                                       if (strRefAddress.empty())
-                                       {
-                                           strRefAddress = address_data[k];
-                                           if (msc_debug_parser_data) file_log("Reference Address located via matching amounts - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
-                                       }
-                                       else
-                                       {
-                                           strRefAddress = "";
-                                           if (msc_debug_parser_data) file_log("Reference Address collision, multiple potential candidates. Class A invalidated, defaulting to BTC payment\n");
-                                           break;
-                                       }
-                                  }
+                  if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (dataAddressValue == value_data[k])) { // this output matches data output, check if matches exodus output
+                      for (int exodus_idx=0;exodus_idx<marker_count;exodus_idx++) {
+                          if (value_data[k] == ExodusValues[exodus_idx]) { //this output matches data address value and exodus address value, choose as ref
+                              if (strRefAddress.empty()) {
+                                  strRefAddress = address_data[k];
+                                  if (msc_debug_parser_data) file_log("Reference Address located via matching amounts - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
+                              } else {
+                                  strRefAddress = "";
+                                  if (msc_debug_parser_data) file_log("Reference Address collision, multiple potential candidates. Class A invalidated, defaulting to BTC payment\n");
+                                  break;
                               }
                           }
                       }
                   }
-              } // end if (!strDataAddress.empty())
-
-              // Populate expected var strReference with chosen address (if not empty)
-              if (!strRefAddress.empty()) strReference=strRefAddress;
-
-              // Last validation step, if strRefAddress is empty, blank strDataAddress so we default to BTC payment
-              if (strRefAddress.empty()) strDataAddress="";
-
-              // -------------------------------- End Class A parsing -------------------------
-
-              if (strDataAddress.empty()) // an empty Data Address here means it is not Class A valid and should be defaulted to a BTC payment
-              {
-              // this must be the BTC payment - validate (?)
-//              if (msc_debug_verbose) file_log("\n================BLOCK: %d======\ntxid: %s\n", nBlock, wtx.GetHash().GetHex().c_str());
-              file_log("!! sender: %s , receiver: %s\n", strSender.c_str(), strReference.c_str());
-              file_log("!! this may be the BTC payment for an offer !!\n");
-
-              // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
-
-              int count = 0;
-              // go through the outputs, once again...
-              {
-                for (unsigned int i = 0; i < wtx.vout.size(); i++)
-                {
-                CTxDestination dest;
-
-                  if (ExtractDestination(wtx.vout[i].scriptPubKey, dest))
-                  {
-                  const string strAddress = CBitcoinAddress(dest).ToString();
-
-                    if (exodus_address == strAddress) continue;
-                    file_log("payment #%d %s %11.8lf\n", count, strAddress.c_str(), (double)wtx.vout[i].nValue/(double)COIN);
-
-                    // check everything & pay BTC for the property we are buying here...
-                    if (bRPConly) count = 55555;  // no real way to validate a payment during simple RPC call
-                    else if (0 == DEx_payment(wtx.GetHash(), i, strAddress, strSender, wtx.vout[i].nValue, nBlock)) ++count;
-                  }
-                }
               }
-              return count ? count : -5678; // return count -- the actual number of payments within this TX or error if none were made
-            }
-            else
-            {
-            // valid Class A packet almost ready
-              if (msc_debug_parser_data) file_log("valid Class A:from=%s:to=%s:data=%s\n", strSender.c_str(), strReference.c_str(), strScriptData.c_str());
-              packet_size = PACKET_SIZE_CLASS_A;
-              memcpy(single_pkt, &ParseHex(strScriptData)[0], packet_size);
-            }
           }
-          else // if (fMultisig)
-          {
-            unsigned int k = 0;
-            // gotta find the Reference - Z rewrite - scrappy & inefficient, can be optimized
-
-            if (msc_debug_parser_data) file_log("Beginning reference identification\n");
-
-            bool referenceFound = false; // bool to hold whether we've found the reference yet
-            bool changeRemoved = false; // bool to hold whether we've ignored the first output to sender as change
-            unsigned int potentialReferenceOutputs = 0; // int to hold number of potential reference outputs
-
-            // how many potential reference outputs do we have, if just one select it right here
-            BOOST_FOREACH(const string &addr, address_data)
-            {
-                // keep Michael's original debug info & k int as used elsewhere
-                if (msc_debug_parser_data) file_log("ref? data[%d]:%s: %s (%lu.%08lu)\n",
-                 k, script_data[k].c_str(), addr.c_str(), value_data[k] / COIN, value_data[k] % COIN);
-                ++k;
-
-                if (addr != exodus_address)
-                {
-                        ++potentialReferenceOutputs;
-                        if (1 == potentialReferenceOutputs)
-                        {
-                                strReference = addr;
-                                referenceFound = true;
-                                if (msc_debug_parser_data) file_log("Single reference potentially id'd as follows: %s \n", strReference.c_str());
-                        }
-                        else //as soon as potentialReferenceOutputs > 1 we need to go fishing
-                        {
-                                strReference = ""; // avoid leaving strReference populated for sanity
-                                referenceFound = false;
-                                if (msc_debug_parser_data) file_log("More than one potential reference candidate, blanking strReference, need to go fishing\n");
-                        }
-                }
-            }
-
-            // do we have a reference now? or do we need to dig deeper
-            if (!referenceFound) // multiple possible reference addresses
-            {
-                if (msc_debug_parser_data) file_log("Reference has not been found yet, going fishing\n");
-
-                BOOST_FOREACH(const string &addr, address_data)
-                {
-                        // !!!! address_data is ordered by vout (i think - please confirm that's correct analysis?)
-                        if (addr != exodus_address) // removed strSender restriction, not to spec
-                        {
-                                if ((addr == strSender) && (!changeRemoved))
-                                {
-                                        // per spec ignore first output to sender as change if multiple possible ref addresses
-                                        changeRemoved = true;
-                                        if (msc_debug_parser_data) file_log("Removed change\n");
-                                }
-                                else
-                                {
-                                        // this may be set several times, but last time will be highest vout
-                                        strReference = addr;
-                                        if (msc_debug_parser_data) file_log("Resetting strReference as follows: %s \n ", strReference.c_str());
-                                }
-                        }
-                }
-            }
-
-          if (msc_debug_parser_data) file_log("Ending reference identification\n");
-          if (msc_debug_parser_data) file_log("Final decision on reference identification is: %s\n", strReference.c_str());
-
-          if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-          // multisig , Class B; get the data packets that are found here
-          for (unsigned int k = 0; k<multisig_script_data.size();k++)
-          {
-            if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-            CPubKey key(ParseHex(multisig_script_data[k]));
-            CKeyID keyID = key.GetID();
-            string strAddress = CBitcoinAddress(keyID).ToString();
-            char *c_addr_type = (char *)"";
-            string strPacket;
-
-            if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-            {
-              // this is a data packet, must deobfuscate now
-              vector<unsigned char>hash = ParseHex(strObfuscatedHashes[mdata_count+1]);      
-              vector<unsigned char>packet = ParseHex(multisig_script_data[k].substr(2*1,2*PACKET_SIZE));
-
-              for (unsigned int i=0;i<packet.size();i++)
-              {
-                packet[i] ^= hash[i];
+      } // end if (!strDataAddress.empty())
+      if (!strRefAddress.empty()) strReference=strRefAddress; // populate expected var strReference with chosen address (if not empty)
+      if (strRefAddress.empty()) strDataAddress=""; // last validation step, if strRefAddress is empty, blank strDataAddress so we default to BTC payment
+      if (!strDataAddress.empty()) { // valid Class A packet almost ready
+          if (msc_debug_parser_data) file_log("valid Class A:from=%s:to=%s:data=%s\n", strSender.c_str(), strReference.c_str(), strScriptData.c_str());
+          packet_size = PACKET_SIZE_CLASS_A;
+          memcpy(single_pkt, &ParseHex(strScriptData)[0], packet_size);
+      } else {
+          // ### BTC PAYMENT FOR DEX HANDLING ###
+          file_log("!! sender: %s , receiver: %s\n", strSender.c_str(), strReference.c_str());
+          file_log("!! this may be the BTC payment for an offer !!\n");
+          // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
+          int count = 0;
+          for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+              CTxDestination dest;
+              if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
+                  const string strAddress = CBitcoinAddress(dest).ToString();
+                  if (exodus_address == strAddress) continue;
+                  file_log("payment #%d %s %11.8lf\n", count, strAddress.c_str(), (double)wtx.vout[i].nValue/(double)COIN);
+                  // check everything & pay BTC for the property we are buying here...
+                  if (bRPConly) count = 55555;  // no real way to validate a payment during simple RPC call
+                  else if (0 == DEx_payment(wtx.GetHash(), i, strAddress, strSender, wtx.vout[i].nValue, nBlock)) ++count;
               }
+          }
+          return count ? count : -5678; // return count -- the actual number of payments within this TX or error if none were made
+      }
+  }
 
-                memcpy(&packets[mdata_count], &packet[0], PACKET_SIZE);
-                strPacket = HexStr(packet.begin(),packet.end(), false);
-                ++mdata_count;
 
-                if (MAX_PACKETS <= mdata_count)
-                {
+  // ### CLASS B / CLASS C PARSING ###
+  if ((omniClass == OMNI_CLASS_B) || (omniClass == OMNI_CLASS_C)) {
+      unsigned int k = 0;
+      if (msc_debug_parser_data) file_log("Beginning reference identification\n");
+      bool referenceFound = false; // bool to hold whether we've found the reference yet
+      bool changeRemoved = false; // bool to hold whether we've ignored the first output to sender as change
+      unsigned int potentialReferenceOutputs = 0; // int to hold number of potential reference outputs
+      BOOST_FOREACH(const string &addr, address_data) { // how many potential reference outputs do we have, if just one select it right here
+          if (msc_debug_parser_data) file_log("ref? data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), addr.c_str(), value_data[k] / COIN, value_data[k] % COIN);
+          ++k;
+          if (addr != exodus_address) {
+              ++potentialReferenceOutputs;
+              if (1 == potentialReferenceOutputs) {
+                  strReference = addr;
+                  referenceFound = true;
+                  if (msc_debug_parser_data) file_log("Single reference potentially id'd as follows: %s \n", strReference.c_str());
+              } else { //as soon as potentialReferenceOutputs > 1 we need to go fishing
+                  strReference = ""; // avoid leaving strReference populated for sanity
+                  referenceFound = false;
+                  if (msc_debug_parser_data) file_log("More than one potential reference candidate, blanking strReference, need to go fishing\n");
+              }
+          }
+      }
+      if (!referenceFound) { // do we have a reference now? or do we need to dig deeper
+          if (msc_debug_parser_data) file_log("Reference has not been found yet, going fishing\n");
+          BOOST_FOREACH(const string &addr, address_data) {
+              if (addr != exodus_address) { // removed strSender restriction, not to spec
+                  if ((addr == strSender) && (!changeRemoved)) {
+                      changeRemoved = true; // per spec ignore first output to sender as change if multiple possible ref addresses
+                      if (msc_debug_parser_data) file_log("Removed change\n");
+                  } else {
+                      strReference = addr; // this may be set several times, but last time will be highest vout
+                      if (msc_debug_parser_data) file_log("Resetting strReference as follows: %s \n ", strReference.c_str());
+                  }
+              }
+          }
+      }
+      if (msc_debug_parser_data) file_log("Ending reference identification\nFinal decision on reference identification is: %s\n", strReference.c_str());
+      if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+      // ### CLASS B SPECIFC PARSING ###
+      if (omniClass == OMNI_CLASS_B) {
+          for (unsigned int k = 0; k<multisig_script_data.size();k++) {
+              if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+              CPubKey key(ParseHex(multisig_script_data[k]));
+              CKeyID keyID = key.GetID();
+              string strAddress = CBitcoinAddress(keyID).ToString();
+              char *c_addr_type = (char *)"";
+              string strPacket;
+              if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+              vector<unsigned char>hash = ParseHex(strObfuscatedHashes[mdata_count+1]);
+              vector<unsigned char>packet = ParseHex(multisig_script_data[k].substr(2*1,2*PACKET_SIZE));
+              for (unsigned int i=0;i<packet.size();i++) { // this is a data packet, must deobfuscate now
+                  packet[i] ^= hash[i];
+              }
+              memcpy(&packets[mdata_count], &packet[0], PACKET_SIZE);
+              strPacket = HexStr(packet.begin(),packet.end(), false);
+              ++mdata_count;
+              if (MAX_PACKETS <= mdata_count) {
                   file_log("increase MAX_PACKETS ! mdata_count= %d\n", mdata_count);
                   return -222;
-                }
-            }
-
-          if (msc_debug_parser_data) file_log("multisig_data[%d]:%s: %s%s\n", k, multisig_script_data[k].c_str(), strAddress.c_str(), c_addr_type);
-
-            if (!strPacket.empty())
-            {
-              if (msc_debug_parser) file_log("packet #%d: %s\n", mdata_count, strPacket.c_str());
-            }
-          if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-          }
-
-          packet_size = mdata_count * (PACKET_SIZE - 1);
-
-          if (sizeof(single_pkt)<packet_size)
-          {
-            return -111;
-          }
-
-          if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-          } // end of if (fMultisig)
-          if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-
-            // now decode mastercoin packets
-            for (int m=0;m<mdata_count;m++)
-            {
-              if (msc_debug_parser) file_log("m=%d: %s\n", m, HexStr(packets[m], PACKET_SIZE + packets[m], false).c_str());
-
-              // check to ensure the sequence numbers are sequential and begin with 01 !
-              if (1+m != packets[m][0])
-              {
-                if (msc_debug_spec) file_log("Error: non-sequential seqnum ! expected=%d, got=%d\n", 1+m, packets[m][0]);
               }
+              if (msc_debug_parser_data) file_log("multisig_data[%d]:%s: %s%s\n", k, multisig_script_data[k].c_str(), strAddress.c_str(), c_addr_type);
+              if (!strPacket.empty()) { if (msc_debug_parser) file_log("packet #%d: %s\n", mdata_count, strPacket.c_str()); }
+              if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+          }
+          packet_size = mdata_count * (PACKET_SIZE - 1);
+          if (sizeof(single_pkt)<packet_size) return -111;
+          if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+      }
+      // ### CLASS C SPECIFIC PARSING ###
+      if (omniClass == OMNI_CLASS_C) {
+          if (op_return_script_data.size() > 0) {
+              if (op_return_script_data[0].size() > 8) {
+                  std::string payload = op_return_script_data[0].substr(8,op_return_script_data[0].size()-8); // strip out marker
+                  packet_size=(payload.size())/2; // get packet byte size - hex so always a multiple of 2
+                  if(packet_size < MIN_PACKET_SIZE_CLASS_C) return -111;
+                  memcpy(single_pkt, &ParseHex(payload)[0], packet_size); // load the packet ready to set mp tx info
+              }
+          }
+      }
+  }
 
-              // now ignoring sequence numbers for Class B packets
-              memcpy(m*(PACKET_SIZE-1)+single_pkt, 1+packets[m], PACKET_SIZE-1);
-            }
 
+  // ### FINALIZE CLASS B ###
+  for (int m=0;m<mdata_count;m++) { // now decode mastercoin packets
+      if (msc_debug_parser) file_log("m=%d: %s\n", m, HexStr(packets[m], PACKET_SIZE + packets[m], false).c_str());
+      // check to ensure the sequence numbers are sequential and begin with 01 !
+      if (1+m != packets[m][0]) {
+          if (msc_debug_spec) file_log("Error: non-sequential seqnum ! expected=%d, got=%d\n", 1+m, packets[m][0]);
+      }
+      memcpy(m*(PACKET_SIZE-1)+single_pkt, 1+packets[m], PACKET_SIZE-1); // now ignoring sequence numbers for Class B packets
+  }
+
+
+  // ### SET MP TX INFO ###
   if (msc_debug_verbose) file_log("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt, false).c_str());
-
-  mp_tx->Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, fMultisig, (inAll-outAll));  
-
+  mp_tx->Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, omniClass-1, (inAll-outAll));
   return 0;
 }
-
 
 // parse blocks, potential right from Mastercoin's Exodus
 int msc_initial_scan(int nHeight)
@@ -2815,178 +2655,112 @@ int64_t feeCheck(const string &address)
     return selectCoins(address, coinControl, 0);
 }
 
-//
-// Do we care if this is true: pubkeys[i].IsCompressed() ???
-// returns 0 if everything is OK, the transaction was sent
-int mastercore::ClassB_send(const string &senderAddress, const string &receiverAddress, const string &redemptionAddress, const vector<unsigned char> &data, uint256 & txid, int64_t referenceamount)
+// CLASS Agnostic SEND - will use class depending on size
+int mastercore::ClassAgnostic_send(const string &senderAddress, const string &receiverAddress, const string &redemptionAddress, const vector<unsigned char> &data, uint256 & txid, int64_t referenceamount)
 {
-CWallet *wallet = pwalletMain;
-CCoinControl coinControl;
-vector< pair<CScript, int64_t> > vecSend;
-
-  // pick inputs for this transaction
-  if (0 > selectCoins(senderAddress, coinControl, referenceamount))
-  {
-    return MP_INPUTS_INVALID;
-  }
-
-  txid = 0;
-
-  // determine the redeeming public key for our multisig outputs
-  // partially copied from _createmultisig()
-  CBitcoinAddress address;
-  CPubKey redeemingPubKey;
-  if (false == redemptionAddress.empty()) {
-    address.SetString(redemptionAddress);
-  } else {
-    address.SetString(senderAddress);
-  }
-
-  // validate that the redemption Address is good
-  if (wallet && address.IsValid())
-  {
-    if (address.IsScript())
-    {
-      file_log("%s() ERROR: Redemption Address must be specified !\n", __FUNCTION__);
-      return MP_REDEMP_ILLEGAL;
+    CWallet *wallet = pwalletMain;
+    CCoinControl coinControl;
+    vector< pair<CScript, int64_t> > vecSend;
+    bool fallBackToClassB = false;
+    if(data.size()>nMaxDatacarrierBytes) fallBackToClassB = true; // OP_RETURN data size limited to nMaxDatacarrierBytes bytes, if over this send via multisig
+    CWalletTx wtxNew; // prepare a new transaction
+    int64_t nFeeRet = 0;
+    std::string strFailReason;
+    CReserveKey reserveKey(wallet);
+    CBitcoinAddress addr = CBitcoinAddress(senderAddress);  // change goes back to us
+    coinControl.destChange = addr.Get();
+    if (!receiverAddress.empty()) { // add the the reference/recepient/receiver ouput if needed
+        CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(receiverAddress).Get());
+        vecSend.push_back(make_pair(scriptPubKey, 0 < referenceamount ? referenceamount : GetDustLimit(scriptPubKey)));
     }
-    else
-    {
-      CKeyID keyID;
-
-      if (!address.GetKeyID(keyID))
-        return MP_REDEMP_BAD_KEYID;
-
-      if (!bRawTX)
-      {
-      if (!wallet->GetPubKey(keyID, redeemingPubKey))
-        return MP_REDEMP_FETCH_ERR_PUBKEY;
-
-      if (!redeemingPubKey.IsFullyValid())
-        return MP_REDEMP_INVALID_PUBKEY;
-      }
-     }
-  }
-  else return MP_REDEMP_BAD_VALIDATION;
-
-  int nRemainingBytes = data.size();
-  int nNextByte = 0;
-  unsigned char seqNum = 1;
-  string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
-  prepareObfuscatedHashes(senderAddress, strObfuscatedHashes);
-
-  while (nRemainingBytes > 0) {
-    int nKeys = 1; //assume one key of data since we have data remaining
-    if (nRemainingBytes > (PACKET_SIZE - 1)) {
-      // we have enough data for 2 keys in this output
-      nKeys += 1;
+    if (0 > selectCoins(senderAddress, coinControl, referenceamount)) { return MP_INPUTS_INVALID; }
+    txid = 0;
+    if(fallBackToClassB) { // ### CLASS B ### prepare to send via multisig, first determine the redeeming public key for our multisig outputs - current max 2 keys
+        CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(exodus_address).Get());
+        vecSend.push_back(make_pair(scriptPubKey, GetDustLimit(scriptPubKey))); // add the marker output
+        CBitcoinAddress address;
+        CPubKey redeemingPubKey;
+        if (false == redemptionAddress.empty()) { address.SetString(redemptionAddress); } else { address.SetString(senderAddress); }
+        if (wallet && address.IsValid()) { // validate that the redemption Address is good
+            if (address.IsScript()) {
+                file_log("%s() ERROR: Redemption Address must be specified !\n", __FUNCTION__);
+                return MP_REDEMP_ILLEGAL;
+            } else {
+                CKeyID keyID;
+                if (!address.GetKeyID(keyID)) return MP_REDEMP_BAD_KEYID;
+                if (!bRawTX) {
+                    if (!wallet->GetPubKey(keyID, redeemingPubKey)) return MP_REDEMP_FETCH_ERR_PUBKEY;
+                    if (!redeemingPubKey.IsFullyValid()) return MP_REDEMP_INVALID_PUBKEY;
+                }
+            }
+        }
+        else return MP_REDEMP_BAD_VALIDATION;
+        int nRemainingBytes = data.size();
+        int nNextByte = 0;
+        unsigned char seqNum = 1;
+        string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
+        prepareObfuscatedHashes(senderAddress, strObfuscatedHashes);
+        while (nRemainingBytes > 0) {
+            int nKeys = 1; // assume one key of data since we have data remaining
+            if (nRemainingBytes > (PACKET_SIZE - 1)) { nKeys += 1; } // we have enough data for 2 keys in this output
+            vector<CPubKey> keys;
+            keys.push_back(redeemingPubKey); // always include the redeeming pubkey
+            int i;
+            for (i = 0; i < nKeys; i++) {
+                vector<unsigned char> fakeKey;
+                fakeKey.push_back(seqNum); // add sequence number
+                int numBytes = nRemainingBytes < (PACKET_SIZE - 1) ? nRemainingBytes: (PACKET_SIZE - 1); // add up to 30 bytes of data
+                fakeKey.insert(fakeKey.end(), data.begin() + nNextByte, data.begin() + nNextByte + numBytes);
+                nNextByte += numBytes;
+                nRemainingBytes -= numBytes;
+                while (fakeKey.size() < PACKET_SIZE) { fakeKey.push_back(0); } // pad to 31 total bytes with zeros
+                int j;
+                vector<unsigned char>hash = ParseHex(strObfuscatedHashes[seqNum]);
+                for (j = 0; j < PACKET_SIZE; j++) { // xor in the obfuscation
+                    fakeKey[j] = fakeKey[j] ^ hash[j];
+                }
+                fakeKey.insert(fakeKey.begin(), 2); // prepend the 2
+                CPubKey pubKey;
+                fakeKey.resize(33);
+                unsigned char random_byte = (unsigned char)(GetRand(256)); // fix up the ecdsa code point
+                for (j = 0; i < 256 ; j++) {
+                    fakeKey[32] = random_byte;
+                    pubKey = CPubKey(fakeKey);
+                    file_log("pubKey check: %s\n", (HexStr(pubKey.begin(), pubKey.end()).c_str()));
+                    if (pubKey.IsFullyValid()) break;
+                    ++random_byte; // cycle 256 times, if we must to find a valid ECDSA point
+                }
+                keys.push_back(pubKey);
+                seqNum++;
+            }
+            CScript multisig_output = GetScriptForMultisig(1, keys);
+            vecSend.push_back(make_pair(multisig_output, GetDustLimit(multisig_output)));
+        }
+    } else { // ### CLASS C ### prepare to send via OP_RETURN
+        const unsigned char bytes[] = {0x6f,0x6d,0x6e,0x69};
+        std::vector<unsigned char> omniBytesPlusData(bytes, bytes+sizeof(bytes)/sizeof(bytes[0]));
+        omniBytesPlusData.insert(omniBytesPlusData.end(), data.begin(), data.end());
+        CScript op_return_output;
+        op_return_output << OP_RETURN << omniBytesPlusData; //omnibytes << data;
+        vecSend.push_back(make_pair(op_return_output, 0));
     }
-
-    vector<CPubKey> keys;
-    // always include the redeeming pubkey
-    keys.push_back(redeemingPubKey);
-
-    int i;
-    for (i = 0; i < nKeys; i++)
-    {
-      // add sequence number
-      vector<unsigned char> fakeKey;
-      fakeKey.push_back(seqNum);
-
-      // add up to 30 bytes of data
-      int numBytes = nRemainingBytes < (PACKET_SIZE - 1) ? nRemainingBytes: (PACKET_SIZE - 1);
-      fakeKey.insert(fakeKey.end(), data.begin() + nNextByte, data.begin() + nNextByte + numBytes);
-      nNextByte += numBytes;
-      nRemainingBytes -= numBytes;
-
-      // pad to 31 total bytes with zeros
-      while (fakeKey.size() < PACKET_SIZE) {
-        fakeKey.push_back(0);
-      }
-
-      // xor in the obfuscation
-      int j;
-      vector<unsigned char>hash = ParseHex(strObfuscatedHashes[seqNum]);
-      for (j = 0; j < PACKET_SIZE; j++) {
-        fakeKey[j] = fakeKey[j] ^ hash[j];
-      }
-
-      // prepend the 2
-      fakeKey.insert(fakeKey.begin(), 2);
-
-      // fix up the ecdsa code point
-      CPubKey pubKey;
-      fakeKey.resize(33);
-      unsigned char random_byte = (unsigned char)(GetRand(256));
-      for (j = 0; i < 256 ; j++)
-      {
-        fakeKey[32] = random_byte;
-
-        pubKey = CPubKey(fakeKey);
-        file_log("pubKey check: %s\n", (HexStr(pubKey.begin(), pubKey.end()).c_str()));
-
-        if (pubKey.IsFullyValid()) break;
-
-        ++random_byte; // cycle 256 times, if we must to find a valid ECDSA point
-      }
-
-      keys.push_back(pubKey);
-      seqNum++;
+    if (!wallet) return MP_ERR_WALLET_ACCESS;
+    if (!coinControl.HasSelected()) return MP_ERR_INPUTSELECT_FAIL; // selected in the parent function, i.e.: ensure we are only using the address passed in as the Sender
+    LOCK(wallet->cs_wallet);
+    // the fee will be computed by Bitcoin Core, need an override (?) // TODO: look at Bitcoin Core's global: nTransactionFee (?)
+    if (!wallet->CreateTransaction(vecSend, wtxNew, reserveKey, nFeeRet, strFailReason, &coinControl)) { printf("FAIL %s\n",strFailReason.c_str()); return MP_ERR_CREATE_TX; }
+    if (bRawTX) {
+        CTransaction tx = (CTransaction) wtxNew;
+        CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+        ssTx << tx;
+        string strHex = HexStr(ssTx.begin(), ssTx.end());
+        printf("RawTX:\n%s\n\n", strHex.c_str());
+        return 0;
     }
-
-    CScript multisig_output = GetScriptForMultisig(1, keys);
-    vecSend.push_back(make_pair(multisig_output, GetDustLimit(multisig_output)));
-  }
-
-  CWalletTx wtxNew;
-  int64_t nFeeRet = 0;
-  std::string strFailReason;
-  CReserveKey reserveKey(wallet);
-
-  CBitcoinAddress addr = CBitcoinAddress(senderAddress);  // change goes back to us
-  coinControl.destChange = addr.Get();
-
-  if (!wallet) return MP_ERR_WALLET_ACCESS;
-
-  // add the the reference/recepient/receiver ouput if needed
-  if (!receiverAddress.empty())
-  {
-    // Send To Owners is the first use case where the receiver is empty
-    CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(receiverAddress).Get());
-    vecSend.push_back(make_pair(scriptPubKey, 0 < referenceamount ? referenceamount : GetDustLimit(scriptPubKey)));
-  }
-
-  // add the marker output
-  CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(exodus_address).Get());
-  vecSend.push_back(make_pair(scriptPubKey, GetDustLimit(scriptPubKey)));
-
-  // selected in the parent function, i.e.: ensure we are only using the address passed in as the Sender
-  if (!coinControl.HasSelected()) return MP_ERR_INPUTSELECT_FAIL;
-
-  LOCK(wallet->cs_wallet);
-
-  // the fee will be computed by Bitcoin Core, need an override (?)
-  // TODO: look at Bitcoin Core's global: nTransactionFee (?)
-  if (!wallet->CreateTransaction(vecSend, wtxNew, reserveKey, nFeeRet, strFailReason, &coinControl)) return MP_ERR_CREATE_TX;
-
-  if (bRawTX)
-  {
-    CTransaction tx = (CTransaction) wtxNew;
-    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
-    ssTx << tx;
-    string strHex = HexStr(ssTx.begin(), ssTx.end());
-    printf("RawTX:\n%s\n\n", strHex.c_str());
-
+    file_log("%s():%s; nFeeRet = %lu, line %d, file: %s\n", __FUNCTION__, wtxNew.ToString().c_str(), nFeeRet, __LINE__, __FILE__);
+    if (!wallet->CommitTransaction(wtxNew, reserveKey)) return MP_ERR_COMMIT_TX;
+    txid = wtxNew.GetHash();
     return 0;
-  }
-
-  file_log("%s():%s; nFeeRet = %lu, line %d, file: %s\n", __FUNCTION__, wtxNew.ToString().c_str(), nFeeRet, __LINE__, __FILE__);
-
-  if (!wallet->CommitTransaction(wtxNew, reserveKey)) return MP_ERR_COMMIT_TX;
-
-  txid = wtxNew.GetHash();
-
-  return 0;
 }
 
 // WIP: expanding the function to a general-purpose one, but still sending 1 packet only for now (30-31 bytes)
@@ -3070,7 +2844,7 @@ const unsigned int prop = PropertyID;
     PUSH_BACK_BYTES(data, action);
   }
 
-  rc = ClassB_send(FromAddress, ToAddress, RedeemAddress, data, txid, additional);
+  rc = ClassAgnostic_send(FromAddress, ToAddress, RedeemAddress, data, txid, additional);
   if (msc_debug_send) file_log("ClassB_send returned %d\n", rc);
 
   if (error_code) *error_code = rc;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1175,7 +1175,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
   mp_tx->Set(wtx.GetHash(), nBlock, idx, nTime);
 
 
-  // ### EXODUS MARKER IDENTIFICATION ### - quickly go through the outputs & ensure there is a marker (a send to the Exodus address)
+  // ### EXODUS MARKER IDENTIFICATION ### - quickly go through the outputs & ensure there is a marker (exodus and/or omni bytes)
   for (unsigned int i = 0; i < wtx.vout.size(); i++) {
       txnouttype outType;
       if (!getOutputType(wtx.vout[i].scriptPubKey, outType)) continue; //unable to get an output type, ignore
@@ -2663,6 +2663,7 @@ int mastercore::ClassAgnostic_send(const string &senderAddress, const string &re
     vector< pair<CScript, int64_t> > vecSend;
     bool fallBackToClassB = false;
     if(data.size()>nMaxDatacarrierBytes-4) fallBackToClassB = true; // OP_RETURN data size limited to nMaxDatacarrierBytes bytes (and we need 4 for the marker), if size is over this send via multisig
+    if((fallBackToClassB) && (data.size()>CLASS_B_MAX_SENDABLE_PACKETS*30)) return MP_TX_TOO_BIG; // transaction is too big to send
     CWalletTx wtxNew; // prepare a new transaction
     int64_t nFeeRet = 0;
     std::string strFailReason;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2631,12 +2631,6 @@ int mastercore::ClassAgnostic_send(const string &senderAddress, const string &re
     CBitcoinAddress addr = CBitcoinAddress(senderAddress);
     coinControl.destChange = addr.Get();
 
-    // Then add a paytopubkeyhash output for the recipient (if needed)
-    if (!receiverAddress.empty()) {
-        CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(receiverAddress).Get());
-        vecSend.push_back(make_pair(scriptPubKey, 0 < referenceamount ? referenceamount : GetDustLimit(scriptPubKey)));
-    }
-
     // Select the inputs
     if (0 > selectCoins(senderAddress, coinControl, referenceamount)) { return MP_INPUTS_INVALID; }
 
@@ -2664,6 +2658,12 @@ int mastercore::ClassAgnostic_send(const string &senderAddress, const string &re
         case OMNI_CLASS_C:
             if(!OmniCore_Encode_ClassC(data,vecSend)) { return MP_ENCODING_ERROR; }
         break;
+    }
+
+    // Then add a paytopubkeyhash output for the recipient (if needed) - note we do this last as we want this to be the highest vout
+    if (!receiverAddress.empty()) {
+        CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(receiverAddress).Get());
+        vecSend.push_back(make_pair(scriptPubKey, 0 < referenceamount ? referenceamount : GetDustLimit(scriptPubKey)));
     }
 
     // Now we have what we need to pass to the wallet to create the transaction, perform some checks first

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -58,6 +58,11 @@ int const MAX_STATE_HISTORY = 50;
 #define FORMAT_BOOST_TXINDEXKEY "index-tx-%s"
 #define FORMAT_BOOST_SPKEY      "sp-%d"
 
+// Omni Layer Transaction Class
+#define OMNI_CLASS_A 1
+#define OMNI_CLASS_B 2
+#define OMNI_CLASS_C 3
+
 // Master Protocol Transaction (Packet) Version
 #define MP_TX_PKT_V0  0
 #define MP_TX_PKT_V1  1
@@ -67,6 +72,7 @@ int const MAX_STATE_HISTORY = 50;
 
 #define MAX_SHA256_OBFUSCATION_TIMES  255
 
+#define MIN_PACKET_SIZE_CLASS_C 16
 #define PACKET_SIZE_CLASS_A 19
 #define PACKET_SIZE         31
 #define MAX_PACKETS         64
@@ -120,6 +126,7 @@ enum BLOCKHEIGHTRESTRICTIONS {
   MSC_BET_BLOCK     = 999999,
   MSC_MANUALSP_BLOCK= 323230,
   P2SH_BLOCK        = 322000,
+  OP_RETURN_BLOCK   = 999999
 };
 
 enum FILETYPES {
@@ -546,7 +553,7 @@ bool isCrowdsalePurchase(uint256 txid, string address, int64_t *propertyId = NUL
 bool isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound);
 std::string FormatIndivisibleMP(int64_t n);
 
-int ClassB_send(const string &senderAddress, const string &receiverAddress, const string &redemptionAddress, const std::vector<unsigned char> &data, uint256 & txid, int64_t additional = 0);
+int ClassAgnostic_send(const string &senderAddress, const string &receiverAddress, const string &redemptionAddress, const std::vector<unsigned char> &data, uint256 & txid, int64_t additional = 0);
 
 uint256 send_INTERNAL_1packet(const string &FromAddress, const string &ToAddress, const string &RedeemAddress, unsigned int PropertyID, uint64_t Amount,
  unsigned int PropertyID_2, uint64_t Amount_2, unsigned int TransactionType, int64_t additional, int *error_code = NULL);

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -521,6 +521,8 @@ extern uint64_t global_balance_reserved_maineco[100000];
 extern uint64_t global_balance_money_testeco[100000];
 extern uint64_t global_balance_reserved_testeco[100000];
 
+extern std::string exodus_address;
+
 int mastercore_init(void);
 
 int64_t getMPbalance(const string &Address, unsigned int property, TallyType ttype);

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -72,7 +72,7 @@ int const MAX_STATE_HISTORY = 50;
 
 #define MAX_SHA256_OBFUSCATION_TIMES  255
 
-#define MIN_PACKET_SIZE_CLASS_C 16
+#define MIN_PAYLOAD_SIZE     8
 #define PACKET_SIZE_CLASS_A 19
 #define PACKET_SIZE         31
 #define MAX_PACKETS         64

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -63,6 +63,9 @@ int const MAX_STATE_HISTORY = 50;
 #define OMNI_CLASS_B 2
 #define OMNI_CLASS_C 3
 
+// Maximum number of keys supported in Class B
+#define CLASS_B_MAX_SENDABLE_PACKETS 2
+
 // Master Protocol Transaction (Packet) Version
 #define MP_TX_PKT_V0  0
 #define MP_TX_PKT_V1  1

--- a/src/mastercore_errors.h
+++ b/src/mastercore_errors.h
@@ -13,6 +13,7 @@ enum MPRPCErrorCode
     //ClassB_send
     MP_INPUTS_INVALID =             -212,
     MP_REDEMP_ILLEGAL =             -233,
+    MP_TX_TOO_BIG =                 -240,
     MP_REDEMP_BAD_KEYID =           -220,
     MP_REDEMP_FETCH_ERR_PUBKEY =    -221,
     MP_REDEMP_INVALID_PUBKEY =      -222,

--- a/src/mastercore_errors.h
+++ b/src/mastercore_errors.h
@@ -10,10 +10,10 @@ enum MPRPCErrorCode
     MP_INSUF_FUNDS_APENDI =         -2,     // balance after pending
     MP_INPUT_NOT_IN_RANGE =         -11,    // input value larger than supported
     
-    //ClassB_send
+    //ClassAgnostic_send
     MP_INPUTS_INVALID =             -212,
+    MP_ENCODING_ERROR =             -250,
     MP_REDEMP_ILLEGAL =             -233,
-    MP_TX_TOO_BIG =                 -240,
     MP_REDEMP_BAD_KEYID =           -220,
     MP_REDEMP_FETCH_ERR_PUBKEY =    -221,
     MP_REDEMP_INVALID_PUBKEY =      -222,

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -402,7 +402,7 @@ if (fHelp || params.size() < 2 || params.size() > 5)
   //some sanity checking of the data supplied?
   uint256 newTX;
   std::vector<unsigned char> data = ParseHex(hexTransaction);
-  int rc = ClassB_send(fromAddress, toAddress, redeemAddress, data, newTX, referenceAmount);
+  int rc = ClassAgnostic_send(fromAddress, toAddress, redeemAddress, data, newTX, referenceAmount);
 
   if (0 != rc)
       throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("error code= %i", rc));

--- a/src/mastercore_tx.cpp
+++ b/src/mastercore_tx.cpp
@@ -28,7 +28,7 @@ using namespace mastercore;
 // initial packet interpret step
 int CMPTransaction::step1()
 {
-  if (MIN_PACKET_SIZE_CLASS_C > pkt_size)  // class C packets could now be as small as 16 bytes
+  if (MIN_PAYLOAD_SIZE > pkt_size)  // class C packets could now be as small as 8 bytes
   {
     file_log("%s() ERROR PACKET TOO SMALL; size = %d, line %d, file: %s\n", __FUNCTION__, pkt_size, __LINE__, __FILE__);
     return -(PKT_ERROR -1);

--- a/src/mastercore_tx.cpp
+++ b/src/mastercore_tx.cpp
@@ -28,7 +28,7 @@ using namespace mastercore;
 // initial packet interpret step
 int CMPTransaction::step1()
 {
-  if (PACKET_SIZE_CLASS_A > pkt_size)  // class A could be 19 bytes
+  if (MIN_PACKET_SIZE_CLASS_C > pkt_size)  // class C packets could now be as small as 16 bytes
   {
     file_log("%s() ERROR PACKET TOO SMALL; size = %d, line %d, file: %s\n", __FUNCTION__, pkt_size, __LINE__, __FILE__);
     return -(PKT_ERROR -1);
@@ -45,7 +45,19 @@ int CMPTransaction::step1()
 
   swapByteOrder32(type);
 
-  file_log("version: %d, Class %s\n", version, !multi ? "A":"B");
+  string classType;
+  switch(multi) {
+      case 0:
+          classType = "A";
+      break;
+      case 1:
+          classType = "B";
+      break;
+      case 2:
+          classType = "C";
+      break;
+  }
+  file_log("\t         version: %d, Class %s\n", version, classType.c_str());
   file_log("\t            type: %u (%s)\n", type, c_strMasterProtocolTXType(type));
 
   return (type);

--- a/src/mastercore_tx.h
+++ b/src/mastercore_tx.h
@@ -39,7 +39,7 @@ private:
   int pkt_size;
   unsigned char pkt[1 + MAX_PACKETS * PACKET_SIZE];
   uint64_t nValue;
-  int multi;  // Class A = 0, Class B = 1
+  int multi;  // Class A = 0, Class B = 1, Class C = 2
   uint64_t tx_fee_paid;
   unsigned int type;
   unsigned int property;

--- a/src/omnicore_encoding.cpp
+++ b/src/omnicore_encoding.cpp
@@ -1,0 +1,81 @@
+/**
+ * This file serves to seperate encoding of data outputs from the main mastercore.cpp/h files.
+ */
+
+#include "mastercore.h"
+#include "omnicore_encoding.h"
+#include "omnicore_utils.h"
+#include "base58.h"
+#include "primitives/transaction.h"
+#include "pubkey.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+#include "random.h"
+#include "wallet.h"
+#include "openssl/sha.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include <string>
+#include <vector>
+
+bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& redeemingPubKey, const std::vector<unsigned char>& vecPayload, std::vector<std::pair <CScript,int64_t> >& vecOutputs)
+{
+    int nRemainingBytes = vecPayload.size();
+    int nNextByte = 0;
+    unsigned char seqNum = 1;
+    std::string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
+    prepareObfuscatedHashes(senderAddress, strObfuscatedHashes);
+    while (nRemainingBytes > 0) {
+        int nKeys = 1; // assume one key of data since we have data remaining
+        if (nRemainingBytes > (PACKET_SIZE - 1)) { nKeys += 1; } // we have enough data for 2 keys in this output
+        std::vector<CPubKey> keys;
+        keys.push_back(redeemingPubKey); // always include the redeeming pubkey
+        int i;
+        for (i = 0; i < nKeys; i++) {
+            std::vector<unsigned char> fakeKey;
+            fakeKey.push_back(seqNum); // add sequence number
+            int numBytes = nRemainingBytes < (PACKET_SIZE - 1) ? nRemainingBytes: (PACKET_SIZE - 1); // add up to 30 bytes of data
+            fakeKey.insert(fakeKey.end(), vecPayload.begin() + nNextByte, vecPayload.begin() + nNextByte + numBytes);
+            nNextByte += numBytes;
+            nRemainingBytes -= numBytes;
+            while (fakeKey.size() < PACKET_SIZE) { fakeKey.push_back(0); } // pad to 31 total bytes with zeros
+            int j;
+            std::vector<unsigned char>hash = ParseHex(strObfuscatedHashes[seqNum]);
+            for (j = 0; j < PACKET_SIZE; j++) { // xor in the obfuscation
+                fakeKey[j] = fakeKey[j] ^ hash[j];
+            }
+            fakeKey.insert(fakeKey.begin(), 2); // prepend the 2
+            CPubKey pubKey;
+            fakeKey.resize(33);
+            unsigned char random_byte = (unsigned char)(GetRand(256)); // fix up the ecdsa code point
+            for (j = 0; i < 256 ; j++) {
+                fakeKey[32] = random_byte;
+                pubKey = CPubKey(fakeKey);
+                file_log("pubKey check: %s\n", (HexStr(pubKey.begin(), pubKey.end()).c_str()));
+                if (pubKey.IsFullyValid()) break;
+                ++random_byte; // cycle 256 times, if we must to find a valid ECDSA point
+            }
+            keys.push_back(pubKey);
+            seqNum++;
+        }
+        CScript multisig_output = GetScriptForMultisig(1, keys);
+        vecOutputs.push_back(make_pair(multisig_output, GetDustLimit(multisig_output)));
+    }
+    CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(exodus_address).Get());
+    vecOutputs.push_back(make_pair(scriptPubKey, GetDustLimit(scriptPubKey))); // add the Exodus marker
+    return true;
+}
+
+bool OmniCore_Encode_ClassC(const std::vector<unsigned char>& vecPayload, std::vector<std::pair <CScript,int64_t> >& vecOutputs)
+{
+    if (vecPayload.size() > nMaxDatacarrierBytes-4) { return false; } // we shouldn't see this since classAgnostic_send handles size vs class, but include check here for safety
+    const unsigned char bytes[] = {0x6f,0x6d,0x6e,0x69}; // define Omni marker bytes
+    std::vector<unsigned char> omniBytesPlusData(bytes, bytes+sizeof(bytes)/sizeof(bytes[0]));
+    omniBytesPlusData.insert(omniBytesPlusData.end(), vecPayload.begin(), vecPayload.end());
+    CScript script;
+    script << OP_RETURN << omniBytesPlusData;
+    vecOutputs.push_back(make_pair(script, 0));
+    return true;
+}

--- a/src/omnicore_encoding.cpp
+++ b/src/omnicore_encoding.cpp
@@ -70,8 +70,8 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
 
 bool OmniCore_Encode_ClassC(const std::vector<unsigned char>& vecPayload, std::vector<std::pair <CScript,int64_t> >& vecOutputs)
 {
-    if (vecPayload.size() > nMaxDatacarrierBytes-4) { return false; } // we shouldn't see this since classAgnostic_send handles size vs class, but include check here for safety
-    const unsigned char bytes[] = {0x6f,0x6d,0x6e,0x69}; // define Omni marker bytes
+    const unsigned char bytes[] = {0x6f,0x6d}; // define Omni marker bytes
+    if (vecPayload.size() > nMaxDatacarrierBytes-sizeof(bytes)/sizeof(bytes[0])) { return false; } // we shouldn't see this since classAgnostic_send handles size vs class, but include check here for safety
     std::vector<unsigned char> omniBytesPlusData(bytes, bytes+sizeof(bytes)/sizeof(bytes[0]));
     omniBytesPlusData.insert(omniBytesPlusData.end(), vecPayload.begin(), vecPayload.end());
     CScript script;

--- a/src/omnicore_encoding.h
+++ b/src/omnicore_encoding.h
@@ -1,0 +1,15 @@
+#ifndef OMNICORE_ENCODING_H
+#define OMNICORE_ENCODING_H
+
+class CPubKey;
+class CTxOut;
+
+#include <string>
+#include <vector>
+#include "script/script.h"
+#include "script/standard.h"
+
+bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& redeemingPubKey, const std::vector<unsigned char>& vecPayload, std::vector<std::pair <CScript,int64_t> >& vecOutputs);
+bool OmniCore_Encode_ClassC(const std::vector<unsigned char>& vecPayload, std::vector<std::pair <CScript,int64_t> >& vecOutputs);
+
+#endif // OMNICORE_ENCODING_H

--- a/src/omnicore_utils.cpp
+++ b/src/omnicore_utils.cpp
@@ -1,0 +1,51 @@
+// This file serves to seperate utility functions from the main mastercore.cpp/h files.
+
+#include "mastercore.h"
+#include "omnicore_encoding.h"
+#include "omnicore_utils.h"
+#include "openssl/sha.h"
+#include "wallet.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include <string>
+#include <vector>
+
+void prepareObfuscatedHashes(const string &address, string (&ObfsHashes)[1+MAX_SHA256_OBFUSCATION_TIMES])
+{
+    unsigned char sha_input[128];
+    unsigned char sha_result[128];
+    std::vector<unsigned char> vec_chars;
+    strcpy((char *)sha_input, address.c_str());
+    // do only as many re-hashes as there are mastercoin packets, 255 per spec
+    for (unsigned int j = 1; j<=MAX_SHA256_OBFUSCATION_TIMES;j++)
+    {
+        SHA256(sha_input, strlen((const char *)sha_input), sha_result);
+        vec_chars.resize(32);
+        memcpy(&vec_chars[0], &sha_result[0], 32);
+        ObfsHashes[j] = HexStr(vec_chars);
+        boost::to_upper(ObfsHashes[j]); // uppercase per spec
+        strcpy((char *)sha_input, ObfsHashes[j].c_str());
+    }
+}
+
+int64_t GetDustLimit(const CScript& scriptPubKey)
+{
+    // The total size is based on a typical scriptSig size of 148 byte,
+    // 8 byte accounted for the size of output value and the serialized
+    // size of scriptPubKey.
+    size_t nSize = ::GetSerializeSize(scriptPubKey, SER_DISK, 0) + 156;
+
+    // The minimum relay fee dictates a threshold value under which a
+    // transaction won't be relayed.
+    int64_t nRelayTxFee = (::minRelayTxFee).GetFee(nSize);
+
+    // A transaction is considered as "dust", if less than 1/3 of the
+    // minimum fee required to relay a transaction is spent by one of
+    // it's outputs. The minimum relay fee is defined per 1000 byte.
+    int64_t nDustLimit = nRelayTxFee * 3;
+
+    return nDustLimit;
+}
+
+

--- a/src/omnicore_utils.h
+++ b/src/omnicore_utils.h
@@ -1,0 +1,17 @@
+#ifndef OMNICORE_UTILS_H
+#define OMNICORE_UTILS_H
+
+class CPubKey;
+class CTxOut;
+
+#include <string>
+#include "script/script.h"
+#include "script/standard.h"
+
+void prepareObfuscatedHashes(const string &address, string (&ObfsHashes)[1+MAX_SHA256_OBFUSCATION_TIMES]);
+int64_t GetDustLimit(const CScript& scriptPubKey);
+
+#endif // OMNICORE_UTILS_H
+
+
+

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_PRIMITIVES_TRANSACTION_H
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
+#include "stdio.h"
 #include "amount.h"
 #include "script/script.h"
 #include "serialize.h"
@@ -142,8 +143,12 @@ public:
         // to spend something, then we consider it dust.
         // A typical txout is 34 bytes big, and will
         // need a CTxIn of at least 148 bytes to spend:
-        // so dust is a txout less than 546 satoshis 
+        // so dust is a txout less than 546 satoshis
         // with default minRelayTxFee.
+        if (scriptPubKey.IsUnspendable()) {
+            return false; // dust calculations applicable to spendable outputs only
+        }
+
         size_t nSize = GetSerializeSize(SER_DISK,0)+148u;
         return (nValue < 3*minRelayTxFee.GetFee(nSize));
     }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_PRIMITIVES_TRANSACTION_H
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
-#include "stdio.h"
 #include "amount.h"
 #include "script/script.h"
 #include "serialize.h"


### PR DESCRIPTION
Note: Not yet final.
Also pending outcome of https://github.com/mastercoin-MSC/spec/issues/281.

This PR adds Class C support for both encoding and decoding.  Class C in the current context (but open to change) is:
* Data packet moved to OP_RETURN output
* Data packet is not obfuscated
* Exodus marker removed and replaced with ```omni``` bytes at beginning of OP_RETURN output

A singular send function (```ClassAgnostic_send```) is now used which will default to Class C if the packet is small enough, otherwise falling back to class B.

