### PR TITLE
Improve handling of transaction index

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1131,7 +1131,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         if (fRet) {
             // add txindex=1 to config file in GetConfigFile()
             boost::filesystem::path configPathInfo = GetConfigFile();
-            FILE *fp = fopen(configPathInfo.string().c_str(), "a");
+            FILE *fp = fopen(configPathInfo.string().c_str(), "at");
             if (!fp) {
                 std::string failMsg = _("Unable to update configuration file at");
                 failMsg += ":\n" + GetConfigFile().string() + "\n\n";
@@ -1139,7 +1139,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                 failMsg += _("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown.");
                 return InitError(failMsg);
             }
-            fprintf(fp, "\ntxindex=1\n");
+            fprintf(fp, "\ntxindex=1");
             fflush(fp);
             fclose(fp);
             return InitError(_("Your configuration file has been updated.\n\n"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1124,8 +1124,8 @@ bool AppInit2(boost::thread_group& threadGroup)
                             "transaction indexing, please use the \"-txindex\" option as "
                             "command line argument or add \"txindex=1\" to your client "
                             "configuration file within your data directory.\n\n"
-                            "Configuration file: "); // allow translation of main text body while still allowing differing config file string
-        msg += GetConfigFile().string() + "\n\n";
+                            "Configuration file"); // allow translation of main text body while still allowing differing config file string
+        msg += ": " + GetConfigFile().string() + "\n\n";
         msg += _("Would you like Omni Core to attempt to update your configuration file accordingly?");
         bool fRet = uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
         if (fRet) {
@@ -1133,19 +1133,19 @@ bool AppInit2(boost::thread_group& threadGroup)
             boost::filesystem::path configPathInfo = GetConfigFile();
             FILE *fp = fopen(configPathInfo.string().c_str(), "a");
             if (!fp) {
-                std::string failMsg = _("Unable to update configuration file at:\n");
-                failMsg += GetConfigFile().string() + "\n\n";
+                std::string failMsg = _("Unable to update configuration file at\n");
+                failMsg += ": " + GetConfigFile().string() + "\n\n";
                 failMsg += _("The file may be write protected or you may not have the required permissions to edit it.\n");
-                failMsg += _("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown");
+                failMsg += _("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown.");
                 return InitError(failMsg);
             }
             fprintf(fp, "\ntxindex=1\n");
             fflush(fp);
             fclose(fp);
             return InitError(_("Your configuration file has been updated.\n\n"
-                               "Omni Core will now shutdown - please restart the client for your new configuration to take effect"));
+                               "Omni Core will now shutdown - please restart the client for your new configuration to take effect."));
         } else {
-            return InitError(_("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown"));
+            return InitError(_("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown."));
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1118,13 +1118,14 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
 
     if (!fTxIndex) {
-        return InitError(_(
-                "Disabled transaction index detected.\n\n"
-                "Omni Core requires an enabled transaction index. To enable "
-                "transaction indexing, please use the \"-txindex\" option as "
-                "command line argument or add \"txindex=1\" to your client "
-                "configuration file."
-            ));
+        std::string msg = _("Disabled transaction index detected.\n\n"
+                            "Omni Core requires an enabled transaction index. To enable "
+                            "transaction indexing, please use the \"-txindex\" option as "
+                            "command line argument or add \"txindex=1\" to your client "
+                            "configuration file within your data directory.\n\n"
+                            "Configuration file: "); // allow translation of main text body while still allowing differing config file string
+        msg += GetConfigFile().string();
+        return InitError(msg);
     }
 
     uiInterface.InitMessage(_("Parsing Omni Layer transactions..."));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1126,7 +1126,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                             "configuration file within your data directory.\n\n"
                             "Configuration file: "); // allow translation of main text body while still allowing differing config file string
         msg += GetConfigFile().string() + "\n\n";
-        msg += _("Would you like OmniCore to attempt to update your configuration file accordingly?");
+        msg += _("Would you like Omni Core to attempt to update your configuration file accordingly?");
         bool fRet = uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
         if (fRet) {
             // add txindex=1 to config file in GetConfigFile()
@@ -1136,16 +1136,16 @@ bool AppInit2(boost::thread_group& threadGroup)
                 std::string failMsg = _("Unable to update configuration file at:\n");
                 failMsg += GetConfigFile().string() + "\n\n";
                 failMsg += _("The file may be write protected or you may not have the required permissions to edit it.\n");
-                failMsg += _("Please add txindex=1 to your configuration file manually.\n\nOmniCore will now shutdown");
+                failMsg += _("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown");
                 return InitError(failMsg);
             }
             fprintf(fp, "\ntxindex=1\n");
             fflush(fp);
             fclose(fp);
             return InitError(_("Your configuration file has been updated.\n\n"
-                               "OmniCore will now shutdown - please restart the client for your new configuration to take effect"));
+                               "Omni Core will now shutdown - please restart the client for your new configuration to take effect"));
         } else {
-            return InitError(_("Please add txindex=1 to your configuration file manually.\n\nOmniCore will now shutdown"));
+            return InitError(_("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown"));
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1133,8 +1133,8 @@ bool AppInit2(boost::thread_group& threadGroup)
             boost::filesystem::path configPathInfo = GetConfigFile();
             FILE *fp = fopen(configPathInfo.string().c_str(), "a");
             if (!fp) {
-                std::string failMsg = _("Unable to update configuration file at\n");
-                failMsg += ": " + GetConfigFile().string() + "\n\n";
+                std::string failMsg = _("Unable to update configuration file at");
+                failMsg += ":\n" + GetConfigFile().string() + "\n\n";
                 failMsg += _("The file may be write protected or you may not have the required permissions to edit it.\n");
                 failMsg += _("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown.");
                 return InitError(failMsg);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1118,14 +1118,35 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
 
     if (!fTxIndex) {
+        // ask the user if they would like us to modify their config file for them
         std::string msg = _("Disabled transaction index detected.\n\n"
                             "Omni Core requires an enabled transaction index. To enable "
                             "transaction indexing, please use the \"-txindex\" option as "
                             "command line argument or add \"txindex=1\" to your client "
                             "configuration file within your data directory.\n\n"
                             "Configuration file: "); // allow translation of main text body while still allowing differing config file string
-        msg += GetConfigFile().string();
-        return InitError(msg);
+        msg += GetConfigFile().string() + "\n\n";
+        msg += _("Would you like OmniCore to attempt to update your configuration file accordingly?");
+        bool fRet = uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
+        if (fRet) {
+            // add txindex=1 to config file in GetConfigFile()
+            boost::filesystem::path configPathInfo = GetConfigFile();
+            FILE *fp = fopen(configPathInfo.string().c_str(), "a");
+            if (!fp) {
+                std::string failMsg = _("Unable to update configuration file at:\n");
+                failMsg += GetConfigFile().string() + "\n\n";
+                failMsg += _("The file may be write protected or you may not have the required permissions to edit it.\n");
+                failMsg += _("Please add txindex=1 to your configuration file manually.\n\nOmniCore will now shutdown");
+                return InitError(failMsg);
+            }
+            fprintf(fp, "\ntxindex=1\n");
+            fflush(fp);
+            fclose(fp);
+            return InitError(_("Your configuration file has been updated.\n\n"
+                               "OmniCore will now shutdown - please restart the client for your new configuration to take effect"));
+        } else {
+            return InitError(_("Please add txindex=1 to your configuration file manually.\n\nOmniCore will now shutdown"));
+        }
     }
 
     uiInterface.InitMessage(_("Parsing Omni Layer transactions..."));


### PR DESCRIPTION
Various feedback has been received around support for the txindex flag and our recent change to default it back to match Bitcoin Core.

I've defended this decision as I believe it is the right thing to do, but it has caused some users problems whom were relying on our hardcoded txindex value.

Two issues present on this (that I've seen):
1) Users who struggle to update a configuration file manually
2) Users who do not know where their configuration file is

Number 2) actually surprised me, but I've assisted a couple of users who for example have run Bitcoin Core before and chosen a custom datadir, subsequently uninstalled it and then when using OmniCore cannot find where the config file is located.

This small PR serves to address those two points by providing the configuration file location directly within the txindex disabled error message, and by offering to update it automatically on behalf of the user.

Feedback welcomed :)

Thanks
Z

![image](https://cloud.githubusercontent.com/assets/5633351/7486464/1386a7f0-f3e9-11e4-8aae-65ab0bba3967.png)
