### PR TITLE
Add functions for more expressive RPC input validation

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -11,6 +11,7 @@ OMNICORE_H = \
   omnicore/pending.h \
   omnicore/persistence.h \
   omnicore/rpc.h \
+  omnicore/rpcrequirements.h \
   omnicore/rpctx.h \
   omnicore/rpcvalues.h \
   omnicore/script.h \
@@ -32,6 +33,7 @@ OMNICORE_CPP = \
   omnicore/pending.cpp \
   omnicore/persistence.cpp \
   omnicore/rpc.cpp \
+  omnicore/rpcrequirements.cpp \
   omnicore/rpctx.cpp \
   omnicore/rpcvalues.cpp \
   omnicore/script.cpp \

--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -12,6 +12,7 @@ OMNICORE_H = \
   omnicore/persistence.h \
   omnicore/rpc.h \
   omnicore/rpctx.h \
+  omnicore/rpcvalues.h \
   omnicore/script.h \
   omnicore/sp.h \
   omnicore/sto.h \
@@ -32,6 +33,7 @@ OMNICORE_CPP = \
   omnicore/persistence.cpp \
   omnicore/rpc.cpp \
   omnicore/rpctx.cpp \
+  omnicore/rpcvalues.cpp \
   omnicore/script.cpp \
   omnicore/sp.cpp \
   omnicore/sto.cpp \

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -1,0 +1,137 @@
+#include "omnicore/rpcrequirements.h"
+
+#include "omnicore/dex.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
+
+#include "amount.h"
+#include "main.h"
+#include "rpcprotocol.h"
+#include "tinyformat.h"
+
+#include <stdint.h>
+#include <string>
+
+void RequireBalance(const std::string& address, uint32_t propertyId, int64_t amount)
+{
+    int64_t balance = getMPbalance(address, propertyId, BALANCE);
+    if (balance < amount) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance");
+    }
+    int64_t balanceUnconfirmed = getUserAvailableMPbalance(address, propertyId);
+    if (balanceUnconfirmed < amount) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance (due to pending transactions)");
+    }
+}
+
+void RequirePrimaryToken(uint32_t propertyId)
+{
+    if (propertyId < 1 || 2 < propertyId) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier must be 1 (MSC) or 2 (TMSC)");
+    }
+}
+
+void RequirePropertyName(const std::string& name)
+{
+    if (name.empty()) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Property name must not be empty");
+    }
+}
+
+void RequireExistingProperty(uint32_t propertyId)
+{
+    if (!mastercore::_my_sps->hasSP(propertyId)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier does not exist");
+    }
+}
+
+void RequireCrowdsale(uint32_t propertyId)
+{
+    CMPSPInfo::Entry sp;
+    if (!mastercore::_my_sps->getSP(propertyId, sp)) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Failed to retrieve property");
+    }
+    if (sp.fixed || sp.manual) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier does not refer to a crowdsale");
+    }
+}
+
+void RequireActiveCrowdsale(uint32_t propertyId)
+{
+    if (!mastercore::isCrowdsaleActive(propertyId)) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Property identifier does not refer to an active crowdsale");
+    }
+}
+
+void RequireManagedProperty(uint32_t propertyId)
+{
+    CMPSPInfo::Entry sp;
+    if (!mastercore::_my_sps->getSP(propertyId, sp)) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Failed to retrieve property");
+    }
+    if (sp.fixed || !sp.manual) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier does not refer to a managed property");
+    }
+}
+
+void RequireTokenIssuer(const std::string& address, uint32_t propertyId)
+{
+    CMPSPInfo::Entry sp;
+    if (!mastercore::_my_sps->getSP(propertyId, sp)) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Failed to retrieve property");
+    }
+    if (address != sp.issuer) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Sender is not authorized to manage the property");
+    }
+}
+
+void RequireMatchingDExOffer(const std::string& address, uint32_t propertyId)
+{
+    if (!mastercore::DEx_offerExists(address, propertyId)) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "No matching sell offer on the distributed exchange");
+    }
+}
+
+void RequireNoOtherDExOffer(const std::string& address, uint32_t propertyId)
+{
+    if (mastercore::DEx_offerExists(address, propertyId)) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Another active sell offer from the given address already exists on the distributed exchange");
+    }
+}
+
+void RequireSaneReferenceAmount(int64_t amount)
+{
+    if ((0.01 * COIN) < amount) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Reference amount higher is than 0.01 BTC");
+    }
+}
+
+void RequireSaneDExPaymentWindow(const std::string& address, uint32_t propertyId)
+{
+    CMPOffer* poffer = mastercore::DEx_getOffer(address, propertyId);
+    if (poffer == NULL) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Unable to load sell offer from the distributed exchange");
+    }
+    if (poffer->getBlockTimeLimit() < 10) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Payment window is less than 10 blocks (use override = true to continue)");
+    }
+}
+
+void RequireSaneDExFee(const std::string& address, uint32_t propertyId)
+{
+    CMPOffer* poffer = mastercore::DEx_getOffer(address, propertyId);
+    if (poffer == NULL) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Unable to load sell offer from the distributed exchange");
+    }
+    if (poffer->getMinFee() > 1000000) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Minimum accept fee is higher than 0.01 BTC (use override = true to continue)");
+    }
+}
+
+void RequireHeightInChain(int blockHeight)
+{
+    if (blockHeight < 0 || chainActive.Height() < blockHeight) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height is out of range");
+    }
+}
+

--- a/src/omnicore/rpcrequirements.h
+++ b/src/omnicore/rpcrequirements.h
@@ -1,0 +1,26 @@
+#ifndef OMNICORE_RPCREQUIREMENTS_H
+#define OMNICORE_RPCREQUIREMENTS_H
+
+#include <stdint.h>
+#include <string>
+
+void RequireBalance(const std::string& address, uint32_t propertyId, int64_t amount);
+void RequirePrimaryToken(uint32_t propertyId);
+void RequirePropertyName(const std::string& name);
+void RequireExistingProperty(uint32_t propertyId);
+void RequireCrowdsale(uint32_t propertyId);
+void RequireActiveCrowdsale(uint32_t propertyId);
+void RequireManagedProperty(uint32_t propertyId);
+void RequireTokenIssuer(const std::string& address, uint32_t propertyId);
+void RequireMatchingDExOffer(const std::string& address, uint32_t propertyId);
+void RequireNoOtherDExOffer(const std::string& address, uint32_t propertyId);
+void RequireSaneReferenceAmount(int64_t amount);
+void RequireSaneDExPaymentWindow(const std::string& address, uint32_t propertyId);
+void RequireSaneDExFee(const std::string& address, uint32_t propertyId);
+void RequireHeightInChain(int blockHeight);
+
+// TODO:
+// Checks for MetaDEx orders for cancel operations
+
+
+#endif // OMNICORE_RPCREQUIREMENTS_H

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -9,6 +9,7 @@
 #include "omnicore/omnicore.h"
 #include "omnicore/parse_string.h"
 #include "omnicore/pending.h"
+#include "omnicore/rpcvalues.h"
 #include "omnicore/sp.h"
 #include "omnicore/tx.h"
 
@@ -38,13 +39,6 @@ using std::vector;
 using namespace json_spirit;
 using namespace mastercore;
 
-uint32_t int64Touint32Safe(int64_t sourceValue)
-{
-    if ((0 > sourceValue) || (4294967295 < sourceValue)) return 0; // not safe to do conversion
-    unsigned int destValue = int(sourceValue);
-    return destValue;
-}
-
 // send_OMNI - simple send
 Value send_OMNI(const Array& params, bool fHelp)
 {
@@ -66,26 +60,22 @@ Value send_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = (params[0].get_str());
-    std::string toAddress = (params[1].get_str());
-    unsigned int propertyId = int64Touint32Safe(params[2].get_int64());
-    string strAmount = params[3].get_str();
-    std::string redeemAddress = (params.size() > 4) ? (params[4].get_str()): "";
-    std::string strReferenceAmount = (params.size() > 5) ? (params[5].get_str()): "0";
+    std::string fromAddress = ParseAddress(params[0]);
+    std::string toAddress = ParseAddress(params[1]);
+    uint32_t propertyId = ParsePropertyId(params[2]);
+    int64_t amount = ParseAmount(params[3], isPropertyDivisible(propertyId));
+    std::string redeemAddress = (params.size() > 4) ? ParseAddress(params[4]): "";
+    int64_t referenceAmount = (params.size() > 5) ? ParseAmount(params[5], true): 0;
+
     const int64_t senderBalance = getMPbalance(fromAddress, propertyId, BALANCE);
     const int64_t senderAvailableBalance = getUserAvailableMPbalance(fromAddress, propertyId);
 
     // perform conversions
-    int64_t amount = 0, referenceAmount = 0;
     CMPSPInfo::Entry sp;
     if (false == _my_sps->getSP(propertyId, sp)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier does not exist");
-    amount = StrToInt64(strAmount, sp.isDivisible());
-    referenceAmount = StrToInt64(strReferenceAmount, true);
 
     // perform checks
-    if (0 >= amount) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     if ((0.01 * COIN) < referenceAmount) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid reference amount");
-    if (!isRangeOK(amount)) throw JSONRPCError(RPC_TYPE_ERROR, "Input not in range");
     if (senderBalance < amount) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance");
     if (senderAvailableBalance < amount) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance (due to pending transactions)");
 
@@ -132,36 +122,30 @@ Value senddexsell_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    unsigned int propertyIdForSale = int64Touint32Safe(params[1].get_int64());
-    string strAmountForSale = params[2].get_str();
-    string strAmountDesired = params[3].get_str();
-    int64_t paymentWindow = params[4].get_int64();
-    int64_t minAcceptFee = StrToInt64(params[5].get_str(), true); // BTC so always divisible
-    int64_t action = params[6].get_int64();
+    std::string fromAddress = ParseAddress(params[0]);
+    uint32_t propertyIdForSale = ParsePropertyId(params[1]);
+    int64_t amountForSale = 0; // depending on action
+    int64_t amountDesired = 0; // depending on action
+    uint8_t paymentWindow = 0; // depending on action
+    int64_t minAcceptFee = ParseDExFee(params[5]);
+    uint8_t action = ParseDExAction(params[6]);
+
     const int64_t senderBalance = getMPbalance(fromAddress, propertyIdForSale, BALANCE);
     const int64_t senderAvailableBalance = getUserAvailableMPbalance(fromAddress, propertyIdForSale);
 
     // perform conversions
-    int64_t amountForSale = 0, amountDesired = 0;
     if ((propertyIdForSale > 2 || propertyIdForSale <=0)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid propertyID for sale - only 1 and 2 are permitted");
-    amountForSale = StrToInt64(strAmountForSale, true); // TMSC/MSC always divisible
-    amountDesired = StrToInt64(strAmountDesired, true); // BTC so always divisible
 
     // perform checks
-    if (action <= 0 || 3 < action) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid action (1,2,3 only)");
     if (action <= 2) { // actions 3 permit zero values, skip check
-        if (0 >= amountForSale) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for sale");
-        if (!isRangeOK(amountForSale)) throw JSONRPCError(RPC_TYPE_ERROR, "Amount for sale not in range");
-        if (0 >= amountDesired) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount desired");
-        if (!isRangeOK(amountDesired)) throw JSONRPCError(RPC_TYPE_ERROR, "Amount desired not in range");
+        amountForSale = ParseAmount(params[2], true); // TMSC/MSC is divisible
+        amountDesired = ParseAmount(params[3], true); // BTC is divisible
+        paymentWindow = ParseDExPaymentWindow(params[4]);
     }
     if (action != 3) { // only check for sufficient balance for new/update sell offers
         if (senderBalance < amountForSale) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance");
         if (senderAvailableBalance < amountForSale) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance (due to pending transactions)");
     }
-    if (minAcceptFee < 0) throw JSONRPCError(RPC_TYPE_ERROR, "Mininmum accept mining fee invalid");
-    if ((paymentWindow <= 0) || (paymentWindow > 255)) throw JSONRPCError(RPC_TYPE_ERROR, "Payment window invalid");
     if ((action == 1) && (DEx_offerExists(fromAddress, propertyIdForSale))) throw JSONRPCError(RPC_TYPE_ERROR, "There is already a sell offer from this address on the distributed exchange, use update instead");
 
     // create a payload for the transaction
@@ -205,21 +189,14 @@ Value senddexaccept_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = (params[0].get_str());
-    std::string toAddress = (params[1].get_str());
-    unsigned int propertyId = int64Touint32Safe(params[2].get_int64());
-    string strAmount = params[3].get_str();
-    bool override = false;
-    if (params.size() > 4) override = params[4].get_bool();
-
-    // perform conversions
-    int64_t amount = 0;
-    if ((propertyId > 2 || propertyId <=0)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid propertyID - only 1 and 2 are permitted");
-    amount = StrToInt64(strAmount, true); // MSC/TMSC always divisible
+    std::string fromAddress = ParseAddress(params[0]);
+    std::string toAddress = ParseAddress(params[1]);
+    uint32_t propertyId = ParsePropertyId(params[2]);
+    int64_t amount = ParseAmount(params[3], true); // MSC/TMSC is divisible
+    bool override = (params.size() > 4) ? params[4].get_bool(): false;
 
     // perform checks
-    if (0 >= amount) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (!isRangeOK(amount)) throw JSONRPCError(RPC_TYPE_ERROR, "Input not in range");
+    if ((propertyId > 2 || propertyId <=0)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid propertyID - only 1 and 2 are permitted");
     if (!DEx_offerExists(toAddress, propertyId)) throw JSONRPCError(RPC_TYPE_ERROR, "There is no matching sell offer on the distributed exchange");
 
     // retrieve the sell we're accepting and obtain the required minimum fee and payment window
@@ -292,40 +269,25 @@ Value sendissuancecrowdsale_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    int64_t ecosystem = params[1].get_int64();
-    int64_t type = params[2].get_int64();
-    unsigned int previousId = int64Touint32Safe(params[3].get_int64());
-    std::string category = params[4].get_str();
-    std::string subcategory = params[5].get_str();
-    std::string name = params[6].get_str();
-    std::string url = params[7].get_str();
-    std::string data = params[8].get_str();
-    unsigned int propertyIdDesired = int64Touint32Safe(params[9].get_int64());
-    std::string numTokensStr = params[10].get_str();
-    int64_t deadline = params[11].get_int64();
-    int64_t earlyBonus = params[12].get_int64();
-    int64_t issuerPercentage = params[13].get_int64();
-
-    // perform conversions
-    int64_t numTokens = 0;
-    if (type == 1) {
-        numTokens = StrToInt64(numTokensStr, false);
-    } else { // only type 1 and 2 supported currently
-        numTokens = StrToInt64(numTokensStr, true);
-    }
+    std::string fromAddress = ParseAddress(params[0]);
+    uint8_t ecosystem = ParseEcosystem(params[1]);
+    uint16_t type = ParsePropertyType(params[2]);
+    uint32_t previousId = ParsePreviousPropertyId(params[3]);
+    std::string category = ParseText(params[4]);
+    std::string subcategory = ParseText(params[5]);
+    std::string name = ParseText(params[6]);
+    std::string url = ParseText(params[7]);
+    std::string data = ParseText(params[8]);
+    uint32_t propertyIdDesired = ParsePropertyId(params[9]);
+    int64_t numTokens = ParseAmount(params[10], type);
+    int64_t deadline = ParseDeadline(params[11]);
+    uint8_t earlyBonus = ParseEarlyBirdBonus(params[12]);
+    uint8_t issuerPercentage = ParseIssuerBonus(params[13]);
 
     // perform checks
     CMPSPInfo::Entry sp;
     if (false == _my_sps->getSP(propertyIdDesired, sp)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property desired does not exist");
-    if ((type > 2) || (type <= 0)) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid type");
-    if ((ecosystem > 2) || (ecosystem <= 0)) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid ecosystem");
-    if (previousId != 0) throw JSONRPCError(RPC_TYPE_ERROR, "Property appends/replaces are not yet supported");
     if (name.empty()) throw JSONRPCError(RPC_TYPE_ERROR, "Property name cannot be empty");
-    if ((earlyBonus <=0) || (earlyBonus > 255)) throw JSONRPCError(RPC_TYPE_ERROR, "Early bonus must be in the range 1-255");
-    if ((issuerPercentage <=0) || (issuerPercentage > 255)) throw JSONRPCError(RPC_TYPE_ERROR, "Issuer percentage must be in the range 1-255");
-    if (0 >= numTokens) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid number of tokens per unit");
-    if (!isRangeOK(numTokens)) throw JSONRPCError(RPC_TYPE_ERROR, "Input not in range");
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceVariable(ecosystem, type, previousId, category, subcategory, name, url, data, propertyIdDesired, numTokens, deadline, earlyBonus, issuerPercentage);
@@ -372,32 +334,19 @@ Value sendissuancefixed_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    int64_t ecosystem = params[1].get_int64();
-    int64_t type = params[2].get_int64();
-    unsigned int previousId = int64Touint32Safe(params[3].get_int64());
-    std::string category = params[4].get_str();
-    std::string subcategory = params[5].get_str();
-    std::string name = params[6].get_str();
-    std::string url = params[7].get_str();
-    std::string data = params[8].get_str();
-    string strAmount = params[9].get_str();
-
-    // perform conversions
-    int64_t amount = 0;
-    if (type == 1) {
-        amount = StrToInt64(strAmount, false);
-    } else { // only type 1 and 2 supported currently
-        amount = StrToInt64(strAmount, true);
-    }
+    std::string fromAddress = ParseAddress(params[0]);
+    uint8_t ecosystem = ParseEcosystem(params[1]);
+    uint16_t type = ParsePropertyType(params[2]);
+    uint32_t previousId = ParsePreviousPropertyId(params[3]);
+    std::string category = ParseText(params[4]);
+    std::string subcategory = ParseText(params[5]);
+    std::string name = ParseText(params[6]);
+    std::string url = ParseText(params[7]);
+    std::string data = ParseText(params[8]);
+    int64_t amount = ParseAmount(params[9], type);
 
     // perform checks
-    if ((type > 2) || (type <= 0)) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid type");
-    if ((ecosystem > 2) || (ecosystem <= 0)) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid ecosystem");
-    if (previousId != 0) throw JSONRPCError(RPC_TYPE_ERROR, "Property appends/replaces are not yet supported");
     if (name.empty()) throw JSONRPCError(RPC_TYPE_ERROR, "Property name cannot be empty");
-    if (0 >= amount) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (!isRangeOK(amount)) throw JSONRPCError(RPC_TYPE_ERROR, "Input not in range");
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceFixed(ecosystem, type, previousId, category, subcategory, name, url, data, amount);
@@ -443,20 +392,17 @@ Value sendissuancemanaged_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    int64_t ecosystem = params[1].get_int64();
-    int64_t type = params[2].get_int64();
-    unsigned int previousId = int64Touint32Safe(params[3].get_int64());
-    std::string category = params[4].get_str();
-    std::string subcategory = params[5].get_str();
-    std::string name = params[6].get_str();
-    std::string url = params[7].get_str();
-    std::string data = params[8].get_str();
+    std::string fromAddress = ParseAddress(params[0]);
+    uint8_t ecosystem = ParseEcosystem(params[1]);
+    uint16_t type = ParsePropertyType(params[2]);
+    uint32_t previousId = ParsePreviousPropertyId(params[3]);
+    std::string category = ParseText(params[4]);
+    std::string subcategory = ParseText(params[5]);
+    std::string name = ParseText(params[6]);
+    std::string url = ParseText(params[7]);
+    std::string data = ParseText(params[8]);
 
     // perform checks
-    if ((type > 2) || (type <= 0)) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid type");
-    if ((ecosystem > 2) || (ecosystem <= 0)) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid ecosystem");
-    if (previousId != 0) throw JSONRPCError(RPC_TYPE_ERROR, "Property appends/replaces are not yet supported");
     if (name.empty()) throw JSONRPCError(RPC_TYPE_ERROR, "Property name cannot be empty");
 
     // create a payload for the transaction
@@ -498,22 +444,15 @@ Value sendsto_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = (params[0].get_str());
-    unsigned int propertyId = int64Touint32Safe(params[1].get_int64());
-    string strAmount = params[2].get_str();
-    std::string redeemAddress = (params.size() > 3) ? (params[3].get_str()): "";
+    std::string fromAddress = ParseAddress(params[0]);
+    uint32_t propertyId = ParsePropertyId(params[1]);
+    int64_t amount = ParseAmount(params[2], isPropertyDivisible(propertyId));
+    std::string redeemAddress = (params.size() > 3) ? ParseAddress(params[3]): "";
+
     const int64_t senderBalance = getMPbalance(fromAddress, propertyId, BALANCE);
     const int64_t senderAvailableBalance = getUserAvailableMPbalance(fromAddress, propertyId);
 
-    // perform conversions
-    int64_t amount = 0;
-    CMPSPInfo::Entry sp;
-    if (false == _my_sps->getSP(propertyId, sp)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier does not exist");
-    amount = StrToInt64(strAmount, sp.isDivisible());
-
     // perform checks
-    if (0 >= amount) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (!isRangeOK(amount)) throw JSONRPCError(RPC_TYPE_ERROR, "Input not in range");
     if (senderBalance < amount) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance");
     if (senderAvailableBalance < amount) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance (due to pending transactions)");
 
@@ -559,21 +498,17 @@ Value sendgrant_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = (params[0].get_str());
-    std::string toAddress = (params[1].get_str());
-    unsigned int propertyId = int64Touint32Safe(params[2].get_int64());
-    string strAmount = params[3].get_str();
-    std::string memo = (params.size() > 4) ? (params[4].get_str()): "";
+    std::string fromAddress = ParseAddress(params[0]);
+    std::string toAddress = ParseText(params[1]).size() ? ParseAddress(params[1]): "";
+    uint32_t propertyId = ParsePropertyId(params[2]);
+    int64_t amount = ParseAmount(params[3], isPropertyDivisible(propertyId));
+    std::string memo = (params.size() > 4) ? ParseText(params[4]): "";
 
     // perform conversions
-    int64_t amount = 0;
     CMPSPInfo::Entry sp;
     if (false == _my_sps->getSP(propertyId, sp)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier does not exist");
-    amount = StrToInt64(strAmount, sp.isDivisible());
 
     // perform checks
-    if (0 >= amount) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (!isRangeOK(amount)) throw JSONRPCError(RPC_TYPE_ERROR, "Input not in range");
     if (fromAddress != sp.issuer) throw JSONRPCError(RPC_TYPE_ERROR, "Sender is not authorized to grant tokens for this property");
 
     // create a payload for the transaction
@@ -616,22 +551,19 @@ Value sendrevoke_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = (params[0].get_str());
-    unsigned int propertyId = int64Touint32Safe(params[1].get_int64());
-    string strAmount = params[2].get_str();
-    std::string memo = (params.size() > 3) ? (params[3].get_str()): "";
+    std::string fromAddress = ParseAddress(params[0]);
+    uint32_t propertyId = ParsePropertyId(params[1]);
+    int64_t amount = ParseAmount(params[2], isPropertyDivisible(propertyId));
+    std::string memo = (params.size() > 3) ? ParseText(params[3]): "";
+
     const int64_t senderBalance = getMPbalance(fromAddress, propertyId, BALANCE);
     const int64_t senderAvailableBalance = getUserAvailableMPbalance(fromAddress, propertyId);
 
     // perform conversions
-    int64_t amount = 0;
     CMPSPInfo::Entry sp;
     if (false == _my_sps->getSP(propertyId, sp)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier does not exist");
-    amount = StrToInt64(strAmount, sp.isDivisible());
 
     // perform checks
-    if (0 >= amount) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (!isRangeOK(amount)) throw JSONRPCError(RPC_TYPE_ERROR, "Input not in range");
     if (fromAddress != sp.issuer) throw JSONRPCError(RPC_TYPE_ERROR, "Sender is not authorized to revoke tokens for this property");
     if (senderBalance < amount) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance");
     if (senderAvailableBalance < amount) throw JSONRPCError(RPC_TYPE_ERROR, "Sender has insufficient balance (due to pending transactions)");
@@ -673,8 +605,8 @@ Value sendclosecrowdsale_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = (params[0].get_str());
-    unsigned int propertyId = int64Touint32Safe(params[1].get_int64());
+    std::string fromAddress = ParseAddress(params[0]);
+    uint32_t propertyId = ParsePropertyId(params[1]);
 
     // perform conversions
     CMPSPInfo::Entry sp;
@@ -718,7 +650,7 @@ Value trade_MP(const Array& params, bool fHelp)
         );
 
     Array values;
-    uint8_t action = params[5].get_int64();
+    uint8_t action = ParseMetaDExAction(params[5]);
 
     // Forward to the new commands, based on action value
     switch (action) {
@@ -787,11 +719,11 @@ Value sendtrade_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    uint32_t propertyIdForSale = int64Touint32Safe(params[1].get_int64());
-    std::string strAmountForSale = params[2].get_str();
-    uint32_t propertyIdDesired = int64Touint32Safe(params[3].get_int64());
-    std::string strAmountDesired = params[4].get_str();
+    std::string fromAddress = ParseAddress(params[0]);
+    uint32_t propertyIdForSale = ParsePropertyId(params[1]);
+    int64_t amountForSale = ParseAmount(params[2], isPropertyDivisible(propertyIdForSale));
+    uint32_t propertyIdDesired = ParsePropertyId(params[3]);
+    int64_t amountDesired = ParseAmount(params[4], isPropertyDivisible(propertyIdDesired));
 
     CMPSPInfo::Entry spForSale;
     CMPSPInfo::Entry spDesired;
@@ -799,13 +731,6 @@ Value sendtrade_OMNI(const Array& params, bool fHelp)
     if (false == _my_sps->getSP(propertyIdDesired, spDesired)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property desired does not exist");
     if (isTestEcosystemProperty(propertyIdForSale) != isTestEcosystemProperty(propertyIdDesired)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be in the same ecosystem");
     if (propertyIdForSale == propertyIdDesired) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be different");
-
-    int64_t amountForSale = StrToInt64(strAmountForSale, spForSale.isDivisible());
-    int64_t amountDesired = StrToInt64(strAmountDesired, spDesired.isDivisible());
-    if (0 >= amountForSale) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for sale");
-    if (!isRangeOK(amountForSale)) throw JSONRPCError(RPC_TYPE_ERROR, "Amount for sale not in range");
-    if (0 >= amountDesired) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount desired");
-    if (!isRangeOK(amountDesired)) throw JSONRPCError(RPC_TYPE_ERROR, "Amount desired not in range");
 
     const int64_t senderBalance = getMPbalance(fromAddress, propertyIdForSale, BALANCE);
     const int64_t senderAvailableBalance = getUserAvailableMPbalance(fromAddress, propertyIdForSale);
@@ -854,11 +779,11 @@ Value sendcanceltradesbyprice_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    uint32_t propertyIdForSale = int64Touint32Safe(params[1].get_int64());
-    std::string strAmountForSale = params[2].get_str();
-    uint32_t propertyIdDesired = int64Touint32Safe(params[3].get_int64());
-    std::string strAmountDesired = params[4].get_str();
+    std::string fromAddress = ParseAddress(params[0]);
+    uint32_t propertyIdForSale = ParsePropertyId(params[1]);
+    int64_t amountForSale = ParseAmount(params[2], isPropertyDivisible(propertyIdForSale));
+    uint32_t propertyIdDesired = ParsePropertyId(params[3]);
+    int64_t amountDesired = ParseAmount(params[4], isPropertyDivisible(propertyIdDesired));
 
     CMPSPInfo::Entry spForSale;
     CMPSPInfo::Entry spDesired;
@@ -866,13 +791,6 @@ Value sendcanceltradesbyprice_OMNI(const Array& params, bool fHelp)
     if (false == _my_sps->getSP(propertyIdDesired, spDesired)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property desired does not exist");
     if (isTestEcosystemProperty(propertyIdForSale) != isTestEcosystemProperty(propertyIdDesired)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be in the same ecosystem");
     if (propertyIdForSale == propertyIdDesired) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be different");
-
-    int64_t amountForSale = StrToInt64(strAmountForSale, spForSale.isDivisible());
-    int64_t amountDesired = StrToInt64(strAmountDesired, spDesired.isDivisible());
-    if (0 >= amountForSale) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for sale");
-    if (!isRangeOK(amountForSale)) throw JSONRPCError(RPC_TYPE_ERROR, "Amount for sale not in range");
-    if (0 >= amountDesired) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount desired");
-    if (!isRangeOK(amountDesired)) throw JSONRPCError(RPC_TYPE_ERROR, "Amount desired not in range");
 
     // TODO: check, if there are matching offers to cancel
 
@@ -916,9 +834,9 @@ Value sendcanceltradesbypair_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    uint32_t propertyIdForSale = int64Touint32Safe(params[1].get_int64());
-    uint32_t propertyIdDesired = int64Touint32Safe(params[2].get_int64());
+    std::string fromAddress = ParseAddress(params[0]);
+    uint32_t propertyIdForSale = ParsePropertyId(params[1]);
+    uint32_t propertyIdDesired = ParsePropertyId(params[2]);
 
     CMPSPInfo::Entry spForSale;
     CMPSPInfo::Entry spDesired;
@@ -970,12 +888,8 @@ Value sendcancelalltrades_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = params[0].get_str();
-    uint8_t ecosystem = params[1].get_uint64();
-
-    if (OMNI_PROPERTY_TMSC < ecosystem) {
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid ecosystem");
-    }
+    std::string fromAddress = ParseAddress(params[0]);
+    uint8_t ecosystem = ParseEcosystem(params[1]);
 
     // TODO: check, if there are matching offers to cancel
 
@@ -1023,9 +937,9 @@ Value sendchangeissuer_OMNI(const Array& params, bool fHelp)
         );
 
     // obtain parameters & info
-    std::string fromAddress = (params[0].get_str());
-    std::string toAddress = (params[1].get_str());
-    unsigned int propertyId = int64Touint32Safe(params[2].get_int64());
+    std::string fromAddress = ParseAddress(params[0]);
+    std::string toAddress = ParseAddress(params[1]);
+    uint32_t propertyId = ParsePropertyId(params[2]);
 
     // perform conversions
     CMPSPInfo::Entry sp;

--- a/src/omnicore/rpcvalues.cpp
+++ b/src/omnicore/rpcvalues.cpp
@@ -1,0 +1,145 @@
+#include "omnicore/rpcvalues.h"
+
+#include "omnicore/parse_string.h"
+
+#include "base58.h"
+#include "rpcprotocol.h"
+
+#include "json/json_spirit_value.h"
+
+#include <string>
+
+using mastercore::StrToInt64;
+
+std::string ParseAddress(const json_spirit::Value& value)
+{
+    CBitcoinAddress address(value.get_str());
+    if (!address.IsValid()) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+    }
+    return address.ToString();
+}
+
+uint32_t ParsePropertyId(const json_spirit::Value& value)
+{
+    int64_t propertyId = value.get_int64();
+    if (propertyId < 1 || 4294967295 < propertyId) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier is out of range");
+    }
+    return static_cast<uint32_t>(propertyId);
+}
+
+int64_t ParseAmount(const json_spirit::Value& value, bool isDivisible)
+{
+    int64_t amount = mastercore::StrToInt64(value.get_str(), isDivisible);
+    if (amount < 1) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    }
+    return amount;
+}
+
+int64_t ParseAmount(const json_spirit::Value& value, int propertyType)
+{
+    bool fDivisible = (propertyType == 2);  // 1 = indivisible, 2 = divisible
+    return ParseAmount(value, fDivisible);
+}
+
+uint8_t ParseDExPaymentWindow(const json_spirit::Value& value)
+{
+    int64_t blocks = value.get_int64();
+    if (blocks < 1 || 255 < blocks) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Payment window must be within 1-255 blocks");
+    }
+    return static_cast<uint8_t>(blocks);
+}
+
+int64_t ParseDExFee(const json_spirit::Value& value)
+{
+    int64_t fee = StrToInt64(value.get_str(), true);  // BTC is divisible
+    if (fee < 0) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Mininmum accept fee must be positive");
+    }
+    return fee;
+}
+
+uint8_t ParseDExAction(const json_spirit::Value& value)
+{
+    int64_t action = value.get_int64();
+    if (action <= 0 || 3 < action) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid action (1 = new, 2 = update, 3 = cancel only)");
+    }
+    return static_cast<uint8_t>(action);
+}
+
+uint8_t ParseEcosystem(const json_spirit::Value& value)
+{
+    int64_t ecosystem = value.get_int64();
+    if (ecosystem < 1 || 2 < ecosystem) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid ecosystem (1 = main, 2 = test only)");
+    }
+    return static_cast<uint8_t>(ecosystem);
+}
+
+uint16_t ParsePropertyType(const json_spirit::Value& value)
+{
+    int64_t propertyType = value.get_int64();
+    if (propertyType < 1 || 2 < propertyType) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid property type (1 = indivisible, 2 = divisible only)");
+    }
+    return static_cast<uint16_t>(propertyType);
+}
+
+uint32_t ParsePreviousPropertyId(const json_spirit::Value& value)
+{
+    int64_t previousId = value.get_int64();
+    if (previousId != 0) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Property appends/replaces are not yet supported");
+    }
+    return static_cast<uint32_t>(previousId);
+}
+
+std::string ParseText(const json_spirit::Value& value)
+{
+    std::string text = value.get_str();
+    if (text.size() > 255) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Text must not be longer than 255 characters");
+    }
+    return text;
+}
+
+int64_t ParseDeadline(const json_spirit::Value& value)
+{
+    int64_t deadline = value.get_int64();
+    if (deadline < 0) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Deadline must be positive");
+    }
+    return deadline;
+}
+
+uint8_t ParseEarlyBirdBonus(const json_spirit::Value& value)
+{
+    int64_t percentage = value.get_int64();
+    if (percentage < 0 || 255 < percentage) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Early bird bonus must be in the range of 0-255 percent per week");
+    }
+    return static_cast<uint8_t>(percentage);
+}
+
+uint8_t ParseIssuerBonus(const json_spirit::Value& value)
+{
+    int64_t percentage = value.get_int64();
+    if (percentage < 0 || 255 < percentage) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Bonus for issuer must be in the range of 0-255 percent");
+    }
+    return static_cast<uint8_t>(percentage);
+}
+
+uint8_t ParseMetaDExAction(const json_spirit::Value& value)
+{
+    int64_t action = value.get_int64();
+    if (action <= 0 || 4 < action) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid action (1, 2, 3, 4 only)");
+    }
+    return static_cast<uint8_t>(action);
+}
+

--- a/src/omnicore/rpcvalues.h
+++ b/src/omnicore/rpcvalues.h
@@ -1,0 +1,26 @@
+#ifndef OMNICORE_RPCVALUES_H
+#define OMNICORE_RPCVALUES_H
+
+#include "json/json_spirit_value.h"
+
+#include <stdint.h>
+#include <string>
+
+std::string ParseAddress(const json_spirit::Value& value);
+uint32_t ParsePropertyId(const json_spirit::Value& value);
+int64_t ParseAmount(const json_spirit::Value& value, bool isDivisible);
+int64_t ParseAmount(const json_spirit::Value& value, int propertyType);
+uint8_t ParseDExPaymentWindow(const json_spirit::Value& value);
+int64_t ParseDExFee(const json_spirit::Value& value);
+uint8_t ParseDExAction(const json_spirit::Value& value);
+uint8_t ParseEcosystem(const json_spirit::Value& value);
+uint16_t ParsePropertyType(const json_spirit::Value& value);
+uint32_t ParsePreviousPropertyId(const json_spirit::Value& value);
+std::string ParseText(const json_spirit::Value& value);
+int64_t ParseDeadline(const json_spirit::Value& value);
+uint8_t ParseEarlyBirdBonus(const json_spirit::Value& value);
+uint8_t ParseIssuerBonus(const json_spirit::Value& value);
+uint8_t ParseMetaDExAction(const json_spirit::Value& value);
+
+
+#endif // OMNICORE_RPCVALUES_H


### PR DESCRIPTION
The idea is to have `ParseXYZ()` functions to convert user input, while respecting value ranges and other type requirements, which are universal and not state dependent (e.g. `ecosystem = 5` is always wrong), as well as `RequireCondition()` functions to check specific requirements, depending on the user action and state (e.g. `"there must be no other active DEx offering"`). If something is unexpected, then `JSONRPCError` are thrown.

Right now there are the following parsing functions:

 - `ParseAddress(const json_spirit::Value& value)`
 - `ParsePropertyId(const json_spirit::Value& value)`
 - `ParseAmount(const json_spirit::Value& value, bool isDivisible)`
 - `ParseAmount(const json_spirit::Value& value, int propertyType)`
 - `ParseDExPaymentWindow(const json_spirit::Value& value)`
 - `ParseDExFee(const json_spirit::Value& value)`
 - `ParseDExAction(const json_spirit::Value& value)`
 - `ParseEcosystem(const json_spirit::Value& value)`
 - `ParsePropertyType(const json_spirit::Value& value)`
 - `ParsePreviousPropertyId(const json_spirit::Value& value)`
 - `ParseText(const json_spirit::Value& value)`
 - `ParseDeadline(const json_spirit::Value& value)`
 - `ParseEarlyBirdBonus(const json_spirit::Value& value)`
 - `ParseIssuerBonus(const json_spirit::Value& value)`
 - `ParseMetaDExAction(const json_spirit::Value& value)`

And the following requirement checks:

 - `RequireEnoughBalance(const std::string address, uint32_t propertyId, int64_t amount)`
 - `RequireOnlyMSC(uint32_t propertyId)`
 - `RequireNonEmptyPropertyName(const std::string& name)`
 - `RequireExistingProperty(uint32_t propertyId)`
 - `RequireCrowdsale(uint32_t propertyId)`
 - `RequireActiveCrowdsale(uint32_t propertyId)`
 - `RequireManagedProperty(uint32_t propertyId)`
 - `RequireTokenIssuer(const std::string& address, uint32_t propertyId)`
 - `RequireMatchingDExOffer(const std::string& address, uint32_t propertyId)`
 - `RequireNoOtherDExOffer(const std::string& address, uint32_t propertyId)`
 - `RequireSaneReferenceAmount(int64_t amount)`
 - `RequireSaneDExPaymentWindow(const std::string& address, uint32_t propertyId)`
 - `RequireSaneDExFee(const std::string& address, uint32_t propertyId)`
 - `RequireHeightInChain(int blockHeight)`

It might appear to be an overkill, if there are many very specific checks, but I think it would be neat, if one could take a look at a few lines of code, and immediately get a very clear understanding of what's going on.

The error messages were adopted from the existing error messages, but ultimately I'd like to refine them, and also include the user input in the error message.

It does not update the RPC calls yet, because I'd like to discuss the names, and checks first. Do the names make sense? What might be added?