### PR TITLE
Seperate logic and parsing for each transaction type

### DIFF
--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -17,7 +17,6 @@
 // Default log files
 const std::string LOG_FILENAME    = "omnicore.log";
 const std::string INFO_FILENAME   = "mastercore_crowdsales.log";
-const std::string OWNERS_FILENAME = "mastercore_owners.log";
 
 // Options
 static const long LOG_BUFFERSIZE  =  8000000; //  8 MB

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -48,6 +48,8 @@ bool msc_debug_metadex1           = 0;
 bool msc_debug_metadex2           = 0;
 //! Print orderbook before and after each trade
 bool msc_debug_metadex3           = 0;
+//! Print transaction fields, when interpreting packets
+bool msc_debug_packets            = 1;
 
 /**
  * LogPrintf() has been broken a couple of times now
@@ -239,6 +241,7 @@ void InitDebugLogLevels()
         if (*it == "metadex1") msc_debug_metadex1 = true;
         if (*it == "metadex2") msc_debug_metadex2 = true;
         if (*it == "metadex3") msc_debug_metadex3 = true;
+        if (*it == "packets") msc_debug_packets = true;
         if (*it == "none" || *it == "all") {
             bool allDebugState = false;
             if (*it == "all") allDebugState = true;
@@ -265,6 +268,7 @@ void InitDebugLogLevels()
             msc_debug_metadex1 = allDebugState;
             msc_debug_metadex2 = allDebugState;
             msc_debug_metadex3 = allDebugState;
+            msc_debug_packets =  allDebugState;
         }
     }
 }

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -46,6 +46,7 @@ extern bool msc_debug_pending;
 extern bool msc_debug_metadex1;
 extern bool msc_debug_metadex2;
 extern bool msc_debug_metadex3;
+extern bool msc_debug_packets;
 
 /* When we switch to C++11, this can be switched to variadic templates instead
  * of this macro-based construction (see tinyformat.h).

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -20,7 +20,6 @@ void ShrinkDebugLog();
 
 // Log files
 extern const std::string INFO_FILENAME;
-extern const std::string OWNERS_FILENAME;
 
 // Debug flags
 extern bool msc_debug_parser_data;

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -398,10 +398,6 @@ int mastercore::MetaDEx_ADD(const std::string& sender_addr, uint32_t prop, int64
 {
     int rc = METADEX_ERROR -1;
 
-    // Ensure that one side of the trade is MSC/TMSC (phase 1 check)
-    if ((prop != OMNI_PROPERTY_MSC) && (property_desired != OMNI_PROPERTY_MSC) &&
-        (prop != OMNI_PROPERTY_TMSC) && (property_desired != OMNI_PROPERTY_TMSC)) return METADEX_ERROR -800;
-
     // Create a MetaDEx object from paremeters
     CMPMetaDEx new_mdex(sender_addr, block, prop, amount, property_desired, amount_desired, txid, idx, CMPTransaction::ADD);
     if (msc_debug_metadex1) PrintToLog("%s(); buyer obj: %s\n", __FUNCTION__, new_mdex.ToString());

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3623,12 +3623,9 @@ const CBitcoinAddress ExodusAddress()
  // optional: provide the pointer to the CMPOffer object, it will get filled in
  // verify that it does via if (MSC_TYPE_TRADE_OFFER == mp_obj.getType())
  //
-
 int CMPTransaction::interpretPacket(CMPOffer* obj_o, CMPMetaDEx* mdex_o)
 {
-    int rc = PKT_ERROR;
-
-    if (!interpret_TransactionType()) {
+    if (!interpret_Transaction()) {
         return -98765;
     }
 
@@ -3642,119 +3639,58 @@ int CMPTransaction::interpretPacket(CMPOffer* obj_o, CMPMetaDEx* mdex_o)
 
     switch (type) {
         case MSC_TYPE_SIMPLE_SEND:
-            if (!interpret_SimpleSend()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_SimpleSend();
-            break;
+            return logicMath_SimpleSend();
 
         case MSC_TYPE_SEND_TO_OWNERS:
-            if (!interpret_SendToOwners()) {
-                return PKT_ERROR;
+        {
+            // TODO: remove file stuff
+            boost::filesystem::path pathOwners = GetDataDir() / OWNERS_FILENAME;
+            FILE *fp = fopen(pathOwners.string().c_str(), "a");
+            if (fp) {
+                printInfo(fp);
+            } else {
+                PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
             }
-            {   // TODO: remove file stuff
-                boost::filesystem::path pathOwners = GetDataDir() / OWNERS_FILENAME;
-                FILE *fp = fopen(pathOwners.string().c_str(), "a");
-                if (fp) {
-                    printInfo(fp);
-                } else {
-                    PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
-                }
-                rc = logicMath_SendToOwners(fp);
-                if (fp) fclose(fp);
-            }
-            break;
+            int rc = logicMath_SendToOwners(fp);
+            if (fp) fclose(fp);
+            return rc;
+        }
 
         case MSC_TYPE_TRADE_OFFER:
-            if (!interpret_TradeOffer()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_TradeOffer(obj_o);
-            break;
+            return logicMath_TradeOffer(obj_o);
 
         case MSC_TYPE_METADEX:
-            if (!interpret_MetaDEx()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_MetaDEx(mdex_o);
-            break;
+            return logicMath_MetaDEx(mdex_o);
 
         case MSC_TYPE_ACCEPT_OFFER_BTC:
-            if (!interpret_AcceptOfferBTC()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_AcceptOffer_BTC();
-            break;
+            return logicMath_AcceptOffer_BTC();
 
         case MSC_TYPE_CREATE_PROPERTY_FIXED:
-            if (!interpret_CreatePropertyFixed()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_CreatePropertyFixed();
-            break;
+            return logicMath_CreatePropertyFixed();
 
         case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
-            if (!interpret_CreatePropertyVariable()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_CreatePropertyVariable();
-            break;
+            return logicMath_CreatePropertyVariable();
 
         case MSC_TYPE_CLOSE_CROWDSALE:
-            if (!interpret_CloseCrowdsale()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_CloseCrowdsale();
-            break;
+            return logicMath_CloseCrowdsale();
 
         case MSC_TYPE_CREATE_PROPERTY_MANUAL:
-            if (!interpret_CreatePropertyMananged()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_CreatePropertyMananged();
-            break;
+            return logicMath_CreatePropertyMananged();
 
         case MSC_TYPE_GRANT_PROPERTY_TOKENS:
-            if (!interpret_GrantTokens()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_GrantTokens();
-            break;
+            return logicMath_GrantTokens();
 
         case MSC_TYPE_REVOKE_PROPERTY_TOKENS:
-            if (!interpret_RevokeTokens()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_RevokeTokens();
-            break;
+            return logicMath_RevokeTokens();
 
         case MSC_TYPE_CHANGE_ISSUER_ADDRESS:
-            if (!interpret_ChangeIssuer()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_ChangeIssuer();
-            break;
+            return logicMath_ChangeIssuer();
 
         case OMNICORE_MESSAGE_TYPE_ALERT:
-            if (!interpret_Alert()) {
-                return PKT_ERROR;
-            }
-            rc = logicMath_Alert();
-            break;
-
-        case MSC_TYPE_SAVINGS_MARK:
-            rc = logicMath_SavingsMark();
-            break;
-
-        case MSC_TYPE_SAVINGS_COMPROMISED:
-            rc = logicMath_SavingsCompromised();
-            break;
-
-        default:
-            rc = (PKT_ERROR -100);
+            return logicMath_Alert();
     }
 
-    return rc;
+    return (PKT_ERROR -100);
 }
 
 int CMPTransaction::logicMath_SimpleSend()

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3769,6 +3769,11 @@ int step_rc;
 
 int CMPTransaction::logicMath_SimpleSend()
 {
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -801);  // out of range
+    }
+    // ------------------------------------------
+
     int rc = PKT_ERROR_SEND -1000;
 
     if (!isTransactionTypeAllowed(block, property, type, version)) {
@@ -3851,7 +3856,12 @@ int CMPTransaction::logicMath_SimpleSend()
 
 int CMPTransaction::logicMath_SendToOwners(FILE *fhandle)
 {
-int rc = PKT_ERROR_STO -1000;
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -801);  // out of range
+    }
+    // ------------------------------------------
+
+    int rc = PKT_ERROR_STO -1000;
 
       if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_STO -888);
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -899,7 +899,7 @@ static bool isAllowedOutputType(int whichType, int nBlock)
 // RETURNS: 0 if parsed a MP TX
 // RETURNS: < 0 if a non-MP-TX or invalid
 // RETURNS: >0 if 1 or more payments have been made
-static int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigned int idx, CMPTransaction *mp_tx, unsigned int nTime)
+static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, unsigned int idx, CMPTransaction& mp_tx, unsigned int nTime)
 {
   string strSender;
   vector<string>script_data;
@@ -920,9 +920,7 @@ static int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, 
   uint64_t outAll = 0;
   uint64_t txFee = 0;
   int omniClass = 0;
-  if (NULL != mp_tx) {
-      mp_tx->Set(wtx.GetHash(), nBlock, idx, nTime);
-  }
+  mp_tx.Set(wtx.GetHash(), nBlock, idx, nTime);
 
 
   // ### EXODUS MARKER IDENTIFICATION ### - quickly go through the outputs & ensure there is a marker (exodus and/or omni bytes)
@@ -1272,18 +1270,17 @@ static int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, 
 
   // ### SET MP TX INFO ###
   if (msc_debug_verbose) PrintToLog("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt, false));
-  if (NULL != mp_tx) {
-    mp_tx->Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, omniClass-1, (inAll-outAll));
-  }
+  mp_tx.Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, omniClass-1, (inAll-outAll));
+
   return 0;
 }
 
 /**
  * Provides access to parseTransaction in read-only mode.
  */
-int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction* pmptx, unsigned int nTime)
+int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction& mptx, unsigned int nTime)
 {
-    return parseTransaction(true, tx, nBlock, idx, pmptx, nTime);
+    return parseTransaction(true, tx, nBlock, idx, mptx, nTime);
 }
 
 /**
@@ -2334,7 +2331,7 @@ int interp_ret = -555555, pop_ret;
 
   if (nBlock < nWaterlineBlock) return -1;  // we do not care about parsing blocks prior to our waterline (empty blockchain defense)
 
-  pop_ret = parseTransaction(false, tx, nBlock, idx, &mp_obj, pBlockIndex->GetBlockTime() );
+  pop_ret = parseTransaction(false, tx, nBlock, idx, mp_obj, pBlockIndex->GetBlockTime() );
   if (0 == pop_ret)
   {
   // true MP transaction, validity (such as insufficient funds, or offer not found) is determined elsewhere
@@ -2615,7 +2612,7 @@ int CMPTxList::setLastAlert(int blockHeight)
         else // note reparsing here is unavoidable because we've only loaded a txid and have no other alert info stored
         {
             CMPTransaction mp_obj;
-            int parseRC = ParseTransaction(wtx, blockHeight, 0, &mp_obj);
+            int parseRC = ParseTransaction(wtx, blockHeight, 0, mp_obj);
             string new_global_alert_message;
             if (0 <= parseRC)
             {

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3640,19 +3640,7 @@ int CMPTransaction::interpretPacket(CMPOffer* obj_o, CMPMetaDEx* mdex_o)
             return logicMath_SimpleSend();
 
         case MSC_TYPE_SEND_TO_OWNERS:
-        {
-            // TODO: remove file stuff
-            boost::filesystem::path pathOwners = GetDataDir() / OWNERS_FILENAME;
-            FILE *fp = fopen(pathOwners.string().c_str(), "a");
-            if (fp) {
-                printInfo(fp);
-            } else {
-                PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
-            }
-            int rc = logicMath_SendToOwners(fp);
-            if (fp) fclose(fp);
-            return rc;
-        }
+            return logicMath_SendToOwners();
 
         case MSC_TYPE_TRADE_OFFER:
             return logicMath_TradeOffer(obj_o);
@@ -3782,7 +3770,7 @@ int CMPTransaction::logicMath_SimpleSend()
     return 0;
 }
 
-int CMPTransaction::logicMath_SendToOwners(FILE *fhandle)
+int CMPTransaction::logicMath_SendToOwners()
 {
     if (MAX_INT_8_BYTES < nValue) {
         return (PKT_ERROR -801);  // out of range
@@ -3899,9 +3887,6 @@ int CMPTransaction::logicMath_SendToOwners(FILE *fhandle)
           if (msc_debug_sto)
             PrintToLog("%14lu = %s, temp= %38s, should_get= %19lu, will_really_get= %14lu, sent_so_far= %14lu\n",
             owns, address, temp.str(), should_receive, will_really_receive, sent_so_far);
-
-          // record the detailed info as needed
-          if (fhandle) fprintf(fhandle, "%s = %s\n", address.c_str(), FormatMP(property, will_really_receive).c_str());
         }
       } // owners loop
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3640,11 +3640,55 @@ std::string new_global_alert_message;
       rc = logicMath_SimpleSend();
       break;
 
+    case MSC_TYPE_SEND_TO_OWNERS:
+    if (disable_Divs) break;
+    else
+    {
+      step_rc = step2_Value();
+      if (0>step_rc) return step_rc;
+
+      boost::filesystem::path pathOwners = GetDataDir() / OWNERS_FILENAME;
+      FILE *fp = fopen(pathOwners.string().c_str(), "a");
+
+      if (fp)
+      {
+        printInfo(fp);
+      }
+      else
+      {
+        PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
+      }
+
+      rc = logicMath_SendToOwners(fp);
+
+      if (fp) fclose(fp);
+    }
+    break;
+
     case MSC_TYPE_TRADE_OFFER:
       step_rc = step2_Value();
       if (0>step_rc) return step_rc;
 
       rc = logicMath_TradeOffer(obj_o);
+      break;
+
+    case MSC_TYPE_METADEX:
+#ifdef  MY_HACK
+//      if (304500 > block) return -31337;
+//      if (305100 > block) return -31337;
+
+//      if (304930 > block) return -31337;
+//      if (307057 > block) return -31337;
+
+//      if (307234 > block) return -31337;
+//      if (307607 > block) return -31337;
+
+      if (307057 > block) return -31337;
+#endif
+      step_rc = step2_Value();
+      if (0>step_rc) return step_rc;
+
+      rc = logicMath_MetaDEx(mdex_o);
       break;
 
     case MSC_TYPE_ACCEPT_OFFER_BTC:
@@ -3825,64 +3869,12 @@ std::string new_global_alert_message;
       rc = logicMath_RevokeTokens();
       break;
 
-    case MSC_TYPE_SEND_TO_OWNERS:
-    if (disable_Divs) break;
-    else
-    {
-      step_rc = step2_Value();
-      if (0>step_rc) return step_rc;
-
-      boost::filesystem::path pathOwners = GetDataDir() / OWNERS_FILENAME;
-      FILE *fp = fopen(pathOwners.string().c_str(), "a");
-
-      if (fp)
-      {
-        printInfo(fp);
-      }
-      else
-      {
-        PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
-      }
-
-      rc = logicMath_SendToOwners(fp);
-
-      if (fp) fclose(fp);
-    }
-    break;
-
-    case MSC_TYPE_METADEX:
-#ifdef  MY_HACK
-//      if (304500 > block) return -31337;
-//      if (305100 > block) return -31337;
-
-//      if (304930 > block) return -31337;
-//      if (307057 > block) return -31337;
-
-//      if (307234 > block) return -31337;
-//      if (307607 > block) return -31337;
-
-      if (307057 > block) return -31337;
-#endif
-      step_rc = step2_Value();
-      if (0>step_rc) return step_rc;
-
-      rc = logicMath_MetaDEx(mdex_o);
-      break;
-
     case MSC_TYPE_CHANGE_ISSUER_ADDRESS:
       // parse the property from the packet
       memcpy(&property, &pkt[4], 4);
       swapByteOrder32(property);
 
       rc = logicMath_ChangeIssuer();
-      break;
-
-    case MSC_TYPE_SAVINGS_MARK:
-      rc = logicMath_SavingsMark();
-      break;
-
-    case MSC_TYPE_SAVINGS_COMPROMISED:
-      rc = logicMath_SavingsCompromised();
       break;
 
     case OMNICORE_MESSAGE_TYPE_ALERT:
@@ -3893,6 +3885,14 @@ std::string new_global_alert_message;
           if (rc == 0) global_alert_message = new_global_alert_message;
           // end of block handler will expire any old alerts
       }
+      break;
+
+    case MSC_TYPE_SAVINGS_MARK:
+      rc = logicMath_SavingsMark();
+      break;
+
+    case MSC_TYPE_SAVINGS_COMPROMISED:
+      rc = logicMath_SavingsCompromised();
       break;
 
     default:

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3623,172 +3623,138 @@ const CBitcoinAddress ExodusAddress()
  // optional: provide the pointer to the CMPOffer object, it will get filled in
  // verify that it does via if (MSC_TYPE_TRADE_OFFER == mp_obj.getType())
  //
-int CMPTransaction::interpretPacket(CMPOffer *obj_o, CMPMetaDEx *mdex_o)
+
+int CMPTransaction::interpretPacket(CMPOffer* obj_o, CMPMetaDEx* mdex_o)
 {
-int rc = PKT_ERROR;
+    int rc = PKT_ERROR;
 
-  if (!interpret_TransactionType()) return -98765;
-
-  if ((obj_o) && (MSC_TYPE_TRADE_OFFER != type)) return -777; // can't fill in the Offer object !
-  if ((mdex_o) && (MSC_TYPE_METADEX != type)) return -778; // can't fill in the MetaDEx object !
-
-  // further processing for complex types
-  // TODO: version may play a role here !
-  switch(type)
-  {
-    case MSC_TYPE_SIMPLE_SEND:
-    {
-      if (!interpret_SimpleSend()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_SimpleSend();
-      break;
+    if (!interpret_TransactionType()) {
+        return -98765;
     }
 
-    case MSC_TYPE_SEND_TO_OWNERS:
-    {
-      if (!interpret_SendToOwners()) {
-        return PKT_ERROR;
-      }
-
-      boost::filesystem::path pathOwners = GetDataDir() / OWNERS_FILENAME;
-      FILE *fp = fopen(pathOwners.string().c_str(), "a");
-      if (fp) {
-        printInfo(fp);
-      } else {
-        PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
-      }
-
-      rc = logicMath_SendToOwners(fp);
-
-      if (fp) fclose(fp);
-      break;
+    if (obj_o && MSC_TYPE_TRADE_OFFER != type) {
+        return -777; // can't fill in the Offer object !
     }
 
-    case MSC_TYPE_TRADE_OFFER:
-    {
-      if (!interpret_TradeOffer()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_TradeOffer(obj_o);
-      break;
+    if (mdex_o && MSC_TYPE_METADEX != type) {
+        return -778; // can't fill in the MetaDEx object !
     }
 
-    case MSC_TYPE_METADEX:
-    {
-      if (!interpret_MetaDEx()) {
-        return PKT_ERROR;
-      }
+    switch (type) {
+        case MSC_TYPE_SIMPLE_SEND:
+            if (!interpret_SimpleSend()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_SimpleSend();
+            break;
 
-      rc = logicMath_MetaDEx(mdex_o);
-      break;
+        case MSC_TYPE_SEND_TO_OWNERS:
+            if (!interpret_SendToOwners()) {
+                return PKT_ERROR;
+            }
+            {   // TODO: remove file stuff
+                boost::filesystem::path pathOwners = GetDataDir() / OWNERS_FILENAME;
+                FILE *fp = fopen(pathOwners.string().c_str(), "a");
+                if (fp) {
+                    printInfo(fp);
+                } else {
+                    PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
+                }
+                rc = logicMath_SendToOwners(fp);
+                if (fp) fclose(fp);
+            }
+            break;
+
+        case MSC_TYPE_TRADE_OFFER:
+            if (!interpret_TradeOffer()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_TradeOffer(obj_o);
+            break;
+
+        case MSC_TYPE_METADEX:
+            if (!interpret_MetaDEx()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_MetaDEx(mdex_o);
+            break;
+
+        case MSC_TYPE_ACCEPT_OFFER_BTC:
+            if (!interpret_AcceptOfferBTC()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_AcceptOffer_BTC();
+            break;
+
+        case MSC_TYPE_CREATE_PROPERTY_FIXED:
+            if (!interpret_CreatePropertyFixed()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_CreatePropertyFixed();
+            break;
+
+        case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
+            if (!interpret_CreatePropertyVariable()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_CreatePropertyVariable();
+            break;
+
+        case MSC_TYPE_CLOSE_CROWDSALE:
+            if (!interpret_CloseCrowdsale()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_CloseCrowdsale();
+            break;
+
+        case MSC_TYPE_CREATE_PROPERTY_MANUAL:
+            if (!interpret_CreatePropertyMananged()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_CreatePropertyMananged();
+            break;
+
+        case MSC_TYPE_GRANT_PROPERTY_TOKENS:
+            if (!interpret_GrantTokens()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_GrantTokens();
+            break;
+
+        case MSC_TYPE_REVOKE_PROPERTY_TOKENS:
+            if (!interpret_RevokeTokens()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_RevokeTokens();
+            break;
+
+        case MSC_TYPE_CHANGE_ISSUER_ADDRESS:
+            if (!interpret_ChangeIssuer()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_ChangeIssuer();
+            break;
+
+        case OMNICORE_MESSAGE_TYPE_ALERT:
+            if (!interpret_Alert()) {
+                return PKT_ERROR;
+            }
+            rc = logicMath_Alert();
+            break;
+
+        case MSC_TYPE_SAVINGS_MARK:
+            rc = logicMath_SavingsMark();
+            break;
+
+        case MSC_TYPE_SAVINGS_COMPROMISED:
+            rc = logicMath_SavingsCompromised();
+            break;
+
+        default:
+            rc = (PKT_ERROR -100);
     }
 
-    case MSC_TYPE_ACCEPT_OFFER_BTC:
-    {
-      if (!interpret_AcceptOfferBTC()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_AcceptOffer_BTC();
-      break;
-    }
-
-    case MSC_TYPE_CREATE_PROPERTY_FIXED:
-    {
-      if (!interpret_CreatePropertyFixed()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_CreatePropertyFixed();
-      break;
-    }
-
-    case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
-    {
-      if (!interpret_CreatePropertyVariable()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_CreatePropertyVariable();
-      break;
-    }
-
-    case MSC_TYPE_CLOSE_CROWDSALE:
-    {
-      if (!interpret_CloseCrowdsale()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_CloseCrowdsale();
-      break;
-    }
-
-    case MSC_TYPE_CREATE_PROPERTY_MANUAL:
-    {
-      if (!interpret_CreatePropertyMananged()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_CreatePropertyMananged();
-      break;
-    }
-
-    case MSC_TYPE_GRANT_PROPERTY_TOKENS:
-    {
-      if (!interpret_GrantTokens()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_GrantTokens();
-      break;
-    }
-
-    case MSC_TYPE_REVOKE_PROPERTY_TOKENS:
-    {
-      if (!interpret_RevokeTokens()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_RevokeTokens();
-      break;
-    }
-
-    case MSC_TYPE_CHANGE_ISSUER_ADDRESS:
-    {
-      if (!interpret_ChangeIssuer()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_ChangeIssuer();
-      break;
-    }
-
-    case OMNICORE_MESSAGE_TYPE_ALERT:
-    {
-      if (!interpret_Alert()) {
-        return PKT_ERROR;
-      }
-
-      rc = logicMath_Alert();
-      break;
-    }
-
-    case MSC_TYPE_SAVINGS_MARK:
-      rc = logicMath_SavingsMark();
-      break;
-
-    case MSC_TYPE_SAVINGS_COMPROMISED:
-      rc = logicMath_SavingsCompromised();
-      break;
-
-    default:
-      return (PKT_ERROR -100);
-  }
-
-  return rc;
+    return rc;
 }
 
 int CMPTransaction::logicMath_SimpleSend()

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -87,6 +87,7 @@ using leveldb::Status;
 using std::make_pair;
 using std::map;
 using std::ofstream;
+using std::pair;
 using std::string;
 using std::vector;
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -469,6 +469,7 @@ bool isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 
 bool update_tally_map(string who, unsigned int which_currency, int64_t amount, TallyType ttype);
+void setOmniCoreAlert(const std::string& alertMessage);
 std::string getMasterCoreAlertString();
 std::string getMasterCoreAlertTextOnly();
 bool parseAlertMessage(std::string rawAlertStr, int32_t *alertType, uint64_t *expiryValue, uint32_t *typeCheck, uint32_t *verCheck, std::string *alertMessage);

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1244,7 +1244,7 @@ int populateRPCTransactionObject(const uint256& txid, Object *txobj, std::string
     if (p_txlistdb->exists(wtxid))
     {
         //transaction is in levelDB, so we can attempt to parse it
-        int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
+        int parseRC = ParseTransaction(wtx, blockHeight, 0, &mp_obj);
         if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
         {
             // do we have a non-zero RC, if so it's a payment, handle differently
@@ -1834,7 +1834,7 @@ Value getsto_MP(const Array& params, bool fHelp)
     if (!GetTransaction(hash, wtx, blockHash, true)) { return MP_TX_NOT_FOUND; }
     uint64_t propertyId = 0;
     CMPTransaction mp_obj;
-    int parseRC = parseTransaction(true, wtx, 0, 0, &mp_obj);
+    int parseRC = ParseTransaction(wtx, 0, 0, &mp_obj);
     if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for safety
     {
         if (0<=mp_obj.step1())
@@ -1914,7 +1914,7 @@ Value gettrade_MP(const Array& params, bool fHelp)
     if (!GetTransaction(hash, wtx, blockHash, true)) { return MP_TX_NOT_FOUND; }
 
     // Ensure it can be parsed OK
-    int parseRC = parseTransaction(true, wtx, 0, 0, &mp_obj);
+    int parseRC = ParseTransaction(wtx, 0, 0, &mp_obj);
     if (0 <= parseRC) { //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
         if (0<=mp_obj.step1()) {
             senderAddress = mp_obj.getSender();

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1244,7 +1244,7 @@ int populateRPCTransactionObject(const uint256& txid, Object *txobj, std::string
     if (p_txlistdb->exists(wtxid))
     {
         //transaction is in levelDB, so we can attempt to parse it
-        int parseRC = ParseTransaction(wtx, blockHeight, 0, &mp_obj);
+        int parseRC = ParseTransaction(wtx, blockHeight, 0, mp_obj);
         if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
         {
             // do we have a non-zero RC, if so it's a payment, handle differently
@@ -1834,7 +1834,7 @@ Value getsto_MP(const Array& params, bool fHelp)
     if (!GetTransaction(hash, wtx, blockHash, true)) { return MP_TX_NOT_FOUND; }
     uint64_t propertyId = 0;
     CMPTransaction mp_obj;
-    int parseRC = ParseTransaction(wtx, 0, 0, &mp_obj);
+    int parseRC = ParseTransaction(wtx, 0, 0, mp_obj);
     if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for safety
     {
         if (0<=mp_obj.step1())
@@ -1914,7 +1914,7 @@ Value gettrade_MP(const Array& params, bool fHelp)
     if (!GetTransaction(hash, wtx, blockHash, true)) { return MP_TX_NOT_FOUND; }
 
     // Ensure it can be parsed OK
-    int parseRC = ParseTransaction(wtx, 0, 0, &mp_obj);
+    int parseRC = ParseTransaction(wtx, 0, 0, mp_obj);
     if (0 <= parseRC) { //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
         if (0<=mp_obj.step1()) {
             senderAddress = mp_obj.getSender();

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -366,8 +366,6 @@ int CMPTransaction::logicMath_TradeOffer(CMPOffer *obj_o)
     // ------------------------------------------
 
 int rc = PKT_ERROR_TRADEOFFER;
-uint64_t amount_desired, min_fee;
-unsigned char blocktimelimit, subaction = 0;
 static const char * const subaction_name[] = { "empty", "new", "update", "cancel" };
 
       if ((OMNI_PROPERTY_TMSC != property) && (OMNI_PROPERTY_MSC != property))
@@ -378,14 +376,6 @@ static const char * const subaction_name[] = { "empty", "new", "update", "cancel
 
       // block height checks, for instance DEX is only available on MSC starting with block 290630
       if (!isTransactionTypeAllowed(block, property, type, version)) return -88888;
-
-      memcpy(&amount_desired, &pkt[16], 8);
-      memcpy(&blocktimelimit, &pkt[24], 1);
-      memcpy(&min_fee, &pkt[25], 8);
-      memcpy(&subaction, &pkt[33], 1);
-
-      swapByteOrder64(amount_desired);
-      swapByteOrder64(min_fee);
 
     PrintToLog("\t  amount desired: %lu.%08lu\n", amount_desired / COIN, amount_desired % COIN);
     PrintToLog("\tblock time limit: %u\n", blocktimelimit);
@@ -498,19 +488,9 @@ int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
     // ------------------------------------------
 
     int rc = PKT_ERROR_METADEX -100;
-    unsigned char action = 0;
-
-    memcpy(&desired_property, &pkt[16], 4);
-    swapByteOrder32(desired_property);
-
-    memcpy(&desired_value, &pkt[20], 8);
-    swapByteOrder64(desired_value);
 
     PrintToLog("\tdesired property: %u (%s)\n", desired_property, strMPProperty(desired_property));
     PrintToLog("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
-
-    memcpy(&action, &pkt[28], 1);
-
     PrintToLog("\t          action: %u\n", action);
 
     if (mdex_o)
@@ -728,10 +708,6 @@ int CMPTransaction::logicMath_CloseCrowdsale()
     if (it == my_crowds.end()) {
         return (PKT_ERROR_SP -605);
     }
-
-    // retrieve the property id from the incoming packet
-    memcpy(&property, &pkt[4], 4);
-    swapByteOrder32(property);
 
     if (msc_debug_sp) PrintToLog("%s() trying to ERASE CROWDSALE for propid= %u=%X\n", __FUNCTION__, property, property);
 
@@ -982,10 +958,6 @@ int CMPTransaction::logicMath_Alert()
         return PKT_ERROR;
     }
 
-    const char *p = 4 + (char *)&pkt;
-    std::vector<std::string> spstr;
-    char alertString[SP_STRING_FIELD_LEN];
-
     // is sender authorized?
     bool authorized = false;
     if (
@@ -1007,9 +979,6 @@ int CMPTransaction::logicMath_Alert()
         return (PKT_ERROR -912);
     }
     // authorized, decode and make sure there are 4 tokens, then replace global_alert_message
-    spstr.push_back(std::string(p));
-    memcpy(alertString, spstr[0].c_str(), std::min(spstr[0].length(), sizeof(alertString)-1));
-
     std::vector<std::string> vstr;
     boost::split(vstr, alertString, boost::is_any_of(":"), token_compress_on);
     PrintToLog("\t      alert auth: true\n");

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -606,6 +606,21 @@ int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
 
 int CMPTransaction::logicMath_CreatePropertyFixed()
 {
+    if (OMNI_PROPERTY_MSC != ecosystem && OMNI_PROPERTY_TMSC != ecosystem) {
+        return (PKT_ERROR_SP -501);
+    }
+    if (MSC_PROPERTY_TYPE_INDIVISIBLE != prop_type && MSC_PROPERTY_TYPE_DIVISIBLE != prop_type) {
+        return (PKT_ERROR_SP -502);
+    }
+    unsigned int prop_id = _my_sps->peekNextSPID(ecosystem);
+    if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
+        return (PKT_ERROR_SP -503);
+    }
+    if ('\0' == name[0]) {
+        return (PKT_ERROR_SP -505);
+    }
+    // ------------------------------------------
+
     int rc = -1;
 
     CMPSPInfo::Entry newSP;
@@ -630,6 +645,21 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
 
 int CMPTransaction::logicMath_CreatePropertyVariable()
 {
+    if (OMNI_PROPERTY_MSC != ecosystem && OMNI_PROPERTY_TMSC != ecosystem) {
+        return (PKT_ERROR_SP -501);
+    }
+    if (MSC_PROPERTY_TYPE_INDIVISIBLE != prop_type && MSC_PROPERTY_TYPE_DIVISIBLE != prop_type) {
+        return (PKT_ERROR_SP -502);
+    }
+    unsigned int prop_id = _my_sps->peekNextSPID(ecosystem);
+    if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
+        return (PKT_ERROR_SP -503);
+    }
+    if ('\0' == name[0]) {
+        return (PKT_ERROR_SP -505);
+    }
+    // ------------------------------------------
+
     int rc = -1;
 
     // check if one exists for this address already !
@@ -719,6 +749,21 @@ int CMPTransaction::logicMath_CloseCrowdsale()
 
 int CMPTransaction::logicMath_CreatePropertyMananged()
 {
+    if (OMNI_PROPERTY_MSC != ecosystem && OMNI_PROPERTY_TMSC != ecosystem) {
+        return (PKT_ERROR_SP -501);
+    }
+    if (MSC_PROPERTY_TYPE_INDIVISIBLE != prop_type && MSC_PROPERTY_TYPE_DIVISIBLE != prop_type) {
+        return (PKT_ERROR_SP -502);
+    }
+    unsigned int prop_id = _my_sps->peekNextSPID(ecosystem);
+    if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
+        return (PKT_ERROR_SP -503);
+    }
+    if ('\0' == name[0]) {
+        return (PKT_ERROR_SP -505);
+    }
+    // ------------------------------------------
+
     int rc = -1;
 
     CMPSPInfo::Entry newSP;

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -421,23 +421,20 @@ bool CMPTransaction::interpret_TransactionType()
     if (pkt_size < 4) {
         return false;
     }
-
     uint16_t txVersion = 0;
     uint16_t txType = 0;
-
     memcpy(&txVersion, &pkt[0], 2);
     swapByteOrder16(txVersion);
-
     memcpy(&txType, &pkt[2], 2);
     swapByteOrder16(txType);
-
-    PrintToLog("\t------------------------------\n");
-    PrintToLog("\t         version: %d, class %s\n", txVersion, intToClass(multi));
-    PrintToLog("\t            type: %d (%s)\n", txType, c_strMasterProtocolTXType(txType));
-
-    // ------------------------------------------
     version = txVersion;
     type = txType;
+
+    if (msc_debug_packets) {
+        PrintToLog("\t------------------------------\n");
+        PrintToLog("\t         version: %d, class %s\n", txVersion, intToClass(multi));
+        PrintToLog("\t            type: %d (%s)\n", txType, c_strMasterProtocolTXType(txType));
+    }
 
     return true;
 }
@@ -448,15 +445,16 @@ bool CMPTransaction::interpret_SimpleSend()
     if (pkt_size < 16) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
     memcpy(&nValue, &pkt[8], 8);
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    }
 
     return true;
 }
@@ -467,15 +465,16 @@ bool CMPTransaction::interpret_SendToOwners()
     if (pkt_size < 16) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
     memcpy(&nValue, &pkt[8], 8);
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    }
 
     return true;
 }
@@ -486,13 +485,11 @@ bool CMPTransaction::interpret_TradeOffer()
     if (pkt_size < 34) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
     memcpy(&nValue, &pkt[8], 8);
     swapByteOrder64(nValue);
     nNewValue = nValue;
-
     memcpy(&amount_desired, &pkt[16], 8);
     memcpy(&blocktimelimit, &pkt[24], 1);
     memcpy(&min_fee, &pkt[25], 8);
@@ -500,12 +497,14 @@ bool CMPTransaction::interpret_TradeOffer()
     swapByteOrder64(amount_desired);
     swapByteOrder64(min_fee);
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
-    PrintToLog("\t  amount desired: %s\n", FormatDivisibleMP(amount_desired));
-    PrintToLog("\tblock time limit: %d\n", blocktimelimit);
-    PrintToLog("\t         min fee: %s\n", FormatDivisibleMP(min_fee));
-    PrintToLog("\t      sub-action: %d\n", subaction);
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+        PrintToLog("\t  amount desired: %s\n", FormatDivisibleMP(amount_desired));
+        PrintToLog("\tblock time limit: %d\n", blocktimelimit);
+        PrintToLog("\t         min fee: %s\n", FormatDivisibleMP(min_fee));
+        PrintToLog("\t      sub-action: %d\n", subaction);
+    }
 
     return true;
 }
@@ -516,24 +515,24 @@ bool CMPTransaction::interpret_MetaDEx()
     if (pkt_size < 29) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
     memcpy(&nValue, &pkt[8], 8);
     swapByteOrder64(nValue);
     nNewValue = nValue;
-
     memcpy(&desired_property, &pkt[16], 4);
     swapByteOrder32(desired_property);
     memcpy(&desired_value, &pkt[20], 8);
     swapByteOrder64(desired_value);
     memcpy(&action, &pkt[28], 1);
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
-    PrintToLog("\tdesired property: %d (%s)\n", desired_property, strMPProperty(desired_property));
-    PrintToLog("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
-    PrintToLog("\t          action: %d\n", action);
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+        PrintToLog("\tdesired property: %d (%s)\n", desired_property, strMPProperty(desired_property));
+        PrintToLog("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
+        PrintToLog("\t          action: %d\n", action);
+    }
 
     return true;
 }
@@ -544,15 +543,16 @@ bool CMPTransaction::interpret_AcceptOfferBTC()
     if (pkt_size < 16) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
     memcpy(&nValue, &pkt[8], 8);
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    }
 
     return true;
 }
@@ -563,7 +563,6 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
     if (pkt_size < 25) {
         return false;
     }
-
     const char* p = 11 + (char*) &pkt;
     std::vector<std::string> spstr;
     memcpy(&ecosystem, &pkt[4], 1);
@@ -581,21 +580,22 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
     memcpy(name, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(name)-1)); i++;
     memcpy(url, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(url)-1)); i++;
     memcpy(data, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(data)-1)); i++;
-
     memcpy(&nValue, p, 8);
     swapByteOrder64(nValue);
     p += 8;
     nNewValue = nValue;
 
-    PrintToLog("\t       ecosystem: %d\n", ecosystem);
-    PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
-    PrintToLog("\tprev property id: %d\n", prev_prop_id);
-    PrintToLog("\t        category: %s\n", category);
-    PrintToLog("\t     subcategory: %s\n", subcategory);
-    PrintToLog("\t            name: %s\n", name);
-    PrintToLog("\t             url: %s\n", url);
-    PrintToLog("\t            data: %s\n", data);
-    PrintToLog("\t           value: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
+    if (msc_debug_packets) {
+        PrintToLog("\t       ecosystem: %d\n", ecosystem);
+        PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+        PrintToLog("\tprev property id: %d\n", prev_prop_id);
+        PrintToLog("\t        category: %s\n", category);
+        PrintToLog("\t     subcategory: %s\n", subcategory);
+        PrintToLog("\t            name: %s\n", name);
+        PrintToLog("\t             url: %s\n", url);
+        PrintToLog("\t            data: %s\n", data);
+        PrintToLog("\t           value: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
+    }
 
     if (isOverrun(p, __LINE__)) {
         return false;
@@ -610,7 +610,6 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
     if (pkt_size < 39) {
         return false;
     }
-
     const char* p = 11 + (char*) &pkt;
     std::vector<std::string> spstr;
     memcpy(&ecosystem, &pkt[4], 1);
@@ -628,7 +627,6 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
     memcpy(name, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(name)-1)); i++;
     memcpy(url, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(url)-1)); i++;
     memcpy(data, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(data)-1)); i++;
-
     memcpy(&property, p, 4);
     swapByteOrder32(property);
     p += 4;
@@ -642,19 +640,21 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
     memcpy(&early_bird, p++, 1);
     memcpy(&percentage, p++, 1);
 
-    PrintToLog("\t       ecosystem: %d\n", ecosystem);
-    PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
-    PrintToLog("\tprev property id: %d\n", prev_prop_id);
-    PrintToLog("\t        category: %s\n", category);
-    PrintToLog("\t     subcategory: %s\n", subcategory);
-    PrintToLog("\t            name: %s\n", name);
-    PrintToLog("\t             url: %s\n", url);
-    PrintToLog("\t            data: %s\n", data);
-    PrintToLog("\tproperty desired: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t tokens per unit: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
-    PrintToLog("\t        deadline: %s (%x)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline), deadline);
-    PrintToLog("\tearly bird bonus: %d\n", early_bird);
-    PrintToLog("\t    issuer bonus: %d\n", percentage);
+    if (msc_debug_packets) {
+        PrintToLog("\t       ecosystem: %d\n", ecosystem);
+        PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+        PrintToLog("\tprev property id: %d\n", prev_prop_id);
+        PrintToLog("\t        category: %s\n", category);
+        PrintToLog("\t     subcategory: %s\n", subcategory);
+        PrintToLog("\t            name: %s\n", name);
+        PrintToLog("\t             url: %s\n", url);
+        PrintToLog("\t            data: %s\n", data);
+        PrintToLog("\tproperty desired: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t tokens per unit: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
+        PrintToLog("\t        deadline: %s (%x)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline), deadline);
+        PrintToLog("\tearly bird bonus: %d\n", early_bird);
+        PrintToLog("\t    issuer bonus: %d\n", percentage);
+    }
 
     if (isOverrun(p, __LINE__)) {
         return false;
@@ -669,11 +669,12 @@ bool CMPTransaction::interpret_CloseCrowdsale()
     if (pkt_size < 8) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    }
 
     return true;
 }
@@ -684,7 +685,6 @@ bool CMPTransaction::interpret_CreatePropertyMananged()
     if (pkt_size < 17) {
         return false;
     }
-
     const char* p = 11 + (char*) &pkt;
     std::vector<std::string> spstr;
     memcpy(&ecosystem, &pkt[4], 1);
@@ -703,14 +703,16 @@ bool CMPTransaction::interpret_CreatePropertyMananged()
     memcpy(url, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(url)-1)); i++;
     memcpy(data, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(data)-1)); i++;
 
-    PrintToLog("\t       ecosystem: %d\n", ecosystem);
-    PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
-    PrintToLog("\tprev property id: %d\n", prev_prop_id);
-    PrintToLog("\t        category: %s\n", category);
-    PrintToLog("\t     subcategory: %s\n", subcategory);
-    PrintToLog("\t            name: %s\n", name);
-    PrintToLog("\t             url: %s\n", url);
-    PrintToLog("\t            data: %s\n", data);
+    if (msc_debug_packets) {
+        PrintToLog("\t       ecosystem: %d\n", ecosystem);
+        PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+        PrintToLog("\tprev property id: %d\n", prev_prop_id);
+        PrintToLog("\t        category: %s\n", category);
+        PrintToLog("\t     subcategory: %s\n", subcategory);
+        PrintToLog("\t            name: %s\n", name);
+        PrintToLog("\t             url: %s\n", url);
+        PrintToLog("\t            data: %s\n", data);
+    }
 
     if (isOverrun(p, __LINE__)) {
         return false;
@@ -725,15 +727,16 @@ bool CMPTransaction::interpret_GrantTokens()
     if (pkt_size < 16) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
     memcpy(&nValue, &pkt[8], 8);
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    }
 
     return true;
 }
@@ -744,15 +747,16 @@ bool CMPTransaction::interpret_RevokeTokens()
     if (pkt_size < 16) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
     memcpy(&nValue, &pkt[8], 8);
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    }
 
     return true;
 }
@@ -763,11 +767,12 @@ bool CMPTransaction::interpret_ChangeIssuer()
     if (pkt_size < 8) {
         return false;
     }
-
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
 
-    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    if (msc_debug_packets) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    }
 
     return true;
 }
@@ -778,12 +783,13 @@ bool CMPTransaction::interpret_Alert()
     if (pkt_size < 5) {
         return false;
     }
-
     const char* p = 4 + (char*) &pkt;
     std::string spstr(p);
     memcpy(alertString, spstr.c_str(), std::min(spstr.length(), sizeof(alertString)-1));
 
-    PrintToLog("\t           alert: %s\n", alertString);
+    if (msc_debug_packets) {
+        PrintToLog("\t           alert: %s\n", alertString);
+    }
 
     if (isOverrun(p, __LINE__)) {
         return false;

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -356,7 +356,7 @@ int CMPTransaction::step3_sp_variable(const char *p)
 bool CMPTransaction::interpret_Transaction()
 {
     if (!interpret_TransactionType()) {
-        PrintToConsole("Failed to interpret type and version\n");
+        PrintToLog("Failed to interpret type and version\n");
         return false;
     }
 
@@ -431,9 +431,9 @@ bool CMPTransaction::interpret_TransactionType()
     memcpy(&txType, &pkt[2], 2);
     swapByteOrder16(txType);
 
-    PrintToConsole("\t------------------------------\n");
-    PrintToConsole("\t         version: %d, class %s\n", txVersion, intToClass(multi));
-    PrintToConsole("\t            type: %d (%s)\n", txType, c_strMasterProtocolTXType(txType));
+    PrintToLog("\t------------------------------\n");
+    PrintToLog("\t         version: %d, class %s\n", txVersion, intToClass(multi));
+    PrintToLog("\t            type: %d (%s)\n", txType, c_strMasterProtocolTXType(txType));
 
     // ------------------------------------------
     version = txVersion;
@@ -455,8 +455,8 @@ bool CMPTransaction::interpret_SimpleSend()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t           value: %s\n", FormatMP(property, nValue));
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
 
     return true;
 }
@@ -474,8 +474,8 @@ bool CMPTransaction::interpret_SendToOwners()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t           value: %s\n", FormatMP(property, nValue));
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
 
     return true;
 }
@@ -500,12 +500,12 @@ bool CMPTransaction::interpret_TradeOffer()
     swapByteOrder64(amount_desired);
     swapByteOrder64(min_fee);
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t           value: %s\n", FormatMP(property, nValue));
-    PrintToConsole("\t  amount desired: %s\n", FormatDivisibleMP(amount_desired));
-    PrintToConsole("\tblock time limit: %d\n", blocktimelimit);
-    PrintToConsole("\t         min fee: %s\n", FormatDivisibleMP(min_fee));
-    PrintToConsole("\t      sub-action: %d\n", subaction);
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    PrintToLog("\t  amount desired: %s\n", FormatDivisibleMP(amount_desired));
+    PrintToLog("\tblock time limit: %d\n", blocktimelimit);
+    PrintToLog("\t         min fee: %s\n", FormatDivisibleMP(min_fee));
+    PrintToLog("\t      sub-action: %d\n", subaction);
 
     return true;
 }
@@ -529,11 +529,11 @@ bool CMPTransaction::interpret_MetaDEx()
     swapByteOrder64(desired_value);
     memcpy(&action, &pkt[28], 1);
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t           value: %s\n", FormatMP(property, nValue));
-    PrintToConsole("\tdesired property: %d (%s)\n", desired_property, strMPProperty(desired_property));
-    PrintToConsole("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
-    PrintToConsole("\t          action: %d\n", action);
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
+    PrintToLog("\tdesired property: %d (%s)\n", desired_property, strMPProperty(desired_property));
+    PrintToLog("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
+    PrintToLog("\t          action: %d\n", action);
 
     return true;
 }
@@ -551,8 +551,8 @@ bool CMPTransaction::interpret_AcceptOfferBTC()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t           value: %s\n", FormatMP(property, nValue));
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
 
     return true;
 }
@@ -587,15 +587,15 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
     p += 8;
     nNewValue = nValue;
 
-    PrintToConsole("\t       ecosystem: %d\n", ecosystem);
-    PrintToConsole("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
-    PrintToConsole("\tprev property id: %d\n", prev_prop_id);
-    PrintToConsole("\t        category: %s\n", category);
-    PrintToConsole("\t     subcategory: %s\n", subcategory);
-    PrintToConsole("\t            name: %s\n", name);
-    PrintToConsole("\t             url: %s\n", url);
-    PrintToConsole("\t            data: %s\n", data);
-    PrintToConsole("\t           value: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
+    PrintToLog("\t       ecosystem: %d\n", ecosystem);
+    PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+    PrintToLog("\tprev property id: %d\n", prev_prop_id);
+    PrintToLog("\t        category: %s\n", category);
+    PrintToLog("\t     subcategory: %s\n", subcategory);
+    PrintToLog("\t            name: %s\n", name);
+    PrintToLog("\t             url: %s\n", url);
+    PrintToLog("\t            data: %s\n", data);
+    PrintToLog("\t           value: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
 
     if (isOverrun(p, __LINE__)) {
         return false;
@@ -642,19 +642,19 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
     memcpy(&early_bird, p++, 1);
     memcpy(&percentage, p++, 1);
 
-    PrintToConsole("\t       ecosystem: %d\n", ecosystem);
-    PrintToConsole("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
-    PrintToConsole("\tprev property id: %d\n", prev_prop_id);
-    PrintToConsole("\t        category: %s\n", category);
-    PrintToConsole("\t     subcategory: %s\n", subcategory);
-    PrintToConsole("\t            name: %s\n", name);
-    PrintToConsole("\t             url: %s\n", url);
-    PrintToConsole("\t            data: %s\n", data);
-    PrintToConsole("\tproperty desired: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t tokens per unit: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
-    PrintToConsole("\t        deadline: %s (%x)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline), deadline);
-    PrintToConsole("\tearly bird bonus: %d\n", early_bird);
-    PrintToConsole("\t    issuer bonus: %d\n", percentage);
+    PrintToLog("\t       ecosystem: %d\n", ecosystem);
+    PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+    PrintToLog("\tprev property id: %d\n", prev_prop_id);
+    PrintToLog("\t        category: %s\n", category);
+    PrintToLog("\t     subcategory: %s\n", subcategory);
+    PrintToLog("\t            name: %s\n", name);
+    PrintToLog("\t             url: %s\n", url);
+    PrintToLog("\t            data: %s\n", data);
+    PrintToLog("\tproperty desired: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t tokens per unit: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
+    PrintToLog("\t        deadline: %s (%x)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline), deadline);
+    PrintToLog("\tearly bird bonus: %d\n", early_bird);
+    PrintToLog("\t    issuer bonus: %d\n", percentage);
 
     if (isOverrun(p, __LINE__)) {
         return false;
@@ -673,7 +673,7 @@ bool CMPTransaction::interpret_CloseCrowdsale()
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
 
     return true;
 }
@@ -703,14 +703,14 @@ bool CMPTransaction::interpret_CreatePropertyMananged()
     memcpy(url, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(url)-1)); i++;
     memcpy(data, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(data)-1)); i++;
 
-    PrintToConsole("\t       ecosystem: %d\n", ecosystem);
-    PrintToConsole("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
-    PrintToConsole("\tprev property id: %d\n", prev_prop_id);
-    PrintToConsole("\t        category: %s\n", category);
-    PrintToConsole("\t     subcategory: %s\n", subcategory);
-    PrintToConsole("\t            name: %s\n", name);
-    PrintToConsole("\t             url: %s\n", url);
-    PrintToConsole("\t            data: %s\n", data);
+    PrintToLog("\t       ecosystem: %d\n", ecosystem);
+    PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+    PrintToLog("\tprev property id: %d\n", prev_prop_id);
+    PrintToLog("\t        category: %s\n", category);
+    PrintToLog("\t     subcategory: %s\n", subcategory);
+    PrintToLog("\t            name: %s\n", name);
+    PrintToLog("\t             url: %s\n", url);
+    PrintToLog("\t            data: %s\n", data);
 
     if (isOverrun(p, __LINE__)) {
         return false;
@@ -732,8 +732,8 @@ bool CMPTransaction::interpret_GrantTokens()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t           value: %s\n", FormatMP(property, nValue));
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
 
     return true;
 }
@@ -751,8 +751,8 @@ bool CMPTransaction::interpret_RevokeTokens()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
-    PrintToConsole("\t           value: %s\n", FormatMP(property, nValue));
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
 
     return true;
 }
@@ -767,7 +767,7 @@ bool CMPTransaction::interpret_ChangeIssuer()
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
 
-    PrintToConsole("\t        property: %d (%s)\n", property, strMPProperty(property));
+    PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
 
     return true;
 }
@@ -783,7 +783,7 @@ bool CMPTransaction::interpret_Alert()
     std::string spstr(p);
     memcpy(alertString, spstr.c_str(), std::min(spstr.length(), sizeof(alertString)-1));
 
-    PrintToConsole("\t           alert: %s\n", alertString);
+    PrintToLog("\t           alert: %s\n", alertString);
 
     if (isOverrun(p, __LINE__)) {
         return false;
@@ -807,7 +807,6 @@ int CMPTransaction::logicMath_TradeOffer(CMPOffer *obj_o)
     // ------------------------------------------
 
 int rc = PKT_ERROR_TRADEOFFER;
-static const char * const subaction_name[] = { "empty", "new", "update", "cancel" };
 
       if ((OMNI_PROPERTY_TMSC != property) && (OMNI_PROPERTY_MSC != property))
       {
@@ -817,11 +816,6 @@ static const char * const subaction_name[] = { "empty", "new", "update", "cancel
 
       // block height checks, for instance DEX is only available on MSC starting with block 290630
       if (!isTransactionTypeAllowed(block, property, type, version)) return -88888;
-
-    PrintToLog("\t  amount desired: %lu.%08lu\n", amount_desired / COIN, amount_desired % COIN);
-    PrintToLog("\tblock time limit: %u\n", blocktimelimit);
-    PrintToLog("\t         min fee: %lu.%08lu\n", min_fee / COIN, min_fee % COIN);
-    PrintToLog("\t      sub-action: %u (%s)\n", subaction, subaction < sizeof(subaction_name)/sizeof(subaction_name[0]) ? subaction_name[subaction] : "");
 
       if (obj_o)
       {
@@ -930,10 +924,6 @@ int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
 
     int rc = PKT_ERROR_METADEX -100;
 
-    PrintToLog("\tdesired property: %u (%s)\n", desired_property, strMPProperty(desired_property));
-    PrintToLog("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
-    PrintToLog("\t          action: %u\n", action);
-
     if (mdex_o)
     {
       mdex_o->Set(sender, block, property, nValue, desired_property, desired_value, txid, tx_idx, action);
@@ -1041,13 +1031,8 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
         return (PKT_ERROR_SP -505);
     }
     // ------------------------------------------
-    if (MSC_PROPERTY_TYPE_INDIVISIBLE == prop_type) {
-        PrintToLog("\t           value: %lu\n", nValue);
-        if (0 == nValue) return (PKT_ERROR_SP -101);
-    } else
-        if (MSC_PROPERTY_TYPE_DIVISIBLE == prop_type) {
-        PrintToLog("\t           value: %s\n", FormatDivisibleMP(nValue));
-        if (0 == nValue) return (PKT_ERROR_SP -102);
+    if (0 == nValue) {
+        return (PKT_ERROR_SP -101);
     }
     if (MAX_INT_8_BYTES < nValue) {
         return (PKT_ERROR -802); // out of range
@@ -1092,12 +1077,8 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
         return (PKT_ERROR_SP -505);
     }
     // ------------------------------------------
-    if (MSC_PROPERTY_TYPE_INDIVISIBLE == prop_type) {
-        PrintToLog("\t           value: %lu\n", nValue);
-        if (0 == nValue) return (PKT_ERROR_SP - 201);
-    } else if (MSC_PROPERTY_TYPE_DIVISIBLE == prop_type) {
-        PrintToLog("\t           value: %s\n", FormatDivisibleMP(nValue));
-        if (0 == nValue) return (PKT_ERROR_SP - 202);
+    if (0 == nValue) {
+        return (PKT_ERROR_SP - 201);
     }
     if (MAX_INT_8_BYTES < nValue) {
         return (PKT_ERROR - 803); // out of range

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -949,6 +949,10 @@ int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
         if (0 >= static_cast<int64_t>(nNewValue)) return (PKT_ERROR_METADEX -11);
         if (0 >= static_cast<int64_t>(desired_value)) return (PKT_ERROR_METADEX -12);
 
+        // ensure that one side of the trade is MSC/TMSC (phase 1 check)
+        if ((property != OMNI_PROPERTY_MSC) && (desired_property != OMNI_PROPERTY_MSC) &&
+            (property != OMNI_PROPERTY_TMSC) && (desired_property != OMNI_PROPERTY_TMSC)) return (PKT_ERROR_METADEX -800);
+
         // ensure sufficient balance is available to offer
         if (getMPbalance(sender, property, BALANCE) < static_cast<int64_t>(nNewValue)) return (PKT_ERROR_METADEX -567);
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -620,6 +620,18 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
         return (PKT_ERROR_SP -505);
     }
     // ------------------------------------------
+    if (MSC_PROPERTY_TYPE_INDIVISIBLE == prop_type) {
+        PrintToLog("\t           value: %lu\n", nValue);
+        if (0 == nValue) return (PKT_ERROR_SP -101);
+    } else
+        if (MSC_PROPERTY_TYPE_DIVISIBLE == prop_type) {
+        PrintToLog("\t           value: %s\n", FormatDivisibleMP(nValue));
+        if (0 == nValue) return (PKT_ERROR_SP -102);
+    }
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -802); // out of range
+    }
+    // ------------------------------------------
 
     int rc = -1;
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -589,6 +589,34 @@ int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
     return rc;
 }
 
+int CMPTransaction::logicMath_CreatePropertyFixed()
+{
+    int rc = -1;
+
+    return rc;
+}
+
+int CMPTransaction::logicMath_CreatePropertyVariable()
+{
+    int rc = -1;
+
+    return rc;
+}
+
+int CMPTransaction::logicMath_CloseCrowdsale()
+{
+    int rc = -1;
+
+    return rc;
+}
+
+int CMPTransaction::logicMath_CreatePropertyMananged()
+{
+    int rc = -1;
+
+    return rc;
+}
+
 int CMPTransaction::logicMath_GrantTokens()
 {
     int rc = PKT_ERROR_TOKENS - 1000;
@@ -741,6 +769,13 @@ int CMPTransaction::logicMath_ChangeIssuer()
 
   rc = 0;
   return rc;
+}
+
+int CMPTransaction::logicMath_Alert()
+{
+    int rc = -1;
+
+    return rc;
 }
 
 int CMPTransaction::logicMath_SavingsMark()

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -360,6 +360,11 @@ void CMPTransaction::printInfo(FILE *fp)
 
 int CMPTransaction::logicMath_TradeOffer(CMPOffer *obj_o)
 {
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -801);  // out of range
+    }
+    // ------------------------------------------
+
 int rc = PKT_ERROR_TRADEOFFER;
 uint64_t amount_desired, min_fee;
 unsigned char blocktimelimit, subaction = 0;
@@ -472,7 +477,12 @@ static const char * const subaction_name[] = { "empty", "new", "update", "cancel
 
 int CMPTransaction::logicMath_AcceptOffer_BTC()
 {
-int rc = DEX_ERROR_ACCEPT;
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -801);  // out of range
+    }
+    // ------------------------------------------
+
+    int rc = DEX_ERROR_ACCEPT;
 
     // the min fee spec requirement is checked in the following function
     rc = DEx_acceptCreate(sender, receiver, property, nValue, block, tx_fee_paid, &nNewValue);
@@ -482,6 +492,11 @@ int rc = DEX_ERROR_ACCEPT;
 
 int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
 {
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -801);  // out of range
+    }
+    // ------------------------------------------
+
     int rc = PKT_ERROR_METADEX -100;
     unsigned char action = 0;
 
@@ -727,6 +742,11 @@ int CMPTransaction::logicMath_CreatePropertyMananged()
 
 int CMPTransaction::logicMath_GrantTokens()
 {
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -801);  // out of range
+    }
+    // ------------------------------------------
+
     int rc = PKT_ERROR_TOKENS - 1000;
 
     if (!isTransactionTypeAllowed(block, property, type, version)) {
@@ -792,6 +812,11 @@ int CMPTransaction::logicMath_GrantTokens()
 
 int CMPTransaction::logicMath_RevokeTokens()
 {
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR -801);  // out of range
+    }
+    // ------------------------------------------
+
     int rc = PKT_ERROR_TOKENS - 1000;
 
     if (!isTransactionTypeAllowed(block, property, type, version)) {

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -659,6 +659,20 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
         return (PKT_ERROR_SP -505);
     }
     // ------------------------------------------
+    if (MSC_PROPERTY_TYPE_INDIVISIBLE == prop_type) {
+        PrintToLog("\t           value: %lu\n", nValue);
+        if (0 == nValue) return (PKT_ERROR_SP - 201);
+    } else if (MSC_PROPERTY_TYPE_DIVISIBLE == prop_type) {
+        PrintToLog("\t           value: %s\n", FormatDivisibleMP(nValue));
+        if (0 == nValue) return (PKT_ERROR_SP - 202);
+    }
+    if (MAX_INT_8_BYTES < nValue) {
+        return (PKT_ERROR - 803); // out of range
+    }
+    if (!deadline) return (PKT_ERROR_SP - 203); // deadline cannot be 0
+    // deadline can not be smaller than the timestamp of the current block
+    if (deadline < (uint64_t) blockTime) return (PKT_ERROR_SP - 204);
+    // ------------------------------------------
 
     int rc = -1;
 

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -261,7 +261,7 @@ public:
     }
 };
 
-int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction* pmptx, unsigned int nTime=0);
+int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction& mptx, unsigned int nTime=0);
 
 
 #endif // OMNICORE_TX_H

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -215,7 +215,7 @@ public:
   }
 };
 
-int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigned int idx, CMPTransaction *mp_tx, unsigned int nTime=0);
+int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction* pmptx, unsigned int nTime=0);
 
 
 #endif // OMNICORE_TX_H

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -148,16 +148,21 @@ public:
     SetNull();
   }
 
-  int logicMath_SimpleSend(void);
-  int logicMath_TradeOffer(CMPOffer *);
-  int logicMath_AcceptOffer_BTC(void);
-  int logicMath_SendToOwners(FILE *fp = NULL);
-  int logicMath_MetaDEx(CMPMetaDEx *);
-  int logicMath_GrantTokens(void);
-  int logicMath_RevokeTokens(void);
-  int logicMath_ChangeIssuer(void);
-  int logicMath_SavingsMark(void);
-  int logicMath_SavingsCompromised(void);
+  int logicMath_SimpleSend();                   //  1
+  int logicMath_SendToOwners(FILE* fp = NULL);  //  3
+  int logicMath_TradeOffer(CMPOffer*);          // 20
+  int logicMath_MetaDEx(CMPMetaDEx*);           // 21
+  int logicMath_AcceptOffer_BTC();              // 22
+  int logicMath_CreatePropertyFixed();          // 50
+  int logicMath_CreatePropertyVariable();       // 51
+  int logicMath_CloseCrowdsale();               // 53
+  int logicMath_CreatePropertyMananged();       // 54
+  int logicMath_GrantTokens();                  // 55
+  int logicMath_RevokeTokens();                 // 56
+  int logicMath_ChangeIssuer();                 // 70
+  int logicMath_Alert();                        // 65535
+  int logicMath_SavingsMark(void);              // missing
+  int logicMath_SavingsCompromised(void);       // missing
 
  int interpretPacket(CMPOffer *obj_o = NULL, CMPMetaDEx *mdex_o = NULL);
  int step1(void);

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -67,6 +67,19 @@ private:
   unsigned int desired_property;
   uint64_t desired_value;
 
+  // TradeOffer
+  uint64_t amount_desired;
+  unsigned char blocktimelimit;
+  uint64_t min_fee;
+  unsigned char subaction;
+
+  // MetaDEx
+  unsigned char action;
+
+  // Alert
+  char alertString[SP_STRING_FIELD_LEN];
+
+
   class SendToOwners_compare
   {
   public:
@@ -147,6 +160,22 @@ public:
   {
     SetNull();
   }
+
+  bool interpret_Transaction();
+  bool interpret_TransactionType();
+  bool interpret_SimpleSend();                  //  1
+  bool interpret_SendToOwners();                //  3
+  bool interpret_TradeOffer();                  // 20
+  bool interpret_MetaDEx();                     // 21
+  bool interpret_AcceptOfferBTC();              // 22
+  bool interpret_CreatePropertyFixed();         // 50
+  bool interpret_CreatePropertyVariable();      // 51
+  bool interpret_CloseCrowdsale();              // 53
+  bool interpret_CreatePropertyMananged();      // 54
+  bool interpret_GrantTokens();                 // 55
+  bool interpret_RevokeTokens();                // 56
+  bool interpret_ChangeIssuer();                // 70
+  bool interpret_Alert();                       // 65535
 
   int logicMath_SimpleSend();                   //  1
   int logicMath_SendToOwners(FILE* fp = NULL);  //  3

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -191,7 +191,7 @@ public:
      * Logic and "effects"
      */
     int logicMath_SimpleSend();
-    int logicMath_SendToOwners(FILE* fp = NULL);
+    int logicMath_SendToOwners();
     int logicMath_TradeOffer(CMPOffer*);
     int logicMath_MetaDEx(CMPMetaDEx*);
     int logicMath_AcceptOffer_BTC();

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -128,7 +128,7 @@ public:
     void SetNull()
     {
         txid = 0;
-        block = 0;
+        block = -1;
         blockTime = 0;
         tx_idx = 0;
         tx_fee_paid = 0;

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -20,256 +20,245 @@ class CTransaction;
 #include <string>
 #include <utility>
 
-using std::pair;
-using std::string;
-
 using mastercore::c_strMasterProtocolTXType;
 
-
-// The class responsible for tx interpreting/parsing.
-//
-// It invokes other classes & methods: offers, accepts, tallies (balances).
+/** The class is responsible for transaction interpreting/parsing.
+ *
+ * It invokes other classes and methods: offers, accepts, tallies (balances).
+ */
 class CMPTransaction
 {
 private:
-  uint256 txid;
-  int block;
-  int64_t blockTime;  // internally nTime is still an "unsigned int"
-  unsigned int tx_idx;  // tx # within the block, 0-based
-  uint64_t tx_fee_paid;
+    uint256 txid;
+    int block;
+    int64_t blockTime;  // internally nTime is still an "unsigned int"
+    unsigned int tx_idx;  // tx # within the block, 0-based
+    uint64_t tx_fee_paid;
 
-  int pkt_size;
-  unsigned char pkt[1 + MAX_PACKETS * PACKET_SIZE];
-  int multi;  // Class A = 0, Class B = 1, Class C = 2
+    int pkt_size;
+    unsigned char pkt[1 + MAX_PACKETS * PACKET_SIZE];
+    int multi;  // Class A = 0, Class B = 1, Class C = 2
 
-  std::string sender;
-  std::string receiver;
+    std::string sender;
+    std::string receiver;
 
-  unsigned int type;
-  unsigned short version; // = MP_TX_PKT_V0;
+    unsigned int type;
+    unsigned short version; // = MP_TX_PKT_V0;
 
-  // SimpleSend, SendToOwners, TradeOffer, MetaDEx, AcceptOfferBTC,
-  // CreatePropertyFixed, CreatePropertyVariable, GrantTokens, RevokeTokens
-  uint64_t nValue;
-  uint64_t nNewValue;
+    // SimpleSend, SendToOwners, TradeOffer, MetaDEx, AcceptOfferBTC,
+    // CreatePropertyFixed, CreatePropertyVariable, GrantTokens, RevokeTokens
+    uint64_t nValue;
+    uint64_t nNewValue;
 
-  // SimpleSend, SendToOwners, TradeOffer, MetaDEx, AcceptOfferBTC,
-  // CreatePropertyFixed, CreatePropertyVariable, CloseCrowdsale,
-  // CreatePropertyMananged, GrantTokens, RevokeTokens, ChangeIssuer
-  unsigned int property;
+    // SimpleSend, SendToOwners, TradeOffer, MetaDEx, AcceptOfferBTC,
+    // CreatePropertyFixed, CreatePropertyVariable, CloseCrowdsale,
+    // CreatePropertyMananged, GrantTokens, RevokeTokens, ChangeIssuer
+    unsigned int property;
 
-  // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged
-  unsigned char ecosystem;
-  unsigned short prop_type;
-  unsigned int prev_prop_id;
-  char category[SP_STRING_FIELD_LEN];
-  char subcategory[SP_STRING_FIELD_LEN];
-  char name[SP_STRING_FIELD_LEN];
-  char url[SP_STRING_FIELD_LEN];
-  char data[SP_STRING_FIELD_LEN];
-  uint64_t deadline;
-  unsigned char early_bird;
-  unsigned char percentage;
-
-  // MetaDEx
-  unsigned int desired_property;
-  uint64_t desired_value;
-  unsigned char action;
-
-  // TradeOffer
-  uint64_t amount_desired;
-  unsigned char blocktimelimit;
-  uint64_t min_fee;
-  unsigned char subaction;
-
-  // Alert
-  char alertString[SP_STRING_FIELD_LEN];
-
-
-  class SendToOwners_compare
-  {
-  public:
-
-    bool operator()(pair<int64_t, string> p1, pair<int64_t, string> p2) const
-    {
-      if (p1.first == p2.first) return p1.second > p2.second; // reverse check
-      else return p1.first < p2.first;
-    }
-  };
-
-public:
-  enum ActionTypes
-  {
-    INVALID = 0,
-
-    // DEx
-    NEW = 1,
-    UPDATE = 2,
-    CANCEL = 3,
+    // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged
+    unsigned char ecosystem;
+    unsigned short prop_type;
+    unsigned int prev_prop_id;
+    char category[SP_STRING_FIELD_LEN];
+    char subcategory[SP_STRING_FIELD_LEN];
+    char name[SP_STRING_FIELD_LEN];
+    char url[SP_STRING_FIELD_LEN];
+    char data[SP_STRING_FIELD_LEN];
+    uint64_t deadline;
+    unsigned char early_bird;
+    unsigned char percentage;
 
     // MetaDEx
-    ADD                 = 1,
-    CANCEL_AT_PRICE     = 2,
-    CANCEL_ALL_FOR_PAIR = 3,
-    CANCEL_EVERYTHING   = 4,
-  };
+    unsigned int desired_property;
+    uint64_t desired_value;
+    unsigned char action;
 
-//  mutable CCriticalSection cs_msc;  // TODO: need to refactor first...
+    // TradeOffer
+    uint64_t amount_desired;
+    unsigned char blocktimelimit;
+    uint64_t min_fee;
+    unsigned char subaction;
 
-  unsigned int getType() const { return type; }
-  const string getTypeString() const { return string(c_strMasterProtocolTXType(getType())); }
-  unsigned int getProperty() const { return property; }
-  unsigned short getVersion() const { return version; }
-  unsigned short getPropertyType() const { return prop_type; }
-  uint64_t getFeePaid() const { return tx_fee_paid; }
+    // Alert
+    char alertString[SP_STRING_FIELD_LEN];
 
-  const string & getSender() const { return sender; }
-  const string & getReceiver() const { return receiver; }
-
-  uint64_t getAmount() const { return nValue; }
-  uint64_t getNewAmount() const { return nNewValue; }
-
-  string getSPName() const { return string(name); }
-
-  void printInfo(FILE *fp);
-
-  void SetNull()
-  {
-    txid = 0;
-    block = 0;
-    blockTime = 0;
-    tx_idx = 0;
-    tx_fee_paid = 0;
-
-    pkt_size = 0;
-    memset(&pkt, 0, sizeof(pkt));
-    multi = 0;
-
-    sender.clear();
-    receiver.clear();
-
-    type = 0;
-    version = 0;
-
-    nValue = 0;
-    nNewValue = 0;
-
-    property = 0;
-
-    ecosystem = 0;
-    prop_type = 0;
-    prev_prop_id = 0;
-    memset(&category, 0, sizeof(category));
-    memset(&subcategory, 0, sizeof(subcategory));
-    memset(&name, 0, sizeof(name));
-    memset(&url, 0, sizeof(url));
-    memset(&data, 0, sizeof(data));
-    deadline = 0;
-    early_bird = 0;
-    percentage = 0;
-
-    desired_property = 0;
-    desired_value = 0;
-    action = 0;
-
-    amount_desired = 0;
-    blocktimelimit = 0;
-    min_fee = 0;
-    subaction = 0;
-    memset(&alertString, 0, sizeof(alertString));
-  }
-
-  CMPTransaction()
-  {
-    SetNull();
-  }
-
-  bool interpret_Transaction();
-  bool interpret_TransactionType();
-  bool interpret_SimpleSend();                  //  1
-  bool interpret_SendToOwners();                //  3
-  bool interpret_TradeOffer();                  // 20
-  bool interpret_MetaDEx();                     // 21
-  bool interpret_AcceptOfferBTC();              // 22
-  bool interpret_CreatePropertyFixed();         // 50
-  bool interpret_CreatePropertyVariable();      // 51
-  bool interpret_CloseCrowdsale();              // 53
-  bool interpret_CreatePropertyMananged();      // 54
-  bool interpret_GrantTokens();                 // 55
-  bool interpret_RevokeTokens();                // 56
-  bool interpret_ChangeIssuer();                // 70
-  bool interpret_Alert();                       // 65535
-
-  int logicMath_SimpleSend();                   //  1
-  int logicMath_SendToOwners(FILE* fp = NULL);  //  3
-  int logicMath_TradeOffer(CMPOffer*);          // 20
-  int logicMath_MetaDEx(CMPMetaDEx*);           // 21
-  int logicMath_AcceptOffer_BTC();              // 22
-  int logicMath_CreatePropertyFixed();          // 50
-  int logicMath_CreatePropertyVariable();       // 51
-  int logicMath_CloseCrowdsale();               // 53
-  int logicMath_CreatePropertyMananged();       // 54
-  int logicMath_GrantTokens();                  // 55
-  int logicMath_RevokeTokens();                 // 56
-  int logicMath_ChangeIssuer();                 // 70
-  int logicMath_Alert();                        // 65535
-  int logicMath_SavingsMark(void);              // missing
-  int logicMath_SavingsCompromised(void);       // missing
-
- int interpretPacket(CMPOffer *obj_o = NULL, CMPMetaDEx *mdex_o = NULL);
- int step1(void);
- int step2_Alert(std::string *new_global_alert_message);
- int step2_Value(void);
- bool isOverrun(const char *p, unsigned int line);
- const char *step2_SmartProperty(int &error_code);
- int step3_sp_fixed(const char *p);
- int step3_sp_variable(const char *p);
-
-  void Set(const uint256 &t, int b, unsigned int idx, int64_t bt)
-  {
-    txid = t;
-    block = b;
-    tx_idx = idx;
-    blockTime = bt;
-  }
-
-  void Set(string s, string r, uint64_t n, const uint256 &t, int b, unsigned int idx, unsigned char *p, unsigned int size, int fMultisig, uint64_t txf)
-  {
-    sender = s;
-    receiver = r;
-    txid = t;
-    block = b;
-    tx_idx = idx;
-    pkt_size = size < sizeof(pkt) ? size : sizeof(pkt);
-    nValue = n;
-    nNewValue = n;
-    multi= fMultisig;
-    tx_fee_paid = txf;
-
-    memcpy(&pkt, p, pkt_size);
-  }
-
-  bool operator<(const CMPTransaction& other) const
-  {
-    // sort by block # & additionally the tx index within the block
-    if (block != other.block) return block > other.block;
-    return tx_idx > other.tx_idx;
-  }
-
-  void print()
-  {
-    PrintToLog("BLOCK: %d =txid: %s =fee: %1.8lf\n", block, txid.GetHex(), (double)tx_fee_paid/(double)COIN);
-    PrintToLog("sender: %s ; receiver: %s\n", sender, receiver);
-
-    if (0<pkt_size)
+    struct SendToOwners_compare
     {
-      PrintToLog("pkt: %s\n", HexStr(pkt, pkt_size + pkt, false));
-    }
-    else
+        bool operator()(std::pair<int64_t, std::string> p1, std::pair<int64_t, std::string> p2) const
+        {
+            if (p1.first == p2.first) return p1.second > p2.second; // reverse check
+            else return p1.first < p2.first;
+        }
+    };
+
+public:
+    enum ActionTypes
     {
-      // error ?
+        INVALID = 0,
+
+        // DEx
+        NEW = 1,
+        UPDATE = 2,
+        CANCEL = 3,
+
+        // MetaDEx
+        ADD                 = 1,
+        CANCEL_AT_PRICE     = 2,
+        CANCEL_ALL_FOR_PAIR = 3,
+        CANCEL_EVERYTHING   = 4,
+    };
+
+    unsigned int getType() const { return type; }
+    std::string getTypeString() const { return c_strMasterProtocolTXType(getType()); }
+    unsigned int getProperty() const { return property; }
+    unsigned short getVersion() const { return version; }
+    unsigned short getPropertyType() const { return prop_type; }
+    uint64_t getFeePaid() const { return tx_fee_paid; }
+
+    std::string getSender() const { return sender; }
+    std::string getReceiver() const { return receiver; }
+
+    uint64_t getAmount() const { return nValue; }
+    uint64_t getNewAmount() const { return nNewValue; }
+
+    std::string getSPName() const { return name; }
+
+    void printInfo(FILE *fp);
+
+    void SetNull()
+    {
+        txid = 0;
+        block = 0;
+        blockTime = 0;
+        tx_idx = 0;
+        tx_fee_paid = 0;
+        pkt_size = 0;
+        memset(&pkt, 0, sizeof(pkt));
+        multi = 0;
+        sender.clear();
+        receiver.clear();
+        type = 0;
+        version = 0;
+        nValue = 0;
+        nNewValue = 0;
+        property = 0;
+        ecosystem = 0;
+        prop_type = 0;
+        prev_prop_id = 0;
+        memset(&category, 0, sizeof(category));
+        memset(&subcategory, 0, sizeof(subcategory));
+        memset(&name, 0, sizeof(name));
+        memset(&url, 0, sizeof(url));
+        memset(&data, 0, sizeof(data));
+        deadline = 0;
+        early_bird = 0;
+        percentage = 0;
+        desired_property = 0;
+        desired_value = 0;
+        action = 0;
+        amount_desired = 0;
+        blocktimelimit = 0;
+        min_fee = 0;
+        subaction = 0;
+        memset(&alertString, 0, sizeof(alertString));
     }
-  }
+
+    CMPTransaction()
+    {
+        SetNull();
+    }
+
+    /**
+     * Payload parsing
+     */
+    bool interpret_Transaction();
+    bool interpret_TransactionType();
+    bool interpret_SimpleSend();
+    bool interpret_SendToOwners();
+    bool interpret_TradeOffer();
+    bool interpret_MetaDEx();
+    bool interpret_AcceptOfferBTC();
+    bool interpret_CreatePropertyFixed();
+    bool interpret_CreatePropertyVariable();
+    bool interpret_CloseCrowdsale();
+    bool interpret_CreatePropertyMananged();
+    bool interpret_GrantTokens();
+    bool interpret_RevokeTokens();
+    bool interpret_ChangeIssuer();
+    bool interpret_Alert();
+
+    /**
+     * Logic and "effects"
+     */
+    int logicMath_SimpleSend();
+    int logicMath_SendToOwners(FILE* fp = NULL);
+    int logicMath_TradeOffer(CMPOffer*);
+    int logicMath_MetaDEx(CMPMetaDEx*);
+    int logicMath_AcceptOffer_BTC();
+    int logicMath_CreatePropertyFixed();
+    int logicMath_CreatePropertyVariable();
+    int logicMath_CloseCrowdsale();
+    int logicMath_CreatePropertyMananged();
+    int logicMath_GrantTokens();
+    int logicMath_RevokeTokens();
+    int logicMath_ChangeIssuer();
+    int logicMath_Alert();
+    int logicMath_SavingsMark();
+    int logicMath_SavingsCompromised();
+
+    int interpretPacket(CMPOffer* obj_o = NULL, CMPMetaDEx* mdex_o = NULL);
+    bool isOverrun(const char* p, unsigned int line);
+
+    // Deprecated
+    int step1();
+    int step2_Alert(std::string* new_global_alert_message);
+    int step2_Value();
+    const char* step2_SmartProperty(int& error_code);
+    int step3_sp_fixed(const char* p);
+    int step3_sp_variable(const char* p);
+
+    void Set(const uint256& t, int b, unsigned int idx, int64_t bt)
+    {
+        txid = t;
+        block = b;
+        tx_idx = idx;
+        blockTime = bt;
+    }
+
+    void Set(const std::string& s, const std::string& r, uint64_t n, const uint256& t,
+        int b, unsigned int idx, unsigned char *p, unsigned int size, int fMultisig, uint64_t txf)
+    {
+        sender = s;
+        receiver = r;
+        txid = t;
+        block = b;
+        tx_idx = idx;
+        pkt_size = size < sizeof (pkt) ? size : sizeof (pkt);
+        nValue = n;
+        nNewValue = n;
+        multi = fMultisig;
+        tx_fee_paid = txf;
+        memcpy(&pkt, p, pkt_size);
+    }
+
+    bool operator<(const CMPTransaction& other) const
+    {
+        // sort by block # & additionally the tx index within the block
+        if (block != other.block) return block > other.block;
+        return tx_idx > other.tx_idx;
+    }
+
+    void print()
+    {
+        PrintToLog("BLOCK: %d =txid: %s =fee: %s\n", block, txid.GetHex(), FormatDivisibleMP(tx_fee_paid));
+        PrintToLog("sender: %s ; receiver: %s\n", sender, receiver);
+
+        if (0 < pkt_size) {
+            PrintToLog("pkt: %s\n", HexStr(pkt, pkt_size + pkt, false));
+        } else {
+            // error ?
+        }
+    }
 };
 
 int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction* pmptx, unsigned int nTime=0);

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -32,49 +32,55 @@ using mastercore::c_strMasterProtocolTXType;
 class CMPTransaction
 {
 private:
-  string sender;
-  string receiver;
   uint256 txid;
   int block;
+  int64_t blockTime;  // internally nTime is still an "unsigned int"
   unsigned int tx_idx;  // tx # within the block, 0-based
+  uint64_t tx_fee_paid;
+
   int pkt_size;
   unsigned char pkt[1 + MAX_PACKETS * PACKET_SIZE];
-  uint64_t nValue;
   int multi;  // Class A = 0, Class B = 1, Class C = 2
-  uint64_t tx_fee_paid;
-  unsigned int type;
-  unsigned int property;
-  unsigned short version; // = MP_TX_PKT_V0;
-  uint64_t nNewValue;
-  int64_t blockTime;  // internally nTime is still an "unsigned int"
 
-  // SP additions, perhaps a new class or a union is needed
+  std::string sender;
+  std::string receiver;
+
+  unsigned int type;
+  unsigned short version; // = MP_TX_PKT_V0;
+
+  // SimpleSend, SendToOwners, TradeOffer, MetaDEx, AcceptOfferBTC,
+  // CreatePropertyFixed, CreatePropertyVariable, GrantTokens, RevokeTokens
+  uint64_t nValue;
+  uint64_t nNewValue;
+
+  // SimpleSend, SendToOwners, TradeOffer, MetaDEx, AcceptOfferBTC,
+  // CreatePropertyFixed, CreatePropertyVariable, CloseCrowdsale,
+  // CreatePropertyMananged, GrantTokens, RevokeTokens, ChangeIssuer
+  unsigned int property;
+
+  // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged
   unsigned char ecosystem;
   unsigned short prop_type;
   unsigned int prev_prop_id;
-
   char category[SP_STRING_FIELD_LEN];
   char subcategory[SP_STRING_FIELD_LEN];
   char name[SP_STRING_FIELD_LEN];
   char url[SP_STRING_FIELD_LEN];
   char data[SP_STRING_FIELD_LEN];
-
   uint64_t deadline;
   unsigned char early_bird;
   unsigned char percentage;
 
-  // METADEX additions
+  // MetaDEx
   unsigned int desired_property;
   uint64_t desired_value;
+  unsigned char action;
 
   // TradeOffer
   uint64_t amount_desired;
   unsigned char blocktimelimit;
   uint64_t min_fee;
   unsigned char subaction;
-
-  // MetaDEx
-  unsigned char action;
 
   // Alert
   char alertString[SP_STRING_FIELD_LEN];
@@ -96,12 +102,12 @@ public:
   {
     INVALID = 0,
 
+    // DEx
     NEW = 1,
-
     UPDATE = 2,
-
     CANCEL = 3,
 
+    // MetaDEx
     ADD                 = 1,
     CANCEL_AT_PRICE     = 2,
     CANCEL_ALL_FOR_PAIR = 3,
@@ -129,31 +135,48 @@ public:
 
   void SetNull()
   {
-    property = 0;
-    type = 0;
     txid = 0;
-    tx_idx = 0;  // tx # within the block, 0-based
+    block = 0;
+    blockTime = 0;
+    tx_idx = 0;
+    tx_fee_paid = 0;
+
+    pkt_size = 0;
+    memset(&pkt, 0, sizeof(pkt));
+    multi = 0;
+
+    sender.clear();
+    receiver.clear();
+
+    type = 0;
+    version = 0;
+
     nValue = 0;
     nNewValue = 0;
-    tx_fee_paid = 0;
-    block = -1;
-    pkt_size = 0;
-    sender.erase();
-    receiver.erase();
 
-    blockTime = 0;
+    property = 0;
 
     ecosystem = 0;
     prop_type = 0;
     prev_prop_id = 0;
-
-    memset(&pkt, 0, sizeof(pkt));
-
     memset(&category, 0, sizeof(category));
     memset(&subcategory, 0, sizeof(subcategory));
     memset(&name, 0, sizeof(name));
     memset(&url, 0, sizeof(url));
     memset(&data, 0, sizeof(data));
+    deadline = 0;
+    early_bird = 0;
+    percentage = 0;
+
+    desired_property = 0;
+    desired_value = 0;
+    action = 0;
+
+    amount_desired = 0;
+    blocktimelimit = 0;
+    min_fee = 0;
+    subaction = 0;
+    memset(&alertString, 0, sizeof(alertString));
   }
 
   CMPTransaction()

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -322,7 +322,7 @@ int TradeHistoryDialog::PopulateTradeHistoryMap()
         bool valid = false;
 
         // parse the transaction
-        int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
+        int parseRC = ParseTransaction(wtx, blockHeight, 0, &mp_obj);
         if (0 != parseRC) continue;
         if (0<=mp_obj.step1()) {
             int tmpblock=0;
@@ -527,7 +527,7 @@ void TradeHistoryDialog::showDetails()
             uint256 blockHash = 0;
             if (!GetTransaction(txid, wtx, blockHash, true)) { return; }
             CMPTransaction mp_obj;
-            int parseRC = parseTransaction(true, wtx, 0, 0, &mp_obj);
+            int parseRC = ParseTransaction(wtx, 0, 0, &mp_obj);
             if (0 <= parseRC) { //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
                 if (0<=mp_obj.step1()) {
                     senderAddress = mp_obj.getSender();

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -322,7 +322,7 @@ int TradeHistoryDialog::PopulateTradeHistoryMap()
         bool valid = false;
 
         // parse the transaction
-        int parseRC = ParseTransaction(wtx, blockHeight, 0, &mp_obj);
+        int parseRC = ParseTransaction(wtx, blockHeight, 0, mp_obj);
         if (0 != parseRC) continue;
         if (0<=mp_obj.step1()) {
             int tmpblock=0;
@@ -527,7 +527,7 @@ void TradeHistoryDialog::showDetails()
             uint256 blockHash = 0;
             if (!GetTransaction(txid, wtx, blockHash, true)) { return; }
             CMPTransaction mp_obj;
-            int parseRC = ParseTransaction(wtx, 0, 0, &mp_obj);
+            int parseRC = ParseTransaction(wtx, 0, 0, mp_obj);
             if (0 <= parseRC) { //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
                 if (0<=mp_obj.step1()) {
                     senderAddress = mp_obj.getSender();

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -293,7 +293,7 @@ int TXHistoryDialog::PopulateHistoryMap()
             bool valid = false;
             string MPTxType;
             CMPTransaction mp_obj;
-            int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
+            int parseRC = ParseTransaction(wtx, blockHeight, 0, &mp_obj);
             string displayAmount;
             string displayToken;
             string displayValid;

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -293,7 +293,7 @@ int TXHistoryDialog::PopulateHistoryMap()
             bool valid = false;
             string MPTxType;
             CMPTransaction mp_obj;
-            int parseRC = ParseTransaction(wtx, blockHeight, 0, &mp_obj);
+            int parseRC = ParseTransaction(wtx, blockHeight, 0, mp_obj);
             string displayAmount;
             string displayToken;
             string displayValid;


### PR DESCRIPTION
1) [ParseTransaction()](https://github.com/OmniLayer/omnicore/blob/5d41ae8f6f49b8d9638750817262273e1b25d54b/src/omnicore/omnicore.cpp#L1275-L1281) was added, without `bRPConly`, to have "safe" read-only access to the base layer.

2) The interpretation checks from `stepXYZ()` were added directly to the logic methods.

3) Until now, some parts of the logic were directly part of [interpretPacket()](https://github.com/OmniLayer/omnicore/blob/73bfd7af048ad575d3498d6cbbf3630aa7ae589a/src/omnicore/omnicore.cpp#L3626-L3694), which were moved into seperated [logicMath_XXX()](https://github.com/OmniLayer/omnicore/blob/c5bc2483450fef3644846eeeff8dfbcdc2583ab0/src/omnicore/tx.cpp#L802-L1443) methods, for all transaction types.

4) Payloads for every transaction type are parsed in new [interpret_XXX()](https://github.com/OmniLayer/omnicore/blob/c5bc2483450fef3644846eeeff8dfbcdc2583ab0/src/omnicore/tx.cpp#L355-L793) methods.

The main motivation is to provide a way to parse/interpret payloads, without triggering any effects, and to depreciate the `stepXYZ()` methods. The one-for-all-types method for this is [interpret_Transaction()](https://github.com/OmniLayer/omnicore/blob/c5bc2483450fef3644846eeeff8dfbcdc2583ab0/src/omnicore/tx.cpp#L355-L405), which then calls other parsing/interpretation methods, based on the transaction type.

This should pave the way and lay out a basis for finer transaction handling.