### PR TITLE
Hide messy build messages of Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,5 +106,5 @@ script:
     - if [ "$RUN_SPOCK_TESTS" = "true" ]; then cd qa/omnicore-rpc-tests; fi
     - if [ "$RUN_SPOCK_TESTS" = "true" ]; then $OUTDIR/bin/bitcoin-cli -datadir="$DATADIR" -rpcuser=bitcoinrpc -rpcpassword=pass -regtest -rpcwait getinfo; fi
     - if [ "$RUN_SPOCK_TESTS" = "true" ]; then $OUTDIR/bin/bitcoin-cli -datadir="$DATADIR" -rpcuser=bitcoinrpc -rpcpassword=pass -regtest -rpcwait getinfo_MP; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then ./gradlew :omnij-rpc:regTest; fi
+    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then ./gradlew --console plain :omnij-rpc:regTest; fi
     - if [ "$RUN_SPOCK_TESTS" = "true" ]; then $OUTDIR/bin/bitcoin-cli -datadir="$DATADIR" -rpcuser=bitcoinrpc -rpcpassword=pass -regtest -rpcwait stop; fi


### PR DESCRIPTION
This resolves the issue outlined in https://github.com/OmniLayer/OmniJ/issues/79.

The log of Travis CI can't handle "rich" output of Gradle, which results in unclean output such as:

- https://travis-ci.org/OmniLayer/omnicore/jobs/62741266#L3970-L4096