### PR TITLE
Refine and update and meta DEx core logic

### DIFF
--- a/src/mastercore_mdex.h
+++ b/src/mastercore_mdex.h
@@ -105,7 +105,7 @@ public:
     unsigned int getDesProperty() const { return desired_property; }
 
     int64_t getAmountForSale() const { return amount_forsale; }
-    int64_t getAmountDesired() const;
+    int64_t getAmountDesired() const { return amount_desired; }
     int64_t getAmountRemaining() const { return amount_remaining; }
 
     void setAmountRemaining(int64_t ar, const std::string& label = "");

--- a/src/mastercore_mdex.h
+++ b/src/mastercore_mdex.h
@@ -1,23 +1,85 @@
 #ifndef MASTERCORE_MDEX_H
 #define MASTERCORE_MDEX_H
 
+#include "tinyformat.h"
 #include "uint256.h"
 
+#include <boost/lexical_cast.hpp>
 #include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/rational.hpp>
 
 #include <openssl/sha.h>
 
 #include <stdint.h>
 
 #include <fstream>
+#include <limits>
 #include <map>
 #include <set>
 #include <string>
 
-typedef boost::multiprecision::cpp_dec_float_100 XDOUBLE;
+using boost::multiprecision::int128_t;
+
+typedef boost::multiprecision::cpp_dec_float_100 dec_float;
+typedef boost::rational<int128_t> rational_t;
 
 #define DISPLAY_PRECISION_LEN  50
-#define INTERNAL_PRECISION_LEN 50
+
+inline bool rangeInt64(const int128_t& value)
+{
+    return (std::numeric_limits<int64_t>::min() <= value && value <= std::numeric_limits<int64_t>::max());
+}
+
+inline bool rangeInt64(const rational_t& value)
+{
+    return (rangeInt64(value.numerator()) && rangeInt64(value.denominator()));
+}
+
+inline std::string xToString(const dec_float& value)
+{
+    return value.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed);
+}
+
+inline std::string xToString(const int128_t& value)
+{
+    return strprintf("%s", boost::lexical_cast<std::string>(value));
+}
+
+inline std::string xToString(const rational_t& value)
+{
+    if (rangeInt64(value)) {
+        int64_t num = value.numerator().convert_to<int64_t>();
+        int64_t denom = value.denominator().convert_to<int64_t>();
+        dec_float x = dec_float(num) / dec_float(denom);
+        return xToString(x);
+    } else {
+        return strprintf("%s / %s", xToString(value.numerator()), xToString(value.denominator()));
+    }
+}
+
+inline int128_t xToInt128(const rational_t& value, bool fRoundUp)
+{
+    // for integer rounding up: ceil(num / denom) => 1 + (num - 1) / denom
+    int128_t result(0);
+
+    if (!fRoundUp) {
+        result = value.numerator() / value.denominator();
+    } else {
+        result = int128_t(1) + (value.numerator() - int128_t(1)) / value.denominator();
+    }
+
+    return result;
+}
+
+inline int64_t xToInt64(const rational_t& value, bool fRoundUp)
+{
+    int128_t result = xToInt128(value, fRoundUp);
+
+    assert(rangeInt64(result));
+
+    return result.convert_to<int64_t>();
+}
 
 /** A trade on the distributed exchange.
  */
@@ -77,8 +139,8 @@ public:
 
     std::string ToString() const;
 
-    XDOUBLE unitPrice() const;
-    XDOUBLE inversePrice() const;
+    rational_t unitPrice() const;
+    rational_t inversePrice() const;
 
     void saveOffer(std::ofstream& file, SHA256_CTX* shaCtx) const;
 };
@@ -94,7 +156,7 @@ struct MetaDEx_compare
 //! Set of objects sorted by block+idx
 typedef std::set<CMPMetaDEx, MetaDEx_compare> md_Set; 
 //! Map of prices; there is a set of sorted objects for each price
-typedef std::map<XDOUBLE, md_Set> md_PricesMap;
+typedef std::map<rational_t, md_Set> md_PricesMap;
 //! Map of properties; there is a map of prices for each property
 typedef std::map<uint32_t, md_PricesMap> md_PropertiesMap;
 
@@ -102,7 +164,7 @@ extern md_PropertiesMap metadex;
 
 // TODO: explore a property-pair, instead of a single property as map's key........
 md_PricesMap* get_Prices(uint32_t prop);
-md_Set* get_Indexes(md_PricesMap* p, XDOUBLE price);
+md_Set* get_Indexes(md_PricesMap* p, rational_t price);
 // ---------------
 
 int MetaDEx_ADD(const std::string& sender_addr, uint32_t, int64_t, int block, uint32_t property_desired, int64_t amount_desired, const uint256& txid, unsigned int idx);

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -1333,7 +1333,7 @@ int populateRPCTransactionObject(const uint256& txid, Object *txobj, std::string
                                      mdex_amountRemaining = temp_metadexoffer.getAmountRemaining();
                                      mdex_action = temp_metadexoffer.getAction();
                                      // unit price display adjustment based on divisibility and always showing prices in MSC/TMSC
-                                     XDOUBLE tempUnitPrice = 0;
+                                     rational_t tempUnitPrice(int128_t(0));
                                      if ((propertyId == OMNI_PROPERTY_MSC) || (propertyId == OMNI_PROPERTY_TMSC)) {
                                          tempUnitPrice = temp_metadexoffer.inversePrice();
                                          if (!mdex_propertyWanted_Div) tempUnitPrice = tempUnitPrice/COIN;
@@ -1341,7 +1341,7 @@ int populateRPCTransactionObject(const uint256& txid, Object *txobj, std::string
                                          tempUnitPrice = temp_metadexoffer.unitPrice();
                                          if (!mdex_propertyId_Div) tempUnitPrice = tempUnitPrice/COIN;
                                      }
-                                     mdex_unitPriceStr = tempUnitPrice.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed);
+                                     mdex_unitPriceStr = xToString(tempUnitPrice);
                                      if(1 == mdex_action) mdex_actionStr = "new sell";
                                      if(2 == mdex_action) mdex_actionStr = "cancel price";
                                      if(3 == mdex_action) mdex_actionStr = "cancel pair";


### PR DESCRIPTION
Floating point numbers are now only used for the price to string conversion, which resolves #23. Very strict assertions were added, to confirm correct order execution, and the core logic was updated, and is now closer to the specification. This PR also resolves #21, and besides some potential cleanup or optimizations, the core logic seems solid and finalized.

Especially `xToString()`, `xToInt64()` might be moved somewhere else, such as `mastercore_convert` or `mastercore_parse_string`, but given the close context of the meta DEx, doing so seemed too early.