### PR TITLE
METADEX: Remove duplicate function for determining if metadex trade open

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -398,27 +398,6 @@ bool mastercore::isMainEcosystemProperty(unsigned int property)
   return false;
 }
 
-bool mastercore::isMetaDExOfferActive(const uint256 txid, unsigned int propertyId)
-{
-  for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it)
-  {
-      if (my_it->first == propertyId) //at bear minimum only go deeper if it's the right property id
-      {
-           md_PricesMap & prices = my_it->second;
-           for (md_PricesMap::iterator it = prices.begin(); it != prices.end(); ++it)
-           {
-                md_Set & indexes = (it->second);
-                for (md_Set::iterator it = indexes.begin(); it != indexes.end(); ++it)
-                {
-                     CMPMetaDEx obj = *it;
-                     if( obj.getHash().GetHex() == txid.GetHex() ) return true;
-                }
-           }
-      }
-  }
-  return false;
-}
-
 std::string mastercore::getMasterCoreAlertString()
 {
     return global_alert_message;

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -458,7 +458,6 @@ uint32_t GetNextPropertyId(bool maineco);
 
 CMPTally *getTally(const string & address);
 
-bool isMetaDExOfferActive(const uint256 txid, unsigned int propertyId);
 int64_t getTotalTokens(unsigned int propertyId, int64_t *n_owners_total = NULL);
 bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime);
 int set_wallet_totals();

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1962,7 +1962,7 @@ Value gettrade_MP(const Array& params, bool fHelp)
 
     // everything seems ok, now add status and add array of matches to the object
     // work out status
-    bool orderOpen = isMetaDExOfferActive(hash, propertyId);
+    bool orderOpen = MetaDEx_isOpen(hash, propertyId);
     bool partialFilled = false;
     bool filled = false;
     string statusText;

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -567,7 +567,7 @@ void TradeHistoryDialog::showDetails()
             }
 
             // obtain the status of the trade
-            bool orderOpen = isMetaDExOfferActive(txid, propertyId);
+            bool orderOpen = MetaDEx_isOpen(txid, propertyId);
             bool partialFilled = false, filled = false;
             string statusText = "unknown";
             if (totalSold>0) partialFilled = true;


### PR DESCRIPTION
New function MetaDEx_isOpen was mistakenly a duplicate of already existing function isMetaDExOfferActive.
New function supports searches without propertyId when needed and exists in the correct location (mdex.cpp/h) so new function was kept, old was removed.

Very minor change so merging without explicit ack - please let me know if any objections.