### PR TITLE
Logging: fix reuse of fReopenDebugLog flag

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -217,6 +217,7 @@ void HandleSIGTERM(int)
 void HandleSIGHUP(int)
 {
     fReopenDebugLog = true;
+    fReopenOmniCoreLog = true;
 }
 
 bool static InitError(const std::string &str)

--- a/src/mastercore_log.cpp
+++ b/src/mastercore_log.cpp
@@ -64,6 +64,8 @@ static boost::once_flag debugLogInitFlag = BOOST_ONCE_INIT;
  */
 static FILE* fileout = NULL;
 static boost::mutex* mutexDebugLog = NULL;
+/** Flag to indicate, whether the Omni Core log file should be reopened. */
+extern volatile bool fReopenOmniCoreLog;
 
 /**
  * Opens debug log file.
@@ -117,8 +119,8 @@ int LogFilePrint(const std::string& str)
         boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
 
         // Reopen the log file, if requested
-        if (fReopenDebugLog) {
-            fReopenDebugLog = false;
+        if (fReopenOmniCoreLog) {
+            fReopenOmniCoreLog = false;
             boost::filesystem::path pathDebug = GetDataDir() / LOG_FILENAME;
             if (freopen(pathDebug.string().c_str(), "a", fileout) != NULL) {
                 setbuf(fileout, NULL); // Unbuffered

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -104,6 +104,8 @@ string strMiscWarning;
 bool fLogTimestamps = false;
 bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
+/** Flag to indicate, whether the Omni Core log file should be reopened. */
+volatile bool fReopenOmniCoreLog = false;
 
 /** Init OpenSSL library multithreading support */
 static CCriticalSection** ppmutexOpenSSL;

--- a/src/util.h
+++ b/src/util.h
@@ -37,6 +37,8 @@ extern std::string strMiscWarning;
 extern bool fLogTimestamps;
 extern bool fLogIPs;
 extern volatile bool fReopenDebugLog;
+/** Flag to indicate, whether the Omni Core log file should be reopened. */
+extern volatile bool fReopenOmniCoreLog;
 
 void SetupEnvironment();
 


### PR DESCRIPTION
When a SIGHUP is received, a bool is set true to force reopening of the log file.  After reopening the log this bool is flipped back to false.

Reusing the same bool between debug.log and mastercore.log means whichever is written to first after a SIGHUP will be reopened and the bool flipped back to false, meaning the other log will miss the request and not be reopened.

Rebased, and originally published via [1ac1b3f7483f1218836a6f4a0eb184fb2d090cc4](https://github.com/zathras-crypto/mastercore/commit/1ac1b3f7483f1218836a6f4a0eb184fb2d090cc4).