### PR TITLE
Logger and initialization refinement and overhaul

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -158,6 +158,7 @@ OMNICORE_H = \
   mastercore_convert.h \
   mastercore_dex.h \
   mastercore_errors.h \
+  mastercore_log.h \
   mastercore_parse_string.h \
   mastercore_rpc.h \
   mastercore_script.h \
@@ -169,6 +170,7 @@ OMNICORE_CPP = \
   mastercore.cpp \
   mastercore_convert.cpp \
   mastercore_dex.cpp \
+  mastercore_log.cpp \
   mastercore_parse_string.cpp \
   mastercore_rpc.cpp \
   mastercore_script.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -71,9 +71,9 @@ enum BindFlags {
 static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 CClientUIInterface uiInterface;
 
-/** Omni Core initialization and shutdown handler */
-int mastercore_init(void);
-int mastercore_shutdown(void);
+// Omni Core initialization and shutdown handlers
+int mastercore_init();
+int mastercore_shutdown();
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1104,8 +1104,6 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     // ********************************************************* Step 7.5: load omni core
 
-    uiInterface.InitMessage(_("Performing out of order block detection..."));
-
     if (fDisableWallet) {
         return InitError(_(
                 "Disabled wallet detected.\n\n"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1104,6 +1104,10 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     // ********************************************************* Step 7.5: load omni core
 
+#ifndef ENABLE_WALLET
+    bool fDisableWallet = true;
+#endif
+
     if (fDisableWallet) {
         return InitError(_(
                 "Disabled wallet detected.\n\n"

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -409,8 +409,6 @@ static bool isRangeOK(const uint64_t input)
 // call just before multiplying large numbers
 bool isMultiplicationOK(const uint64_t a, const uint64_t b)
 {
-//  printf("%s(%lu, %lu): ", __FUNCTION__, a, b);
-
   if (!a || !b) return true;
 
   if (MAX_INT_8_BYTES < a) return false;
@@ -691,23 +689,12 @@ uint64_t before, after;
   return bRet;
 }
 
-std::string p128(int128_t quantity)
-{
-    //printf("\nTest # was %s\n", boost::lexical_cast<std::string>(quantity).c_str() );
-   return boost::lexical_cast<std::string>(quantity);
-}
-std::string p_arb(cpp_int quantity)
-{
-    //printf("\nTest # was %s\n", boost::lexical_cast<std::string>(quantity).c_str() );
-   return boost::lexical_cast<std::string>(quantity);
-}
 //calculateFundraiser does token calculations per transaction
 //calcluateFractional does calculations for missed tokens
 void calculateFundraiser(unsigned short int propType, uint64_t amtTransfer, unsigned char bonusPerc, 
   uint64_t fundraiserSecs, uint64_t currentSecs, uint64_t numProps, unsigned char issuerPerc, uint64_t totalTokens, 
   std::pair<uint64_t, uint64_t>& tokens, bool &close_crowdsale )
 {
-  //uint64_t weeks_sec = 604800;
   int128_t weeks_sec_ = 604800L;
   //define weeks in seconds
   int128_t precision_ = 1000000000000L;
@@ -715,84 +702,32 @@ void calculateFundraiser(unsigned short int propType, uint64_t amtTransfer, unsi
   int128_t percentage_precision = 100L;
   //define precision for all percentages (10/100 = 10%)
 
-  //uint64_t bonusSeconds = fundraiserSecs - currentSecs;
   //calcluate the bonusseconds
-  //printf("\n bonus sec %lu\n", bonusSeconds);
   int128_t bonusSeconds_ = fundraiserSecs - currentSecs;
 
-  //double weeks_d = bonusSeconds / (double) weeks_sec;
-  //debugging
-  
   int128_t weeks_ = (bonusSeconds_ / weeks_sec_) * precision_ + ( (bonusSeconds_ % weeks_sec_ ) * precision_) / weeks_sec_;
   //calculate the whole number of weeks to apply bonus
-
-  //printf("\n weeks_d: %.8lf \n weeks: %s + (%s / %s) =~ %.8lf \n", weeks_d, p128(bonusSeconds_ / weeks_sec_).c_str(), p128(bonusSeconds_ % weeks_sec_).c_str(), p128(weeks_sec_).c_str(), boost::lexical_cast<double>(bonusSeconds_ / weeks_sec_) + boost::lexical_cast<double> (bonusSeconds_ % weeks_sec_) / boost::lexical_cast<double>(weeks_sec_) );
-  //debugging lines
-
-  //double ebPercentage_d = weeks_d * bonusPerc;
-  //debugging lines
 
   int128_t ebPercentage_ = weeks_ * bonusPerc;
   //calculate the earlybird percentage to be applied
 
-  //printf("\n ebPercentage_d: %.8lf \n ebPercentage: %s + (%s / %s ) =~ %.8lf \n", ebPercentage_d, p128(ebPercentage_ / precision_).c_str(), p128( (ebPercentage_) % precision_).c_str() , p128(precision_).c_str(), boost::lexical_cast<double>(ebPercentage_ / precision_) + boost::lexical_cast<double>(ebPercentage_ % precision_) / boost::lexical_cast<double>(precision_));
-  //debugging
-  
-  //double bonusPercentage_d = ( ebPercentage_d / 100 ) + 1;
-  //debugging
-
   int128_t bonusPercentage_ = (ebPercentage_ + (precision_ * percentage_precision) ) / percentage_precision; 
   //calcluate the bonus percentage to apply up to 'percentage_precision' number of digits
 
-  //printf("\n bonusPercentage_d: %.18lf \n bonusPercentage: %s + (%s / %s) =~ %.11lf \n", bonusPercentage_d, p128(bonusPercentage_ / precision_).c_str(), p128(bonusPercentage_ % precision_).c_str(), p128(precision_).c_str(), boost::lexical_cast<double>(bonusPercentage_ / precision_) + boost::lexical_cast<double>(bonusPercentage_ % precision_) / boost::lexical_cast<double>(precision_));
-  //debugging
-
-  //double issuerPercentage_d = (double) (issuerPerc * 0.01);
-  //debugging
-
   int128_t issuerPercentage_ = (int128_t)issuerPerc * precision_ / percentage_precision;
-
-  //printf("\n issuerPercentage_d: %.8lf \n issuerPercentage: %s + (%s / %s) =~ %.8lf \n", issuerPercentage_d, p128(issuerPercentage_ / precision_ ).c_str(), p128(issuerPercentage_ % precision_).c_str(), p128( precision_ ).c_str(), boost::lexical_cast<double>(issuerPercentage_ / precision_) + boost::lexical_cast<double>(issuerPercentage_ % precision_) / boost::lexical_cast<double>(precision_));
-  //debugging
 
   int128_t satoshi_precision_ = 100000000;
   //define the precision for bitcoin amounts (satoshi)
-  //uint64_t createdTokens, createdTokens_decimal;
   //declare used variables for total created tokens
 
-  //uint64_t issuerTokens, issuerTokens_decimal;
   //declare used variables for total issuer tokens
-
-  //printf("\n NUMBER OF PROPERTIES %ld", numProps); 
-  //printf("\n AMOUNT INVESTED: %ld BONUS PERCENTAGE: %.11f and %s", amtTransfer,bonusPercentage_d, p128(bonusPercentage_).c_str());
-  
-  //long double ct = ((amtTransfer/1e8) * (long double) numProps * bonusPercentage_d);
-
-  //int128_t createdTokens_ = (int128_t)amtTransfer*(int128_t)numProps* bonusPercentage_;
 
   cpp_int createdTokens = boost::lexical_cast<cpp_int>((int128_t)amtTransfer*(int128_t)numProps)* boost::lexical_cast<cpp_int>(bonusPercentage_);
 
-  //printf("\n CREATED TOKENS UINT %s \n", p_arb(createdTokens).c_str());
-
-  //printf("\n CREATED TOKENS %.8Lf, %s + (%s / %s) ~= %.8lf",ct, p128(createdTokens_ / (precision_ * satoshi_precision_) ).c_str(), p128(createdTokens_ % (precision_ * satoshi_precision_) ).c_str() , p128( precision_*satoshi_precision_ ).c_str(), boost::lexical_cast<double>(createdTokens_ / (precision_ * satoshi_precision_) ) + boost::lexical_cast<double>(createdTokens_ % (precision_ * satoshi_precision_)) / boost::lexical_cast<double>(precision_*satoshi_precision_));
-
-  //long double it = (uint64_t) ct * issuerPercentage_d;
-
-  //int128_t issuerTokens_ = (createdTokens_ / (satoshi_precision_ * precision_ )) * (issuerPercentage_ / 100) * precision_;
-  
   cpp_int issuerTokens = (createdTokens / (satoshi_precision_ * precision_ )) * (issuerPercentage_ / 100) * precision_;
 
-  //printf("\n ISSUER TOKENS: %.8Lf, %s + (%s / %s ) ~= %.8lf \n",it, p128(issuerTokens_ / (precision_ * satoshi_precision_ * 100 ) ).c_str(), p128( issuerTokens_ % (precision_ * satoshi_precision_ * 100 ) ).c_str(), p128(precision_*satoshi_precision_*100).c_str(), boost::lexical_cast<double>(issuerTokens_ / (precision_ * satoshi_precision_ * 100))  + boost::lexical_cast<double>(issuerTokens_ % (satoshi_precision_*precision_*100) )/ boost::lexical_cast<double>(satoshi_precision_*precision_*100)); 
-  
-  //printf("\n UINT %s \n", p_arb(issuerTokens).c_str());
   //total tokens including remainders
 
-  //printf("\n DIVISIBLE TOKENS (UI LAYER) CREATED: is ~= %.8lf, and %.8lf\n",(double)createdTokens + (double)createdTokens_decimal/(satoshi_precision *precision), (double) issuerTokens + (double)issuerTokens_decimal/(satoshi_precision*precision*percentage_precision) );
-  //if (2 == propType)
-    //printf("\n DIVISIBLE TOKENS (UI LAYER) CREATED: is ~= %.8lf, and %.8lf\n", (uint64_t) (boost::lexical_cast<double>(createdTokens_ / (precision_ * satoshi_precision_) ) + boost::lexical_cast<double>(createdTokens_ % (precision_ * satoshi_precision_)) / boost::lexical_cast<double>(precision_*satoshi_precision_) )/1e8, (uint64_t) (boost::lexical_cast<double>(issuerTokens_ / (precision_ * satoshi_precision_ * 100))  + boost::lexical_cast<double>(issuerTokens_ % (satoshi_precision_*precision_*100) )/ boost::lexical_cast<double>(satoshi_precision_*precision_*100)) / 1e8  );
-  //else
-    //printf("\n INDIVISIBLE TOKENS (UI LAYER) CREATED: is = %lu, and %lu\n", boost::lexical_cast<uint64_t>(createdTokens_ / (precision_ * satoshi_precision_ ) ), boost::lexical_cast<uint64_t>(issuerTokens_ / (precision_ * satoshi_precision_ * 100)));
-  
   cpp_int createdTokens_int = createdTokens / (precision_ * satoshi_precision_);
   cpp_int issuerTokens_int = issuerTokens / (precision_ * satoshi_precision_ * 100 );
   cpp_int newTotalCreated = totalTokens + createdTokens_int  + issuerTokens_int;
@@ -802,17 +737,12 @@ void calculateFundraiser(unsigned short int propType, uint64_t amtTransfer, unsi
 
     cpp_int created = createdTokens_int + issuerTokens_int;
     cpp_int ratio = (created * precision_ * satoshi_precision_) / maxCreatable;
-
-    //printf("\n created %s, ratio %s, maxCreatable %s, totalTokens %s, createdTokens_int %s, issuerTokens_int %s \n", p_arb(created).c_str(), p_arb(ratio).c_str(), p_arb(maxCreatable).c_str(), p_arb(totalTokens).c_str(), p_arb(createdTokens_int).c_str(), p_arb(issuerTokens_int).c_str() );
-    //debugging
   
     issuerTokens_int = (issuerTokens_int * precision_ * satoshi_precision_)/ratio;
     //calcluate the ratio of tokens for what we can create and apply it
     createdTokens_int = MAX_INT_8_BYTES - issuerTokens_int ;
     //give the rest to the user
 
-    //printf("\n created %s, ratio %s, maxCreatable %s, totalTokens %s, createdTokens_int %s, issuerTokens_int %s \n", p_arb(created).c_str(), p_arb(ratio).c_str(), p_arb(maxCreatable).c_str(), p_arb(totalTokens).c_str(), p_arb(createdTokens_int).c_str(), p_arb(issuerTokens_int).c_str() );
-    //debugging
     close_crowdsale = true; //close up the crowdsale after assigning all tokens
   }
   tokens = std::make_pair(boost::lexical_cast<uint64_t>(createdTokens_int) , boost::lexical_cast<uint64_t>(issuerTokens_int));
@@ -948,8 +878,6 @@ int mastercore::set_wallet_totals()
        }
     }
   }
-  //printf("Global MSC totals: MSC_total= %lu, MSC_RESERVED_total= %lu\n", global_balance_money_maineco[1], global_balance_reserved_maineco[1]);
-  //std::cout << t.elapsed() << std::endl;
   return (my_addresses_count);
 }
 
@@ -989,7 +917,6 @@ int TXExodusFundraiser(const CTransaction &wtx, const string &sender, int64_t Ex
 {
   if ((nBlock >= GENESIS_BLOCK && nBlock <= LAST_EXODUS_BLOCK) || (isNonMainNet()))
   { //Exodus Fundraiser start/end blocks
-    //printf("transaction: %s\n", wtx.ToString().c_str() );
     int deadline_timeleft=1377993600-nTime;
     double bonus= 1 + std::max( 0.10 * deadline_timeleft / (60 * 60 * 24 * 7), 0.0 );
 
@@ -3453,8 +3380,6 @@ unsigned int n_found = 0;
     svalue = it->value();
 
     ++count;
-
-//    printf("%5u:%s=%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
 
     string strvalue = it->value().ToString();
 

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -578,8 +578,8 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      {
                          // we know we have transactions live we don't understand
                          // can't be trusted to provide valid data, shutdown
-                         file_log("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n",global_alert_message.c_str());
-                         printf("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n",global_alert_message.c_str()); //echo to screen
+                         file_log("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message);
+                         LogStatus("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message); // echo to screen
                          if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode("Shutting down due to alert: " + getMasterCoreAlertTextOnly());
                          return false;
                      }
@@ -1585,7 +1585,7 @@ int msc_initial_scan(int nFirstBlock)
 
     // this function is useless if there are not enough blocks in the blockchain yet!
     if (nFirstBlock < 0 || nLastBlock < nFirstBlock) return -1;
-    printf("Scanning for transactions in block %d to block %d..\n", nFirstBlock, nLastBlock);
+    LogStatus("Scanning for transactions in block %d to block %d..\n", nFirstBlock, nLastBlock);
 
     for (nBlock = nFirstBlock; nBlock <= nLastBlock; ++nBlock)
     {
@@ -1596,7 +1596,7 @@ int msc_initial_scan(int nFirstBlock)
 
         if (GetTime() >= nNow + 15) {
             double dProgress = 100.0 * (nBlock - nFirstBlock) / (nLastBlock - nFirstBlock);
-            printf("Still scanning.. at block %d of %d. Progress: %.2f %%\n", nBlock, nLastBlock, dProgress);
+            LogStatus("Still scanning.. at block %d of %d. Progress: %.2f %%\n", nBlock, nLastBlock, dProgress);
             nNow = GetTime();
         }
 
@@ -1623,10 +1623,10 @@ int msc_initial_scan(int nFirstBlock)
     }
 
     if (nBlock < nLastBlock) {
-        printf("Scan stopped early at block %d of block %d\n", nBlock, nLastBlock);
+        LogStatus("Scan stopped early at block %d of block %d\n", nBlock, nLastBlock);
     }
 
-    printf("%d transactions processed, %d meta transactions found\n", nTotal, nFound);
+    LogStatus("%d transactions processed, %d meta transactions found\n", nTotal, nFound);
 
     return 0;
 }
@@ -2382,7 +2382,7 @@ int mastercore_init()
     return 0;
   }
 
-  printf("Initializing Omni Core v%s [%s]\n", OmniCoreVersion().c_str(), Params().NetworkIDString().c_str());
+  LogStatus("Initializing Omni Core v%s [%s]\n", OmniCoreVersion(), Params().NetworkIDString());
 
   ShrinkDebugLog();
 
@@ -2419,7 +2419,7 @@ int mastercore_init()
       catch(boost::filesystem::filesystem_error const & e)
       {
           file_log("Exception deleting folders for --startclean option.\n");
-          printf("Exception deleting folders for --startclean option.\n");
+          LogStatus("Exception deleting folders for --startclean option.\n");
       }
   }
 
@@ -2508,8 +2508,8 @@ int mastercore_init()
   exodus_balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);
   file_log("[Initialized] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
 
-  printf("Exodus balance: %s MSC\n", FormatDivisibleMP(exodus_balance).c_str());
-  printf("Omni Core initialization completed\n");
+  LogStatus("Exodus balance: %s MSC\n", FormatDivisibleMP(exodus_balance));
+  LogStatus("Omni Core initialization completed\n");
 
   return 0;
 }
@@ -2534,7 +2534,7 @@ int mastercore_shutdown()
   }
 
   file_log("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
-  printf("Omni Core shutdown completed\n");
+  LogStatus("Omni Core shutdown completed\n");
 
   return 0;
 }
@@ -3428,7 +3428,7 @@ Slice skey, svalue;
     skey = it->key();
     svalue = it->value();
     ++count;
-    printf("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
+    LogStatus("entry #%8d= %s:%s\n", count, skey.ToString(), svalue.ToString());
   }
 
   delete it;
@@ -3475,7 +3475,7 @@ unsigned int n_found = 0;
     }
   }
 
-  printf("%s(%d, %d); n_found= %d\n", __FUNCTION__, starting_block, ending_block, n_found);
+  LogStatus("%s(%d, %d); n_found= %d\n", __FUNCTION__, starting_block, ending_block, n_found);
 
   delete it;
 
@@ -3675,7 +3675,7 @@ void CMPSTOList::printAll()
     skey = it->key();
     svalue = it->value();
     ++count;
-    printf("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
+    LogStatus("entry #%8d= %s:%s\n", count, skey.ToString(), svalue.ToString());
   }
 
   delete it;
@@ -3729,7 +3729,7 @@ int CMPSTOList::deleteAboveBlock(int blockNum)
     }
   }
 
-  printf("%s(%d); stodb n_found= %d\n", __FUNCTION__, blockNum, n_found);
+  LogStatus("%s(%d); stodb n_found= %d\n", __FUNCTION__, blockNum, n_found);
 
   delete it;
 
@@ -3871,7 +3871,7 @@ int CMPTradeList::deleteAboveBlock(int blockNum)
     }
   }
 
-  printf("%s(%d); tradedb n_found= %d\n", __FUNCTION__, blockNum, n_found);
+  LogStatus("%s(%d); tradedb n_found= %d\n", __FUNCTION__, blockNum, n_found);
 
   delete it;
 
@@ -3911,7 +3911,7 @@ void CMPTradeList::printAll()
     skey = it->key();
     svalue = it->value();
     ++count;
-    printf("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
+    LogStatus("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
   }
 
   delete it;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1501,7 +1501,10 @@ uint64_t txFee = 0;
 }
 
 /**
- * Reports the progress of the initial transaction scanning to the user.
+ * Reports the progress of the initial transaction scanning.
+ *
+ * The progress is printed to the console, written to the debug log file, and
+ * the RPC status, as well as the splash screen progress label, are updated.
  *
  * @see msc_initial_scan()
  *
@@ -1512,7 +1515,11 @@ uint64_t txFee = 0;
 static void ReportScanProgress(int nFirst, int nCurrent, int nLast)
 {
     double dProgress = 100.0 * (nCurrent - nFirst) / (nLast - nFirst);
-    PrintToConsole("Still scanning.. at block %d of %d. Progress: %.2f %%\n", nCurrent, nLast, dProgress);
+    std::string strProgress = strprintf(
+            "Still scanning.. at block %d of %d. Progress: %.2f %%", nCurrent, nLast, dProgress);
+
+    PrintToConsole(strProgress + "\n");
+    uiInterface.InitMessage(strProgress);
 }
 
 /**
@@ -1521,7 +1528,7 @@ static void ReportScanProgress(int nFirst, int nCurrent, int nLast)
  * It scans the blockchain, starting at the given block index, to the current
  * tip, much like as if new block were arriving and being processed on the fly.
  *
- * Every 30 seconds the progress of the scan is reported to the user.
+ * Every 30 seconds the progress of the scan is reported.
  *
  * In case the current block being processed is not part of the active chain, or
  * if a block could not be retrieved from the disk, then the scan stops early.

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1579,15 +1579,17 @@ int msc_initial_scan(int nFirstBlock)
 {
     unsigned int nTotal = 0;
     unsigned int nFound = 0;
+    int nBlock = 999999;
     const int nLastBlock = GetHeight();
 
     // this function is useless if there are not enough blocks in the blockchain yet!
     if (nFirstBlock < 0 || nLastBlock < nFirstBlock) return -1;
     printf("Scanning for transactions in block %d to block %d..\n", nFirstBlock, nLastBlock);
 
-    for (int nBlock = nFirstBlock; nBlock <= nLastBlock; ++nBlock)
+    for (nBlock = nFirstBlock; nBlock <= nLastBlock; ++nBlock)
     {
         CBlockIndex* pblockindex = chainActive[nBlock];
+        if (NULL == pblockindex) break;
         std::string strBlockHash = pblockindex->GetBlockHash().GetHex();
 
         if (msc_debug_exo) file_log("%s(%d; max=%d):%s, line %d, file: %s\n",
@@ -1606,6 +1608,10 @@ int msc_initial_scan(int nFirstBlock)
 
         nTotal += nTxNum;
         mastercore_handler_block_end(nBlock, pblockindex, nFound);
+    }
+
+    if (nBlock < nLastBlock) {
+        printf("Scan stopped early at block %d of block %d\n", nBlock, nLastBlock);
     }
 
     printf("%d transactions processed, %d meta transactions found\n", nTotal, nFound);

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1577,6 +1577,7 @@ uint64_t txFee = 0;
 // parse blocks, potential right from Mastercoin's Exodus
 int msc_initial_scan(int nFirstBlock)
 {
+    int64_t nNow = GetTime();
     unsigned int nTotal = 0;
     unsigned int nFound = 0;
     int nBlock = 999999;
@@ -1588,6 +1589,12 @@ int msc_initial_scan(int nFirstBlock)
 
     for (nBlock = nFirstBlock; nBlock <= nLastBlock; ++nBlock)
     {
+        if (GetTime() >= nNow + 15) {
+            double dProgress = 100.0 * (nBlock - nFirstBlock) / (nLastBlock - nFirstBlock);
+            printf("Still scanning.. at block %d of %d. Progress: %.2f %%\n", nBlock, nLastBlock, dProgress);
+            nNow = GetTime();
+        }
+
         CBlockIndex* pblockindex = chainActive[nBlock];
         if (NULL == pblockindex) break;
         std::string strBlockHash = pblockindex->GetBlockHash().GetHex();

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1582,8 +1582,7 @@ const int max_block = GetHeight();
 
   // this function is useless if there are not enough blocks in the blockchain yet!
   if ((0 >= nHeight) || (max_block < nHeight)) return -1;
-
-  printf("starting block= %d, max_block= %d\n", nHeight, max_block);
+  printf("Scanning for transactions in block %d to block %d..\n", nHeight, max_block);
 
   CBlock block;
   for (int blockNum = nHeight;blockNum<=max_block;blockNum++)
@@ -1610,18 +1609,7 @@ const int max_block = GetHeight();
     mastercore_handler_block_end(blockNum, pblockindex, n_found);
   }
 
-  printf("\n");
-  for(map<string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it)
-  {
-    // my_it->first = key
-    // my_it->second = value
-
-    printf("%34s => ", (my_it->first).c_str());
-    (my_it->second).print();
-  }
-
-  printf("starting block= %d, max_block= %d\n", nHeight, max_block);
-  printf("n_total= %d, n_found= %d\n", n_total, n_found);
+  printf("%d transactions processed, %d meta transactions found\n", n_total, n_found);
 
   return 0;
 }
@@ -2377,7 +2365,7 @@ int mastercore_init()
     return 0;
   }
 
-  printf("%s()%s, line %d, file: %s\n", __FUNCTION__, isNonMainNet() ? "TESTNET":"", __LINE__, __FILE__);
+  printf("Initializing Omni Core v%s [%s]\n", OmniCoreVersion().c_str(), Params().NetworkIDString().c_str());
 
   ShrinkDebugLog();
 
@@ -2492,7 +2480,7 @@ int mastercore_init()
   // collect the real Exodus balances available at the snapshot time
   // redundant? do we need to show it both pre-parse and post-parse?  if so let's label the printfs accordingly
   exodus_balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);
-  printf("[Snapshot] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance).c_str());
+  file_log("[Snapshot] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
 
   // check out levelDB for the most recently stored alert and load it into global_alert_message then check if expired
   (void) p_txlistdb->setLastAlert(nWaterlineBlock);
@@ -2501,15 +2489,16 @@ int mastercore_init()
 
   // display Exodus balance
   exodus_balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);
-  printf("[Initialized] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance).c_str());
+  file_log("[Initialized] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
+
+  printf("Exodus balance: %s MSC\n", FormatDivisibleMP(exodus_balance).c_str());
+  printf("Omni Core initialization completed\n");
 
   return 0;
 }
 
 int mastercore_shutdown()
 {
-  printf("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-
   if (p_txlistdb)
   {
     delete p_txlistdb; p_txlistdb = NULL;
@@ -2522,12 +2511,13 @@ int mastercore_shutdown()
   {
     delete s_stolistdb; s_stolistdb = NULL;
   }
-  file_log("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-
   if (_my_sps)
   {
     delete _my_sps; _my_sps = NULL;
   }
+
+  file_log("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
+  printf("Omni Core shutdown completed\n");
 
   return 0;
 }

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1589,6 +1589,11 @@ int msc_initial_scan(int nFirstBlock)
 
     for (nBlock = nFirstBlock; nBlock <= nLastBlock; ++nBlock)
     {
+        if (ShutdownRequested()) {
+            file_log("Shutdown requested, stop scan at block %d of %d\n", nBlock, nLastBlock);
+            break;
+        }
+
         if (GetTime() >= nNow + 15) {
             double dProgress = 100.0 * (nBlock - nFirstBlock) / (nLastBlock - nFirstBlock);
             printf("Still scanning.. at block %d of %d. Progress: %.2f %%\n", nBlock, nLastBlock, dProgress);

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -577,7 +577,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                          // we know we have transactions live we don't understand
                          // can't be trusted to provide valid data, shutdown
                          file_log("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message);
-                         LogStatus("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message); // echo to screen
+                         PrintToConsole("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message); // echo to screen
                          if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode("Shutting down due to alert: " + getMasterCoreAlertTextOnly());
                          return false;
                      }
@@ -1512,7 +1512,7 @@ int msc_initial_scan(int nFirstBlock)
 
     // this function is useless if there are not enough blocks in the blockchain yet!
     if (nFirstBlock < 0 || nLastBlock < nFirstBlock) return -1;
-    LogStatus("Scanning for transactions in block %d to block %d..\n", nFirstBlock, nLastBlock);
+    PrintToConsole("Scanning for transactions in block %d to block %d..\n", nFirstBlock, nLastBlock);
 
     for (nBlock = nFirstBlock; nBlock <= nLastBlock; ++nBlock)
     {
@@ -1523,7 +1523,7 @@ int msc_initial_scan(int nFirstBlock)
 
         if (GetTime() >= nNow + 15) {
             double dProgress = 100.0 * (nBlock - nFirstBlock) / (nLastBlock - nFirstBlock);
-            LogStatus("Still scanning.. at block %d of %d. Progress: %.2f %%\n", nBlock, nLastBlock, dProgress);
+            PrintToConsole("Still scanning.. at block %d of %d. Progress: %.2f %%\n", nBlock, nLastBlock, dProgress);
             nNow = GetTime();
         }
 
@@ -1550,10 +1550,10 @@ int msc_initial_scan(int nFirstBlock)
     }
 
     if (nBlock < nLastBlock) {
-        LogStatus("Scan stopped early at block %d of block %d\n", nBlock, nLastBlock);
+        PrintToConsole("Scan stopped early at block %d of block %d\n", nBlock, nLastBlock);
     }
 
-    LogStatus("%d transactions processed, %d meta transactions found\n", nTotal, nFound);
+    PrintToConsole("%d transactions processed, %d meta transactions found\n", nTotal, nFound);
 
     return 0;
 }
@@ -2309,7 +2309,7 @@ int mastercore_init()
     return 0;
   }
 
-  LogStatus("Initializing Omni Core v%s [%s]\n", OmniCoreVersion(), Params().NetworkIDString());
+  PrintToConsole("Initializing Omni Core v%s [%s]\n", OmniCoreVersion(), Params().NetworkIDString());
 
   ShrinkDebugLog();
 
@@ -2346,7 +2346,7 @@ int mastercore_init()
       catch(boost::filesystem::filesystem_error const & e)
       {
           file_log("Exception deleting folders for --startclean option.\n");
-          LogStatus("Exception deleting folders for --startclean option.\n");
+          PrintToConsole("Exception deleting folders for --startclean option.\n");
       }
   }
 
@@ -2435,8 +2435,8 @@ int mastercore_init()
   exodus_balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);
   file_log("[Initialized] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
 
-  LogStatus("Exodus balance: %s MSC\n", FormatDivisibleMP(exodus_balance));
-  LogStatus("Omni Core initialization completed\n");
+  PrintToConsole("Exodus balance: %s MSC\n", FormatDivisibleMP(exodus_balance));
+  PrintToConsole("Omni Core initialization completed\n");
 
   return 0;
 }
@@ -2461,7 +2461,7 @@ int mastercore_shutdown()
   }
 
   file_log("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
-  LogStatus("Omni Core shutdown completed\n");
+  PrintToConsole("Omni Core shutdown completed\n");
 
   return 0;
 }
@@ -3355,7 +3355,7 @@ Slice skey, svalue;
     skey = it->key();
     svalue = it->value();
     ++count;
-    LogStatus("entry #%8d= %s:%s\n", count, skey.ToString(), svalue.ToString());
+    PrintToConsole("entry #%8d= %s:%s\n", count, skey.ToString(), svalue.ToString());
   }
 
   delete it;
@@ -3400,7 +3400,7 @@ unsigned int n_found = 0;
     }
   }
 
-  LogStatus("%s(%d, %d); n_found= %d\n", __FUNCTION__, starting_block, ending_block, n_found);
+  PrintToConsole("%s(%d, %d); n_found= %d\n", __FUNCTION__, starting_block, ending_block, n_found);
 
   delete it;
 
@@ -3600,7 +3600,7 @@ void CMPSTOList::printAll()
     skey = it->key();
     svalue = it->value();
     ++count;
-    LogStatus("entry #%8d= %s:%s\n", count, skey.ToString(), svalue.ToString());
+    PrintToConsole("entry #%8d= %s:%s\n", count, skey.ToString(), svalue.ToString());
   }
 
   delete it;
@@ -3654,7 +3654,7 @@ int CMPSTOList::deleteAboveBlock(int blockNum)
     }
   }
 
-  LogStatus("%s(%d); stodb n_found= %d\n", __FUNCTION__, blockNum, n_found);
+  PrintToConsole("%s(%d); stodb n_found= %d\n", __FUNCTION__, blockNum, n_found);
 
   delete it;
 
@@ -3796,7 +3796,7 @@ int CMPTradeList::deleteAboveBlock(int blockNum)
     }
   }
 
-  LogStatus("%s(%d); tradedb n_found= %d\n", __FUNCTION__, blockNum, n_found);
+  PrintToConsole("%s(%d); tradedb n_found= %d\n", __FUNCTION__, blockNum, n_found);
 
   delete it;
 
@@ -3836,7 +3836,7 @@ void CMPTradeList::printAll()
     skey = it->key();
     svalue = it->value();
     ++count;
-    LogStatus("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
+    PrintToConsole("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
   }
 
   delete it;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2301,7 +2301,11 @@ static void clear_all_state() {
   exodus_prev = 0;
 }
 
-// called from init.cpp of Bitcoin Core
+/**
+ * Global handler to initialize Omni Core.
+ *
+ * @return An exit code, indicating success or failure
+ */
 int mastercore_init()
 {
   if (mastercoreInitialized) {
@@ -2441,29 +2445,37 @@ int mastercore_init()
   return 0;
 }
 
+/**
+ * Global handler to shut down Omni Core.
+ *
+ * In particular, the LevelDB databases of the global state objects are closed
+ * properly.
+ *
+ * @return An exit code, indicating success or failure
+ */
 int mastercore_shutdown()
 {
-  if (p_txlistdb)
-  {
-    delete p_txlistdb; p_txlistdb = NULL;
-  }
-  if (t_tradelistdb)
-  {
-    delete t_tradelistdb; t_tradelistdb = NULL;
-  }
-  if (s_stolistdb)
-  {
-    delete s_stolistdb; s_stolistdb = NULL;
-  }
-  if (_my_sps)
-  {
-    delete _my_sps; _my_sps = NULL;
-  }
+    if (p_txlistdb) {
+        delete p_txlistdb;
+        p_txlistdb = NULL;
+    }
+    if (t_tradelistdb) {
+        delete t_tradelistdb;
+        t_tradelistdb = NULL;
+    }
+    if (s_stolistdb) {
+        delete s_stolistdb;
+        s_stolistdb = NULL;
+    }
+    if (_my_sps) {
+        delete _my_sps;
+        _my_sps = NULL;
+    }
 
-  file_log("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
-  PrintToConsole("Omni Core shutdown completed\n");
+    file_log("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
+    PrintToConsole("Omni Core shutdown completed\n");
 
-  return 0;
+    return 0;
 }
 
 // this is called for every new transaction that comes in (actually in block parsing loop)

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -9,6 +9,8 @@
 class CBlockIndex;
 class CTransaction;
 
+#include "mastercore_log.h"
+
 #include "sync.h"
 #include "uint256.h"
 #include "util.h"
@@ -20,7 +22,6 @@ class CTransaction;
 #include "json/json_spirit_value.h"
 
 #include <stdint.h>
-#include <stdio.h>
 
 #include <map>
 #include <string>
@@ -249,12 +250,12 @@ public:
 
     if (bDivisible)
     {
-      printf("%22s [SO_RESERVE= %22s , ACCEPT_RESERVE= %22s ] %22s\n",
-       FormatDivisibleMP(money, true).c_str(), FormatDivisibleMP(so_r, true).c_str(), FormatDivisibleMP(a_r, true).c_str(), FormatDivisibleMP(pending, true).c_str());
+      LogStatus("%22s [SO_RESERVE= %22s , ACCEPT_RESERVE= %22s ] %22s\n",
+       FormatDivisibleMP(money, true), FormatDivisibleMP(so_r, true), FormatDivisibleMP(a_r, true), FormatDivisibleMP(pending, true));
     }
     else
     {
-      printf("%14lu [SO_RESERVE= %14lu , ACCEPT_RESERVE= %14lu ] %14ld\n", money, so_r, a_r, pending);
+      LogStatus("%14lu [SO_RESERVE= %14lu , ACCEPT_RESERVE= %14lu ] %14ld\n", money, so_r, a_r, pending);
     }
 
     return (money + so_r + a_r);
@@ -299,7 +300,7 @@ public:
       iteroptions.fill_cache = false;
       syncoptions.sync = true;
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &sdb);
-      printf("Loading send-to-owners database: %s\n", status.ToString().c_str());
+      LogStatus("Loading send-to-owners database: %s\n", status.ToString());
     }
 
     ~CMPSTOList()
@@ -342,7 +343,7 @@ public:
       iteroptions.fill_cache = false;
       syncoptions.sync = true;
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &tdb);
-      printf("Loading trades database: %s\n", status.ToString().c_str());
+      LogStatus("Loading trades database: %s\n", status.ToString());
     }
 
     ~CMPTradeList()
@@ -398,7 +399,7 @@ public:
       syncoptions.sync = true;
 
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &pdb);
-      printf("Loading transactions database: %s\n", status.ToString().c_str());
+      LogStatus("Loading transactions database: %s\n", status.ToString());
     }
 
     ~CMPTxList()
@@ -441,7 +442,7 @@ public:
 
   void print(uint256 txid) const
   {
-    printf("%s : %s %d %ld %ld %s\n", txid.GetHex().c_str(), src.c_str(), prop, amount, type, desc.c_str());
+    LogStatus("%s : %s %d %ld %ld %s\n", txid.GetHex(), src, prop, amount, type, desc);
   }
  
 };

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -10,7 +10,6 @@ class CBlockIndex;
 class CTransaction;
 
 #include "sync.h"
-#include "tinyformat.h"
 #include "uint256.h"
 #include "util.h"
 
@@ -30,11 +29,6 @@ class CTransaction;
 using json_spirit::Array;
 
 using std::string;
-
-
-#define LOG_FILENAME    "mastercore.log"
-#define INFO_FILENAME   "mastercore_crowdsales.log"
-#define OWNERS_FILENAME "mastercore_owners.log"
 
 int const MAX_STATE_HISTORY = 50;
 
@@ -149,50 +143,6 @@ enum FILETYPES {
 #define OMNI_PROPERTY_MSC   1
 #define OMNI_PROPERTY_TMSC  2
 
-int mp_LogPrintStr(const std::string &str);
-
-/* When we switch to C++11, this can be switched to variadic templates instead
- * of this macro-based construction (see tinyformat.h).
- */
-#define MP_MAKE_ERROR_AND_LOG_FUNC(n)                                        \
-    /*   Print to debug.log if -debug=category switch is given OR category is NULL. */ \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int mp_category_log(const char* category, const char* format, TINYFORMAT_VARARGS(n))  \
-    {                                                                         \
-        if(!LogAcceptCategory(category)) return 0;                            \
-        return mp_LogPrintStr(tfm::format(format, TINYFORMAT_PASSARGS(n))); \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int mp_log(TINYFORMAT_VARARGS(n))  \
-    {                                                                         \
-        return mp_LogPrintStr(tfm::format("%s", TINYFORMAT_PASSARGS(n))); \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int mp_log(const char* format, TINYFORMAT_VARARGS(n))  \
-    {                                                                         \
-        return mp_LogPrintStr(tfm::format(format, TINYFORMAT_PASSARGS(n))); \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int file_log(const char* format, TINYFORMAT_VARARGS(n))  \
-    {                                                                         \
-        return mp_LogPrintStr(tfm::format(format, TINYFORMAT_PASSARGS(n))); \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int file_log(TINYFORMAT_VARARGS(n))  \
-    {                                                                         \
-        return mp_LogPrintStr(tfm::format("%s", TINYFORMAT_PASSARGS(n))); \
-    }                                                                         \
-    /*   Log error and return false */                                        \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline bool mp_error(const char* format, TINYFORMAT_VARARGS(n))                     \
-    {                                                                         \
-        mp_LogPrintStr("ERROR: " + tfm::format(format, TINYFORMAT_PASSARGS(n)) + "\n"); \
-        return false;                                                         \
-    }
-
-TINYFORMAT_FOREACH_ARGNUM(MP_MAKE_ERROR_AND_LOG_FUNC)
-//--- CUT HERE ---
-
 // forward declarations
 std::string FormatPriceMP(double n);
 std::string FormatDivisibleMP(int64_t n, bool fSign = false);
@@ -203,11 +153,7 @@ int64_t feeCheck(const string &address);
 
 const std::string ExodusAddress();
 
-extern int msc_debug_ui;
-
 extern CCriticalSection cs_tally;
-
-extern const int msc_debug_dex;
 
 enum TallyType { BALANCE = 0, SELLOFFER_RESERVE = 1, ACCEPT_RESERVE = 2, PENDING = 3, METADEX_RESERVE = 4, TALLY_TYPE_COUNT };
 

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -461,8 +461,12 @@ bool IsMyAddress(const std::string &address);
 
 string getLabel(const string &address);
 
+/** Global handler to initialize Omni Core. */
 int mastercore_init();
+
+/** Global handler to shut down Omni Core. */
 int mastercore_shutdown();
+
 int mastercore_handler_disc_begin(int nBlockNow, CBlockIndex const * pBlockIndex);
 int mastercore_handler_disc_end(int nBlockNow, CBlockIndex const * pBlockIndex);
 int mastercore_handler_block_begin(int nBlockNow, CBlockIndex const * pBlockIndex);

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -299,7 +299,7 @@ public:
       iteroptions.fill_cache = false;
       syncoptions.sync = true;
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &sdb);
-      printf("%s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+      printf("Loading send-to-owners database: %s\n", status.ToString().c_str());
     }
 
     ~CMPSTOList()
@@ -342,7 +342,7 @@ public:
       iteroptions.fill_cache = false;
       syncoptions.sync = true;
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &tdb);
-      printf("%s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+      printf("Loading trades database: %s\n", status.ToString().c_str());
     }
 
     ~CMPTradeList()
@@ -398,8 +398,7 @@ public:
       syncoptions.sync = true;
 
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &pdb);
-
-      printf("%s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+      printf("Loading transactions database: %s\n", status.ToString().c_str());
     }
 
     ~CMPTxList()

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -250,12 +250,12 @@ public:
 
     if (bDivisible)
     {
-      LogStatus("%22s [SO_RESERVE= %22s , ACCEPT_RESERVE= %22s ] %22s\n",
+      PrintToConsole("%22s [SO_RESERVE= %22s , ACCEPT_RESERVE= %22s ] %22s\n",
        FormatDivisibleMP(money, true), FormatDivisibleMP(so_r, true), FormatDivisibleMP(a_r, true), FormatDivisibleMP(pending, true));
     }
     else
     {
-      LogStatus("%14lu [SO_RESERVE= %14lu , ACCEPT_RESERVE= %14lu ] %14ld\n", money, so_r, a_r, pending);
+      PrintToConsole("%14lu [SO_RESERVE= %14lu , ACCEPT_RESERVE= %14lu ] %14ld\n", money, so_r, a_r, pending);
     }
 
     return (money + so_r + a_r);
@@ -300,7 +300,7 @@ public:
       iteroptions.fill_cache = false;
       syncoptions.sync = true;
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &sdb);
-      LogStatus("Loading send-to-owners database: %s\n", status.ToString());
+      PrintToConsole("Loading send-to-owners database: %s\n", status.ToString());
     }
 
     ~CMPSTOList()
@@ -343,7 +343,7 @@ public:
       iteroptions.fill_cache = false;
       syncoptions.sync = true;
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &tdb);
-      LogStatus("Loading trades database: %s\n", status.ToString());
+      PrintToConsole("Loading trades database: %s\n", status.ToString());
     }
 
     ~CMPTradeList()
@@ -399,7 +399,7 @@ public:
       syncoptions.sync = true;
 
       leveldb::Status status = leveldb::DB::Open(options, path.string(), &pdb);
-      LogStatus("Loading transactions database: %s\n", status.ToString());
+      PrintToConsole("Loading transactions database: %s\n", status.ToString());
     }
 
     ~CMPTxList()
@@ -442,7 +442,7 @@ public:
 
   void print(uint256 txid) const
   {
-    LogStatus("%s : %s %d %ld %ld %s\n", txid.GetHex(), src, prop, amount, type, desc);
+    PrintToConsole("%s : %s %d %ld %ld %s\n", txid.GetHex(), src, prop, amount, type, desc);
   }
  
 };

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -454,14 +454,14 @@ extern uint64_t global_balance_reserved_maineco[100000];
 extern uint64_t global_balance_money_testeco[100000];
 extern uint64_t global_balance_reserved_testeco[100000];
 
-int mastercore_init(void);
-
 int64_t getMPbalance(const string &Address, unsigned int property, TallyType ttype);
 int64_t getUserAvailableMPbalance(const string &Address, unsigned int property);
 bool IsMyAddress(const std::string &address);
 
 string getLabel(const string &address);
 
+int mastercore_init();
+int mastercore_shutdown();
 int mastercore_handler_disc_begin(int nBlockNow, CBlockIndex const * pBlockIndex);
 int mastercore_handler_disc_end(int nBlockNow, CBlockIndex const * pBlockIndex);
 int mastercore_handler_block_begin(int nBlockNow, CBlockIndex const * pBlockIndex);

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -319,7 +319,7 @@ void mastercore::MetaDEx_debug_print(bool bShowPriceLevel, bool bDisplay)
       {
       CMPMetaDEx obj = *it;
 
-        if (bDisplay) LogStatus("%s= %s\n", price.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed) , obj.ToString());
+        if (bDisplay) PrintToConsole("%s= %s\n", price.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed) , obj.ToString());
         else file_log("%s= %s\n", price.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed) , obj.ToString());
 
         // extra checks: price or either of the amounts is 0

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -5,6 +5,7 @@
 #include "mastercore.h"
 #include "mastercore_convert.h"
 #include "mastercore_errors.h"
+#include "mastercore_log.h"
 #include "mastercore_tx.h"
 
 #include "main.h"
@@ -31,8 +32,6 @@ using std::string;
 
 using namespace mastercore;
 
-
-extern int msc_debug_metadex1, msc_debug_metadex2, msc_debug_metadex3;
 
 md_PropertiesMap mastercore::metadex;
 

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -319,7 +319,7 @@ void mastercore::MetaDEx_debug_print(bool bShowPriceLevel, bool bDisplay)
       {
       CMPMetaDEx obj = *it;
 
-        if (bDisplay) printf("%s= %s\n", price.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed).c_str() , obj.ToString().c_str());
+        if (bDisplay) LogStatus("%s= %s\n", price.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed) , obj.ToString());
         else file_log("%s= %s\n", price.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed) , obj.ToString());
 
         // extra checks: price or either of the amounts is 0

--- a/src/mastercore_dex.h
+++ b/src/mastercore_dex.h
@@ -2,6 +2,7 @@
 #define _MASTERCOIN_DEX 1
 
 #include "mastercore.h"
+#include "mastercore_log.h"
 
 #include "main.h"
 #include "tinyformat.h"

--- a/src/mastercore_log.cpp
+++ b/src/mastercore_log.cpp
@@ -81,6 +81,14 @@ static void DebugLogInit()
 }
 
 /**
+ * @return The current timestamp in the format: 2015-04-15 11:18:01
+ */
+static std::string GetTimestamp()
+{
+    return DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime());
+}
+
+/**
  * Print to debug log file or console.
  *
  * The configuration options "-printtoconsole" and "-logtimestamps" can be used
@@ -95,8 +103,7 @@ int DebugLogPrint(const std::string& str)
     int ret = 0; // Number of characters written
     if (fPrintToConsole) {
         // Print to console
-        ret = fwrite(str.data(), 1, str.size(), stdout);
-        fflush(stdout);
+        ret = StatusLogPrint(str);
     }
     else if (fPrintToDebugLog && AreBaseParamsConfigured()) {
         static bool fStartedNewLine = true;
@@ -118,7 +125,7 @@ int DebugLogPrint(const std::string& str)
 
         // Printing log timestamps can be useful for profiling
         if (fLogTimestamps && fStartedNewLine) {
-            ret += fprintf(fileout, "%s ", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+            ret += fprintf(fileout, "%s ", GetTimestamp().c_str());
         }
         if (!str.empty() && str[str.size()-1] == '\n') {
             fStartedNewLine = true;
@@ -127,6 +134,35 @@ int DebugLogPrint(const std::string& str)
         }
         ret += fwrite(str.data(), 1, str.size(), fileout);
     }
+
+    return ret;
+}
+
+/**
+ * Print to the console.
+ *
+ * The configuration options "-logtimestamps" can be used to indicate, whether
+ * the message should be prepended with a timestamp.
+ *
+ * @param str[in]  The message to log
+ * @return The total number of characters written
+ */
+int StatusLogPrint(const std::string& str)
+{
+    int ret = 0; // Number of characters written
+    static bool fStartedNewLine = true;
+
+    if (fLogTimestamps && fStartedNewLine) {
+        ret = fprintf(stdout, "%s %s", GetTimestamp().c_str(), str.c_str());
+    } else {
+        ret = fwrite(str.data(), 1, str.size(), stdout);
+    }
+    if (!str.empty() && str[str.size()-1] == '\n') {
+        fStartedNewLine = true;
+    } else {
+        fStartedNewLine = false;
+    }
+    fflush(stdout);
 
     return ret;
 }

--- a/src/mastercore_log.cpp
+++ b/src/mastercore_log.cpp
@@ -44,7 +44,7 @@ bool msc_debug_persistence        = 0;
 bool msc_debug_ui                 = 0;
 bool msc_debug_metadex1           = 0;
 bool msc_debug_metadex2           = 0;
-// Print orderbook before and after each transaction
+//! Print orderbook before and after each trade
 bool msc_debug_metadex3           = 0;
 
 /**
@@ -66,7 +66,7 @@ static FILE* fileout = NULL;
 static boost::mutex* mutexDebugLog = NULL;
 
 /**
- * Open debug log file.
+ * Opens debug log file.
  */
 static void DebugLogInit()
 {
@@ -81,7 +81,7 @@ static void DebugLogInit()
 }
 
 /**
- * @return The current timestamp in the format: 2015-04-15 11:18:01
+ * @return The current timestamp in the format: 2009-01-03 18:15:05
  */
 static std::string GetTimestamp()
 {
@@ -89,21 +89,23 @@ static std::string GetTimestamp()
 }
 
 /**
- * Print to debug log file or console.
+ * Prints to log file.
  *
- * The configuration options "-printtoconsole" and "-logtimestamps" can be used
- * to indicate, whether to add log entries to a file or print to the console,
- * and if the message should be prepended with a timestamp.
+ * The configuration options "-logtimestamps" can be used to indicate, whether
+ * the message to log should be prepended with a timestamp.
+ *
+ * If "-printtoconsole" is enabled, then the message is written to the standard
+ * output, usually the console, instead of a log file.
  *
  * @param str[in]  The message to log
  * @return The total number of characters written
  */
-int DebugLogPrint(const std::string& str)
+int LogFilePrint(const std::string& str)
 {
     int ret = 0; // Number of characters written
     if (fPrintToConsole) {
         // Print to console
-        ret = StatusLogPrint(str);
+        ret = ConsolePrint(str);
     }
     else if (fPrintToDebugLog && AreBaseParamsConfigured()) {
         static bool fStartedNewLine = true;
@@ -139,15 +141,15 @@ int DebugLogPrint(const std::string& str)
 }
 
 /**
- * Print to the console.
+ * Prints to the standard output, usually the console.
  *
- * The configuration options "-logtimestamps" can be used to indicate, whether
+ * The configuration option "-logtimestamps" can be used to indicate, whether
  * the message should be prepended with a timestamp.
  *
- * @param str[in]  The message to log
+ * @param str[in]  The message to print
  * @return The total number of characters written
  */
-int StatusLogPrint(const std::string& str)
+int ConsolePrint(const std::string& str)
 {
     int ret = 0; // Number of characters written
     static bool fStartedNewLine = true;
@@ -168,7 +170,7 @@ int StatusLogPrint(const std::string& str)
 }
 
 /**
- * Scroll debug log, if it's getting too big.
+ * Scrolls debug log, if it's getting too big.
  */
 void ShrinkDebugLog()
 {

--- a/src/mastercore_log.cpp
+++ b/src/mastercore_log.cpp
@@ -1,0 +1,164 @@
+#include "mastercore_log.h"
+
+#include "chainparamsbase.h"
+#include "util.h"
+#include "utiltime.h"
+
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/once.hpp>
+
+#include <assert.h>
+#include <stdio.h>
+#include <string>
+
+// Log files
+const std::string LOG_FILENAME    = "mastercore.log";
+const std::string INFO_FILENAME   = "mastercore_crowdsales.log";
+const std::string OWNERS_FILENAME = "mastercore_owners.log";
+
+// Options
+static const long LOG_BUFFERSIZE  =  8000000; //  8 MB
+static const long LOG_SHRINKSIZE  = 50000000; // 50 MB
+
+// Debug flags
+bool msc_debug_parser_data        = 0;
+bool msc_debug_parser             = 0;
+bool msc_debug_verbose            = 0;
+bool msc_debug_verbose2           = 0;
+bool msc_debug_verbose3           = 0;
+bool msc_debug_vin                = 0;
+bool msc_debug_script             = 0;
+bool msc_debug_dex                = 1;
+bool msc_debug_send               = 1;
+bool msc_debug_tokens             = 0;
+bool msc_debug_spec               = 1;
+bool msc_debug_exo                = 0;
+bool msc_debug_tally              = 1;
+bool msc_debug_sp                 = 1;
+bool msc_debug_sto                = 1;
+bool msc_debug_txdb               = 0;
+bool msc_debug_tradedb            = 1;
+bool msc_debug_persistence        = 0;
+bool msc_debug_ui                 = 0;
+bool msc_debug_metadex1           = 0;
+bool msc_debug_metadex2           = 0;
+// Print orderbook before and after each transaction
+bool msc_debug_metadex3           = 0;
+
+/**
+ * LogPrintf() has been broken a couple of times now
+ * by well-meaning people adding mutexes in the most straightforward way.
+ * It breaks because it may be called by global destructors during shutdown.
+ * Since the order of destruction of static/global objects is undefined,
+ * defining a mutex as a global object doesn't work (the mutex gets
+ * destroyed, and then some later destructor calls OutputDebugStringF,
+ * maybe indirectly, and you get a core dump at shutdown trying to lock
+ * the mutex).
+ */
+static boost::once_flag debugLogInitFlag = BOOST_ONCE_INIT;
+/**
+ * We use boost::call_once() to make sure these are initialized
+ * in a thread-safe manner the first time called:
+ */
+static FILE* fileout = NULL;
+static boost::mutex* mutexDebugLog = NULL;
+
+/**
+ * Open debug log file.
+ */
+static void DebugLogInit()
+{
+    assert(fileout == NULL);
+    assert(mutexDebugLog == NULL);
+
+    boost::filesystem::path pathDebug = GetDataDir() / LOG_FILENAME;
+    fileout = fopen(pathDebug.string().c_str(), "a");
+    if (fileout) setbuf(fileout, NULL); // Unbuffered
+
+    mutexDebugLog = new boost::mutex();
+}
+
+/**
+ * Print to debug log file or console.
+ *
+ * The configuration options "-printtoconsole" and "-logtimestamps" can be used
+ * to indicate, whether to add log entries to a file or print to the console,
+ * and if the message should be prepended with a timestamp.
+ *
+ * @param str[in]  The message to log
+ * @return The total number of characters written
+ */
+int DebugLogPrint(const std::string& str)
+{
+    int ret = 0; // Number of characters written
+    if (fPrintToConsole) {
+        // Print to console
+        ret = fwrite(str.data(), 1, str.size(), stdout);
+        fflush(stdout);
+    }
+    else if (fPrintToDebugLog && AreBaseParamsConfigured()) {
+        static bool fStartedNewLine = true;
+        boost::call_once(&DebugLogInit, debugLogInitFlag);
+
+        if (fileout == NULL) {
+            return ret;
+        }
+        boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+
+        // Reopen the log file, if requested
+        if (fReopenDebugLog) {
+            fReopenDebugLog = false;
+            boost::filesystem::path pathDebug = GetDataDir() / LOG_FILENAME;
+            if (freopen(pathDebug.string().c_str(), "a", fileout) != NULL) {
+                setbuf(fileout, NULL); // Unbuffered
+            }
+        }
+
+        // Printing log timestamps can be useful for profiling
+        if (fLogTimestamps && fStartedNewLine) {
+            ret += fprintf(fileout, "%s ", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+        }
+        if (!str.empty() && str[str.size()-1] == '\n') {
+            fStartedNewLine = true;
+        } else {
+            fStartedNewLine = false;
+        }
+        ret += fwrite(str.data(), 1, str.size(), fileout);
+    }
+
+    return ret;
+}
+
+/**
+ * Scroll debug log, if it's getting too big.
+ */
+void ShrinkDebugLog()
+{
+    boost::filesystem::path pathLog = GetDataDir() / LOG_FILENAME;
+    FILE* file = fopen(pathLog.string().c_str(), "r");
+
+    if (file && boost::filesystem::file_size(pathLog) > LOG_SHRINKSIZE) {
+        // Restart the file with some of the end
+        char* pch = new char[LOG_BUFFERSIZE];
+        if (NULL != pch) {
+            fseek(file, -LOG_BUFFERSIZE, SEEK_END);
+            int nBytes = fread(pch, 1, LOG_BUFFERSIZE, file);
+            fclose(file);
+            file = NULL;
+
+            file = fopen(pathLog.string().c_str(), "w");
+            if (file) {
+                fwrite(pch, 1, nBytes, file);
+                fclose(file);
+                file = NULL;
+            }
+            delete[] pch;
+        }
+    } else if (NULL != file) {
+        fclose(file);
+        file = NULL;
+    }
+}
+

--- a/src/mastercore_log.h
+++ b/src/mastercore_log.h
@@ -1,0 +1,70 @@
+#ifndef MASTERCORE_LOG_H
+#define MASTERCORE_LOG_H
+
+#include "util.h"
+#include "tinyformat.h"
+
+#include <string>
+
+/** Print to debug log file or console. */
+int DebugLogPrint(const std::string& str);
+
+/** Scroll debug log, if it's getting too big. */
+void ShrinkDebugLog();
+
+// Log files
+extern const std::string LOG_FILENAME;
+extern const std::string INFO_FILENAME;
+extern const std::string OWNERS_FILENAME;
+
+// Debug flags
+extern bool msc_debug_parser_data;
+extern bool msc_debug_parser;
+extern bool msc_debug_verbose;
+extern bool msc_debug_verbose2;
+extern bool msc_debug_verbose3;
+extern bool msc_debug_vin;
+extern bool msc_debug_script;
+extern bool msc_debug_dex;
+extern bool msc_debug_send;
+extern bool msc_debug_tokens;
+extern bool msc_debug_spec;
+extern bool msc_debug_exo;
+extern bool msc_debug_tally;
+extern bool msc_debug_sp;
+extern bool msc_debug_sto;
+extern bool msc_debug_txdb;
+extern bool msc_debug_tradedb;
+extern bool msc_debug_persistence;
+extern bool msc_debug_ui;
+extern bool msc_debug_metadex1;
+extern bool msc_debug_metadex2;
+extern bool msc_debug_metadex3;
+
+/* When we switch to C++11, this can be switched to variadic templates instead
+ * of this macro-based construction (see tinyformat.h).
+ */
+#define MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC(n)                                  \
+    /** Log, if -debug=category switch is given OR category is NULL. */       \
+    template<TINYFORMAT_ARGTYPES(n)>                                          \
+    static inline int mp_category_log(const char* category, const char* format, TINYFORMAT_VARARGS(n))  \
+    {                                                                         \
+        if (!LogAcceptCategory(category)) return 0;                           \
+        return DebugLogPrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));    \
+    }                                                                         \
+    template<TINYFORMAT_ARGTYPES(n)>                                          \
+    static inline int file_log(const char* format, TINYFORMAT_VARARGS(n))     \
+    {                                                                         \
+        return DebugLogPrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));    \
+    }                                                                         \
+    template<TINYFORMAT_ARGTYPES(n)>                                          \
+    static inline int file_log(TINYFORMAT_VARARGS(n))                         \
+    {                                                                         \
+        return DebugLogPrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));      \
+    }
+
+TINYFORMAT_FOREACH_ARGNUM(MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC)
+
+#undef MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC
+
+#endif // MASTERCORE_LOG_H

--- a/src/mastercore_log.h
+++ b/src/mastercore_log.h
@@ -6,13 +6,13 @@
 
 #include <string>
 
-/** Print to debug log file or console. */
-int DebugLogPrint(const std::string& str);
+/** Prints to the log file. */
+int LogFilePrint(const std::string& str);
 
-/** Print to the console. */
-int StatusLogPrint(const std::string& str);
+/** Prints to the console. */
+int ConsolePrint(const std::string& str);
 
-/** Scroll debug log, if it's getting too big. */
+/** Scrolls log file, if it's getting too big. */
 void ShrinkDebugLog();
 
 // Log files
@@ -47,33 +47,33 @@ extern bool msc_debug_metadex3;
 /* When we switch to C++11, this can be switched to variadic templates instead
  * of this macro-based construction (see tinyformat.h).
  */
-#define MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC(n)                                  \
-    /** Log, if -debug=category switch is given OR category is NULL. */       \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int mp_category_log(const char* category, const char* format, TINYFORMAT_VARARGS(n))  \
-    {                                                                         \
-        if (!LogAcceptCategory(category)) return 0;                           \
-        return DebugLogPrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));    \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int file_log(const char* format, TINYFORMAT_VARARGS(n))     \
-    {                                                                         \
-        return DebugLogPrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));    \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int file_log(TINYFORMAT_VARARGS(n))                         \
-    {                                                                         \
-        return DebugLogPrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));      \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int LogStatus(const char* format, TINYFORMAT_VARARGS(n))    \
-    {                                                                         \
-        return StatusLogPrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));   \
-    }                                                                         \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int LogStatus(TINYFORMAT_VARARGS(n))                        \
-    {                                                                         \
-        return StatusLogPrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));     \
+#define MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC(n)                                    \
+    /** Log, if -debug=category switch is given OR category is NULL. */         \
+    template<TINYFORMAT_ARGTYPES(n)>                                            \
+    static inline int mp_category_log(const char* category, const char* format, TINYFORMAT_VARARGS(n)) \
+    {                                                                           \
+        if (!LogAcceptCategory(category)) return 0;                             \
+        return LogFilePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));       \
+    }                                                                           \
+    template<TINYFORMAT_ARGTYPES(n)>                                            \
+    static inline int file_log(const char* format, TINYFORMAT_VARARGS(n))       \
+    {                                                                           \
+        return LogFilePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));       \
+    }                                                                           \
+    template<TINYFORMAT_ARGTYPES(n)>                                            \
+    static inline int file_log(TINYFORMAT_VARARGS(n))                           \
+    {                                                                           \
+        return LogFilePrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));         \
+    }                                                                           \
+    template<TINYFORMAT_ARGTYPES(n)>                                            \
+    static inline int PrintToConsole(const char* format, TINYFORMAT_VARARGS(n)) \
+    {                                                                           \
+        return ConsolePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));       \
+    }                                                                           \
+    template<TINYFORMAT_ARGTYPES(n)>                                            \
+    static inline int PrintToConsole(TINYFORMAT_VARARGS(n))                     \
+    {                                                                           \
+        return ConsolePrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));         \
     }
 
 TINYFORMAT_FOREACH_ARGNUM(MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC)

--- a/src/mastercore_log.h
+++ b/src/mastercore_log.h
@@ -9,6 +9,9 @@
 /** Print to debug log file or console. */
 int DebugLogPrint(const std::string& str);
 
+/** Print to the console. */
+int StatusLogPrint(const std::string& str);
+
 /** Scroll debug log, if it's getting too big. */
 void ShrinkDebugLog();
 
@@ -61,6 +64,16 @@ extern bool msc_debug_metadex3;
     static inline int file_log(TINYFORMAT_VARARGS(n))                         \
     {                                                                         \
         return DebugLogPrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));      \
+    }                                                                         \
+    template<TINYFORMAT_ARGTYPES(n)>                                          \
+    static inline int LogStatus(const char* format, TINYFORMAT_VARARGS(n))    \
+    {                                                                         \
+        return StatusLogPrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));   \
+    }                                                                         \
+    template<TINYFORMAT_ARGTYPES(n)>                                          \
+    static inline int LogStatus(TINYFORMAT_VARARGS(n))                        \
+    {                                                                         \
+        return StatusLogPrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));     \
     }
 
 TINYFORMAT_FOREACH_ARGNUM(MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC)

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -6,6 +6,7 @@
 #include "mastercore_convert.h"
 #include "mastercore_dex.h"
 #include "mastercore_errors.h"
+#include "mastercore_log.h"
 #include "mastercore_parse_string.h"
 #include "mastercore_sp.h"
 #include "mastercore_tx.h"

--- a/src/mastercore_sp.cpp
+++ b/src/mastercore_sp.cpp
@@ -319,7 +319,6 @@ int mastercore::calculateFractional(unsigned short int propType, unsigned char b
   uint64_t numProps, unsigned char issuerPerc, const std::map<std::string, std::vector<uint64_t> > txFundraiserData, 
   const uint64_t amountPremined  )
 {
-
   //initialize variables
   double totalCreated = 0;
   double issuerPercentage = (double) (issuerPerc * 0.01);
@@ -335,14 +334,14 @@ int mastercore::calculateFractional(unsigned short int propType, unsigned char b
 
     //make calc for bonus given in sec
     uint64_t bonusSeconds = fundraiserSecs - currentSecs;
-  
+
     //turn it into weeks
     double weeks = bonusSeconds / (double) 604800;
-    
+
     //make it a %
     double ebPercentage = weeks * bonusPerc;
     double bonusPercentage = ( ebPercentage / 100 ) + 1;
-  
+
     //init var
     double createdTokens;
 
@@ -350,17 +349,13 @@ int mastercore::calculateFractional(unsigned short int propType, unsigned char b
     if( MSC_PROPERTY_TYPE_DIVISIBLE == propType ) {
       //calculate tokens
       createdTokens = (amtTransfer/1e8) * (double) numProps * bonusPercentage ;
-      
-      //printf("prop 2: is %Lf, and %Lf \n", createdTokens, issuerTokens);
-      
+
       //add totals up
       totalCreated += createdTokens;
     } else {
-      //printf("amount xfer %Lf and props %f and bonus percs %Lf \n", amtTransfer, (double) numProps, bonusPercentage);
-      
       //same here
       createdTokens = (uint64_t) ( (amtTransfer/1e8) * (double) numProps * bonusPercentage);
-      
+
       totalCreated += createdTokens;
     }
   };
@@ -477,31 +472,30 @@ bool mastercore::isCrowdsalePurchase(uint256 txid, string address, int64_t *prop
 void mastercore::eraseMaxedCrowdsale(const string &address, uint64_t blockTime, int block)
 {
     CrowdMap::iterator it = my_crowds.find(address);
-    
+
     if (it != my_crowds.end()) {
 
       CMPCrowd &crowd = it->second;
       file_log("%s() FOUND MAXED OUT CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, address.c_str());
 
       dumpCrowdsaleInfo(address, crowd);
-      
+
       CMPSPInfo::Entry sp;
-      
+
       //get sp from data struct
       _my_sps->getSP(crowd.getPropertyId(), sp);
-      
+
       //get txdata
       sp.historicalData = crowd.getDatabase();
       sp.close_early = 1;
       sp.max_tokens = 1;
       sp.timeclosed = blockTime;
-      
+
       //update SP with this data
       sp.update_block = chainActive[block]->GetBlockHash();
       _my_sps->updateSP(crowd.getPropertyId() , sp);
-      
+
       //No calculate fractional calls here, no more tokens (at MAX)
-      
       my_crowds.erase(it);
     }
 }
@@ -514,9 +508,6 @@ CrowdMap::iterator my_it = my_crowds.begin();
 
   while (my_crowds.end() != my_it)
   {
-    // my_it->first = key
-    // my_it->second = value
-
     CMPCrowd &crowd = my_it->second;
 
     if (blockTime > (int64_t)crowd.getDeadline())
@@ -525,14 +516,12 @@ CrowdMap::iterator my_it = my_crowds.begin();
 
       // TODO: dump the info about this crowdsale being delete into a TXT file (JSON perhaps)
       dumpCrowdsaleInfo(my_it->first, my_it->second, true);
-      
+
       // Begin calculate Fractional 
       CMPSPInfo::Entry sp;
-      
+
       //get sp from data struct
       _my_sps->getSP(crowd.getPropertyId(), sp);
-
-      //file_log("\nValues going into calculateFractional(): hexid %s earlyBird %d deadline %lu numProps %lu issuerPerc %d, issuerCreated %ld \n", sp.txid.GetHex().c_str(), sp.early_bird, sp.deadline, sp.num_tokens, sp.percentage, crowd.getIssuerCreated());
 
       //find missing tokens
       double missedTokens = calculateFractional(sp.prop_type,
@@ -542,9 +531,6 @@ CrowdMap::iterator my_it = my_crowds.begin();
                           sp.percentage,
                           crowd.getDatabase(),
                           crowd.getIssuerCreated());
-
-
-      //file_log("\nValues coming out of calculateFractional(): Total tokens, Tokens created, Tokens for issuer, amountMissed: issuer %s %lu %lu %lu %f\n",sp.issuer.c_str(), crowd.getUserCreated() + crowd.getIssuerCreated(), crowd.getUserCreated(), crowd.getIssuerCreated(), missedTokens);
 
       //get txdata
       sp.historicalData = crowd.getDatabase();
@@ -557,7 +543,7 @@ CrowdMap::iterator my_it = my_crowds.begin();
       //update values
       update_tally_map(sp.issuer, crowd.getPropertyId(), missedTokens, BALANCE);
       //End
-                     
+
       my_crowds.erase(my_it++);
 
       ++how_many_erased;
@@ -579,5 +565,4 @@ char *mastercore::c_strPropertyType(int i)
 
   return (char *) "*** property type error ***";
 }
-
 

--- a/src/mastercore_sp.cpp
+++ b/src/mastercore_sp.cpp
@@ -3,6 +3,7 @@
 #include "mastercore_sp.h"
 
 #include "mastercore.h"
+#include "mastercore_log.h"
 
 #include "main.h"
 #include "uint256.h"

--- a/src/mastercore_sp.h
+++ b/src/mastercore_sp.h
@@ -277,7 +277,7 @@ private:
   unsigned int next_spid;
   unsigned int next_test_spid;
 
-  void openDB() {
+  leveldb::Status openDB() {
     leveldb::Options options;
     options.paranoid_checks = true;
     options.create_if_missing = true;
@@ -287,6 +287,7 @@ private:
      if (false == s.ok()) {
        printf("Failed to create or read LevelDB for Smart Property at %s", path.c_str());
      }
+     return s;
   }
 
   void closeDB() {
@@ -299,7 +300,8 @@ public:
   CMPSPInfo(const boost::filesystem::path &_path)
     : path(_path)
   {
-    openDB();
+    leveldb::Status status = openDB();
+    printf("Loading smart property database: %s\n", status.ToString().c_str());
 
     // special cases for constant SPs MSC and TMSC
     implied_msc.issuer = ExodusAddress();

--- a/src/mastercore_sp.h
+++ b/src/mastercore_sp.h
@@ -2,6 +2,7 @@
 #define _MASTERCOIN_SP 1
 
 #include "mastercore.h"
+#include "mastercore_log.h"
 
 class CBlockIndex;
 
@@ -255,13 +256,13 @@ public:
 
     void print() const
     {
-      printf("%s:%s(Fixed=%s,Divisible=%s):%lu:%s/%s, %s %s\n",
-        issuer.c_str(),
-        name.c_str(),
-        fixed ? "Yes":"No",
-        isDivisible() ? "Yes":"No",
+      LogStatus("%s:%s(Fixed=%s,Divisible=%s):%lu:%s/%s, %s %s\n",
+        issuer,
+        name,
+        fixed ? "Yes" : "No",
+        isDivisible() ? "Yes" : "No",
         num_tokens,
-        category.c_str(), subcategory.c_str(), url.c_str(), data.c_str());
+        category, subcategory, url, data);
     }
 
   };
@@ -285,7 +286,7 @@ private:
     leveldb::Status s = leveldb::DB::Open(options, path.string(), &pDb);
 
      if (false == s.ok()) {
-       printf("Failed to create or read LevelDB for Smart Property at %s", path.c_str());
+       LogStatus("Failed to create or read LevelDB for Smart Property at %s", path.string());
      }
      return s;
   }
@@ -301,7 +302,7 @@ public:
     : path(_path)
   {
     leveldb::Status status = openDB();
-    printf("Loading smart property database: %s\n", status.ToString().c_str());
+    LogStatus("Loading smart property database: %s\n", status.ToString());
 
     // special cases for constant SPs MSC and TMSC
     implied_msc.issuer = ExodusAddress();
@@ -399,11 +400,11 @@ public:
     // print off the hard coded MSC and TMSC entries
     for (unsigned int idx = OMNI_PROPERTY_MSC; idx <= OMNI_PROPERTY_TMSC; idx++ ) {
       Entry info;
-      printf("%10d => ", idx);
+      LogStatus("%10d => ", idx);
       if (getSP(idx, info)) {
         info.print();
       } else {
-        printf("<Internal Error on implicit SP>\n");
+        LogStatus("<Internal Error on implicit SP>\n");
       }
     }
 
@@ -416,7 +417,7 @@ public:
         std::string key = iter->key().ToString();
         boost::split(vstr, key, boost::is_any_of("-"), token_compress_on);
 
-        printf("%10s => ", vstr[1].c_str());
+        LogStatus("%10s => ", vstr[1]);
 
         // parse the encoded json, failing if it doesnt parse or is an object
         Value spInfoVal;
@@ -425,7 +426,7 @@ public:
           info.fromJSON(spInfoVal.get_obj());
           info.print();
         } else {
-          printf("<Malformed JSON in DB>\n");
+          LogStatus("<Malformed JSON in DB>\n");
         }
       }
     }

--- a/src/mastercore_sp.h
+++ b/src/mastercore_sp.h
@@ -247,7 +247,7 @@ public:
 
     void print() const
     {
-      LogStatus("%s:%s(Fixed=%s,Divisible=%s):%lu:%s/%s, %s %s\n",
+      PrintToConsole("%s:%s(Fixed=%s,Divisible=%s):%lu:%s/%s, %s %s\n",
         issuer,
         name,
         fixed ? "Yes" : "No",
@@ -277,7 +277,7 @@ private:
     leveldb::Status s = leveldb::DB::Open(options, path.string(), &pDb);
 
      if (false == s.ok()) {
-       LogStatus("Failed to create or read LevelDB for Smart Property at %s", path.string());
+       PrintToConsole("Failed to create or read LevelDB for Smart Property at %s", path.string());
      }
      return s;
   }
@@ -292,7 +292,7 @@ public:
     : path(_path)
   {
     leveldb::Status status = openDB();
-    LogStatus("Loading smart property database: %s\n", status.ToString());
+    PrintToConsole("Loading smart property database: %s\n", status.ToString());
 
     // special cases for constant SPs MSC and TMSC
     implied_msc.issuer = ExodusAddress();
@@ -390,11 +390,11 @@ public:
     // print off the hard coded MSC and TMSC entries
     for (unsigned int idx = OMNI_PROPERTY_MSC; idx <= OMNI_PROPERTY_TMSC; idx++ ) {
       Entry info;
-      LogStatus("%10d => ", idx);
+      PrintToConsole("%10d => ", idx);
       if (getSP(idx, info)) {
         info.print();
       } else {
-        LogStatus("<Internal Error on implicit SP>\n");
+        PrintToConsole("<Internal Error on implicit SP>\n");
       }
     }
 
@@ -407,7 +407,7 @@ public:
         std::string key = iter->key().ToString();
         boost::split(vstr, key, boost::is_any_of("-"), token_compress_on);
 
-        LogStatus("%10s => ", vstr[1]);
+        PrintToConsole("%10s => ", vstr[1]);
 
         // parse the encoded json, failing if it doesnt parse or is an object
         Value spInfoVal;
@@ -416,7 +416,7 @@ public:
           info.fromJSON(spInfoVal.get_obj());
           info.print();
         } else {
-          LogStatus("<Malformed JSON in DB>\n");
+          PrintToConsole("<Malformed JSON in DB>\n");
         }
       }
     }

--- a/src/mastercore_sp.h
+++ b/src/mastercore_sp.h
@@ -144,8 +144,6 @@ public:
       std::string values_long = "";
       std::string values = "";
 
-      //file_log("\ncrowdsale started to save, size of db %ld", database.size());
-
       //Iterate through fundraiser data, serializing it with txid:val:val:val:val;
       bool crowdsale = !fixed && !manual;
       for(it = historicalData.begin(); it != historicalData.end(); it++) {
@@ -162,7 +160,6 @@ public:
          values += ";";
          values_long += values;
       }
-      //file_log("\ncrowdsale saved %s", values_long.c_str());
 
       spInfo.push_back(Pair("historicalData", values_long));
       spInfo.push_back(Pair("txid", (boost::format("%s") % txid.ToString()).str()));
@@ -201,16 +198,12 @@ public:
 
       //reconstruct database
       std::string longstr = json[idx++].value_.get_str();
-      
-      //file_log("\nDESERIALIZE GO ----> %s" ,longstr.c_str() );
-      
+
       std::vector<std::string> strngs_vec;
       
       //split serialized form up
       boost::split(strngs_vec, longstr, boost::is_any_of(";"));
 
-      //file_log("\nDATABASE PRE-DESERIALIZE SUCCESS, %ld, %s" ,strngs_vec.size(), strngs_vec[0].c_str());
-      
       //Go through and deserialize the database
       bool crowdsale = !fixed && !manual;
       for(std::vector<std::string>::size_type i = 0; i != strngs_vec.size(); i++) {
@@ -224,7 +217,6 @@ public:
         std::vector<uint64_t> txDataVec;
 
         if ( crowdsale && str_split_vec.size() == 5) {
-          //file_log("\n Deserialized values: %s, %s %s %s %s", str_split_vec.at(0).c_str(), str_split_vec.at(1).c_str(), str_split_vec.at(2).c_str(), str_split_vec.at(3).c_str(), str_split_vec.at(4).c_str());
           txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(1) ));
           txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(2) ));
           txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(3) ));
@@ -236,7 +228,6 @@ public:
 
         historicalData.insert(std::make_pair( str_split_vec.at(0), txDataVec ) ) ;
       }
-      //file_log("\nDATABASE DESERIALIZE SUCCESS %lu", database.size());
       txid = uint256(json[idx++].value_.get_str());
       creation_block = uint256(json[idx++].value_.get_str());
       update_block = uint256(json[idx++].value_.get_str());
@@ -297,7 +288,6 @@ private:
   }
 
 public:
-
   CMPSPInfo(const boost::filesystem::path &_path)
     : path(_path)
   {

--- a/src/mastercore_tx.cpp
+++ b/src/mastercore_tx.cpp
@@ -5,6 +5,7 @@
 #include "mastercore.h"
 #include "mastercore_convert.h"
 #include "mastercore_dex.h"
+#include "mastercore_log.h"
 #include "mastercore_sp.h"
 
 #include "alert.h"

--- a/src/mastercore_tx.h
+++ b/src/mastercore_tx.h
@@ -48,7 +48,7 @@ private:
   uint64_t nNewValue;
   int64_t blockTime;  // internally nTime is still an "unsigned int"
 
-// SP additions, perhaps a new class or a union is needed
+  // SP additions, perhaps a new class or a union is needed
   unsigned char ecosystem;
   unsigned short prop_type;
   unsigned int prev_prop_id;

--- a/src/mastercore_tx.h
+++ b/src/mastercore_tx.h
@@ -5,6 +5,7 @@ class CMPOffer;
 class CMPMetaDEx;
 
 #include "mastercore.h"
+#include "mastercore_log.h"
 
 class CTransaction;
 


### PR DESCRIPTION
**1) File logger and the loggers in general:**

Usage:
- Any entity that likes to use the logger has to include `mastercore_log.h`
- To add a new category, an entry in `mastercore_log.h` and `mastercore_log.cpp` should be created
- To enable or disable logging of a specific category, `mastercore_log.cpp` is the place to go

Notes:
- It provides a central place for anything log related
- With `_log.h` included, there is no need for `external ...` anymore
- `mp_log()` and `mp_error()` were never used, so I don't see any need to carry them around for now
- The categories might be enabled and disabled via RPC or config file at some point later

**2) Console or status logger:**

As subsitute for `printf()` another logger function `PrintToConsole()` was added:

- `PrintToConsole()` has a similar behavior like `file_log()`, but instead of printing to `mastercore.log`, the logger prints directly to the console
- `PrintToConsole()` is superior to `printf()`, as it comes with smarter tinyformat based formatting, and for example `.c_str()` can be omitted, when printing strings
- The main motivation though, was to gain control over all those `printf()`, which were sort of annoying and difficult to tame.. ;)
- In particular, encapsulating the console output allows to apply transformations, like using the option `-logtimestamps` to prepend the output with timestamps
- It is thinkable to use categories in the future, or to add more configuration options, such as `-quiet`, to silence all regular console output

**3) More useful and readable initializtion messages:**

Instead of printing line numbers and file names, the status messages were updated.

Further, the dumping of balances after an initial scan was removed completely for a few reasons:

- It was only printed after a scan, but not on every start
- The information is not really relevant
- The information is still available via other channels, e.g. via RPC `mscrpc`, `getallbalances..MP`

**4) Progress reporting during the intial transaction scanning:**

Every 30 seconds the progress of the scanning is printed to the console, written to the debug log file, and the RPC status, as well as the splash screen progress label, are updated.

It was important for me to show that Omni Core hasn't stalled, or is broken and doesn't do anything  during the scanning, but in fact has already processed n of m blocks.

**5) Shutdown request handling during the initial scanning:**

Until now there was no way to shutdown Omni Core during the initial scanning, whether the shutdown request was intentionally, or triggered by some other event, for example a restart of the OS. The only way was to forcefully kill the process, which is neither user friendly, nor does it properly close the databases, and in the worst case it could result in some corruption.

Closing the QT splash screen window, or killing the process, triggers a global (Bitcoin Core based) shutdown request, which is honored by `msc_initial_scan()`.

**6) Low-hanging fruits on the way:**

After @zathras-crypto gave green light for the initial merge, I started to wonder how to address any potential merge conflicts, and I finally came to the conclusion that it's probably better to bundle somewhat related changes, to reduce the impact on other pull requests.

While I generally think changes should come in smaller packets, the gain seemed to outweight the cost in this case, and in particular I'm referring to the last three commits [79749e9](https://github.com/dexX7/bitcoin/commit/79749e927b67c60105a86bcb7c634f43cbfc1d5f), [f07a23d](https://github.com/dexX7/bitcoin/commit/f07a23d2047ca2845e6adcacc43c96d9cf3cc773) and [93eae99](https://github.com/OmniLayer/omnicore/commit/93eae991967d1313411ff00c435cc33a2c6c31e9), which are hopefully easy to review and basically without any real impact.

**7) No merge conflicts:**

I actually got away with creating none for the pending pull requests.

The UI PR #5 can be merged directly, and #13 can be merged without conflicts, after merging https://github.com/zathras-crypto/mastercore/pull/63.

**8) Let's see some results of the updated initialization and status reports... :)**

```
$ ./src/test/test_bitcoin 
Initializing Omni Core v0.0.9.2-dev [unittest]
Loading trades database: OK
Loading send-to-owners database: OK
Loading transactions database: OK
Loading smart property database: OK
Exodus balance: 0.00000000 MSC
Omni Core initialization completed
Running 150 test cases...
Omni Core shutdown completed

*** No errors detected
```
```
$ ./src/qt/bitcoin-qt -logtimestamps # or bitcoind
2015-04-15 22:04:10 Initializing Omni Core v0.0.9.2-dev [main]
2015-04-15 22:04:10 Loading trades database: OK
2015-04-15 22:04:10 Loading send-to-owners database: OK
2015-04-15 22:04:10 Loading transactions database: OK
2015-04-15 22:04:10 Loading smart property database: OK
2015-04-15 22:04:10 Scanning for transactions in block 249498 to block 352066..
2015-04-15 22:04:25 Still scanning.. at block 253221 of 352066. Progress: 3.63 %
2015-04-15 22:04:40 Still scanning.. at block 256863 of 352066. Progress: 7.18 %
2015-04-15 22:04:55 Still scanning.. at block 258254 of 352066. Progress: 8.54 %
2015-04-15 22:05:10 Still scanning.. at block 259397 of 352066. Progress: 9.65 %
2015-04-15 22:05:25 Still scanning.. at block 260657 of 352066. Progress: 10.88 %
2015-04-15 22:05:40 Still scanning.. at block 261969 of 352066. Progress: 12.16 %
# ctrl+c, kill bitcoind, kill bitcoin-qt, or close bitcoin-qt
2015-04-15 22:05:44 Scan stopped early at block 262346 of block 352066
2015-04-15 22:05:44 3690943 transactions processed, 121 meta transactions found
2015-04-15 22:05:44 Exodus balance: 3845.77658936 MSC
2015-04-15 22:05:44 Omni Core initialization completed
2015-04-15 22:05:44 Omni Core shutdown completed
```
```
$ ./src/bitcoind -logtimestamps -startclean # or bitcoin-qt
2015-04-15 22:18:37 Initializing Omni Core v0.0.9.2-dev [regtest]
2015-04-15 22:18:37 Loading trades database: OK
2015-04-15 22:18:37 Loading send-to-owners database: OK
2015-04-15 22:18:37 Loading transactions database: OK
2015-04-15 22:18:37 Loading smart property database: OK
2015-04-15 22:18:37 Scanning for transactions in block 5 to block 749..
2015-04-15 22:18:43 1591 transactions processed, 432 meta transactions found
2015-04-15 22:18:43 Exodus balance: 38002.65700426 MSC
2015-04-15 22:18:43 Omni Core initialization completed
```