### PR TITLE
Move some STO parts into new STO file

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -14,6 +14,7 @@ OMNICORE_H = \
   omnicore/rpctx.h \
   omnicore/script.h \
   omnicore/sp.h \
+  omnicore/sto.h \
   omnicore/tx.h \
   omnicore/utils.h \
   omnicore/version.h
@@ -33,6 +34,7 @@ OMNICORE_CPP = \
   omnicore/rpctx.cpp \
   omnicore/script.cpp \
   omnicore/sp.cpp \
+  omnicore/sto.cpp \
   omnicore/tx.cpp \
   omnicore/utils.cpp \
   omnicore/version.cpp

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -25,7 +25,6 @@
 #include "omnicore/persistence.h"
 #include "omnicore/script.h"
 #include "omnicore/sp.h"
-#include "omnicore/sto.h"
 #include "omnicore/tx.h"
 #include "omnicore/utils.h"
 #include "omnicore/version.h"
@@ -3767,87 +3766,6 @@ int CMPTransaction::logicMath_SimpleSend()
             }
         }
     }
-
-    return 0;
-}
-
-int CMPTransaction::logicMath_SendToOwners()
-{
-    LOCK(cs_tally);
-
-    if (!isTransactionTypeAllowed(block, property, type, version)) {
-        return (PKT_ERROR_STO -22);
-    }
-
-    if (nValue <= 0 || MAX_INT_8_BYTES < nValue) {
-        return (PKT_ERROR_STO -23);
-    }
-
-    if (!_my_sps->hasSP(property)) {
-        return (PKT_ERROR_STO -24);
-    }
-
-    if (getMPbalance(sender, property, BALANCE) < (int64_t)nValue) {
-        return (PKT_ERROR_STO -25);
-    }
-
-    // ------------------------------------------
-
-    OwnerAddrType receiversSet = STO_GetReceivers(sender, property, nValue);
-    uint64_t numberOfReceivers = receiversSet.size();
-
-    // make sure we found some owners
-    if (numberOfReceivers <= 0) {
-        return (PKT_ERROR_STO -26);
-    }
-
-    // determine which property the fee will be paid in
-    uint32_t feeProperty = isTestEcosystemProperty(property) ? OMNI_PROPERTY_TMSC : OMNI_PROPERTY_MSC;
-
-    int64_t transferFee = TRANSFER_FEE_PER_OWNER * numberOfReceivers;
-    PrintToLog("\t    Transfer fee: %s %s\n", FormatDivisibleMP(transferFee), strMPProperty(feeProperty));
-
-    // enough coins to pay the fee?
-    if (feeProperty != property) {
-        if (getMPbalance(sender, feeProperty, BALANCE) < transferFee) {
-            return (PKT_ERROR_STO -27);
-        }
-    } else {
-        // special case check, only if distributing MSC or TMSC -- the property the fee will be paid in
-        if (getMPbalance(sender, feeProperty, BALANCE) < ((int64_t)nValue + transferFee)) {
-            return (PKT_ERROR_STO -28);
-        }
-    }
-
-    // ------------------------------------------
-
-    // burn MSC or TMSC here: take the transfer fee away from the sender
-    assert(update_tally_map(sender, feeProperty, -transferFee, BALANCE));
-
-    // split up what was taken and distribute between all holders
-    int64_t sent_so_far = 0;
-    for (OwnerAddrType::reverse_iterator it = receiversSet.rbegin(); it != receiversSet.rend(); ++it) {
-        const std::string& address = it->second;
-
-        int64_t will_really_receive = it->first;
-        sent_so_far += will_really_receive;
-
-        // real execution of the loop
-        assert(update_tally_map(sender, property, -will_really_receive, BALANCE));
-        assert(update_tally_map(address, property, will_really_receive, BALANCE));
-
-        // add to stodb
-        s_stolistdb->recordSTOReceive(address, txid, block, property, will_really_receive);
-
-        if (sent_so_far != (int64_t)nValue) {
-            PrintToLog("sent_so_far= %14d, nValue= %14d, n_owners= %d\n", sent_so_far, nValue, numberOfReceivers);
-        } else {
-            PrintToLog("SendToOwners: DONE HERE\n");
-        }
-    }
-
-    // sent_so_far must equal nValue here
-    assert(sent_so_far == (int64_t)nValue);
 
     return 0;
 }

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -278,17 +278,21 @@ public:
     return (money + so_r + a_r);
   }
 
-  int64_t getMoney(unsigned int which_property, TallyType ttype)
+  int64_t getMoney(unsigned int which_property, TallyType ttype) const
   {
-  int64_t ret64 = 0;
-
     if (TALLY_TYPE_COUNT <= ttype) return 0;
 
+    int64_t money = 0;
+
     LOCK(cs_tally);
+    TokenMap::const_iterator it = mp_token.find(which_property);
 
-    if (propertyExists(which_property)) ret64 = mp_token[which_property].balance[ttype];
+    if (it != mp_token.end()) {
+        const BalanceRecord& record = it->second;
+        money = record.balance[ttype];
+    }
 
-    return ret64;
+    return money;
   }
 };
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -46,9 +46,6 @@ int const MAX_STATE_HISTORY = 50;
 
 #define SP_STRING_FIELD_LEN 256
 
-// in Mastercoin Satoshis (Willetts)
-#define TRANSFER_FEE_PER_OWNER  (1)
-
 // some boost formats
 #define FORMAT_BOOST_TXINDEXKEY "index-tx-%s"
 #define FORMAT_BOOST_SPKEY      "sp-%d"

--- a/src/omnicore/sto.cpp
+++ b/src/omnicore/sto.cpp
@@ -1,0 +1,116 @@
+#include "omnicore/sto.h"
+
+#include "omnicore/log.h"
+#include "omnicore/omnicore.h"
+
+#include "sync.h"
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <assert.h>
+#include <stdint.h>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+
+using boost::multiprecision::int128_t;
+
+namespace mastercore
+{
+
+/**
+ * Compares two owner/receiver entries, based on amount.
+ */
+bool SendToOwners_compare::operator()(const std::pair<int64_t, std::string>& p1, const std::pair<int64_t, std::string>& p2) const
+{
+    if (p1.first == p2.first) return p1.second > p2.second; // reverse check
+    else return p1.first < p2.first;
+}
+
+/**
+ * Determines the receivers and amounts to distribute.
+ *
+ * The sender is excluded from the result set.
+ */
+OwnerAddrType STO_GetReceivers(const std::string& sender, uint32_t property, int64_t amount)
+{
+    int64_t totalTokens = 0;
+    int64_t senderTokens = 0;
+    OwnerAddrType ownerAddrSet;
+
+    {
+        LOCK(cs_tally);
+        std::map<std::string, CMPTally>::reverse_iterator it;
+
+        for (it = mp_tally_map.rbegin(); it != mp_tally_map.rend(); ++it) {
+            const std::string& address = it->first;
+            const CMPTally& tally = it->second;
+
+            int64_t tokens = 0;
+            tokens += tally.getMoney(property, BALANCE);
+            tokens += tally.getMoney(property, SELLOFFER_RESERVE);
+            tokens += tally.getMoney(property, ACCEPT_RESERVE);
+            tokens += tally.getMoney(property, METADEX_RESERVE);
+
+            // Do not include the sender
+            if (address == sender) {
+                senderTokens = tokens;
+                continue;
+            }
+
+            totalTokens += tokens;
+
+            // Only holders with balance are relevant
+            if (0 < tokens) {
+                ownerAddrSet.insert(std::make_pair(tokens, address));
+            }
+        }
+    }
+
+    // Split up what was taken and distribute between all holders
+    int64_t sent_so_far = 0;
+    OwnerAddrType receiversSet;
+
+    for (OwnerAddrType::reverse_iterator it = ownerAddrSet.rbegin(); it != ownerAddrSet.rend(); ++it) {
+        const std::string& address = it->second;
+
+        int128_t owns = int128_t(it->first);
+        int128_t temp = owns * int128_t(amount);
+        int128_t piece = 1 + ((temp - 1) / int128_t(totalTokens));
+
+        int64_t will_really_receive = 0;
+        int64_t should_receive = piece.convert_to<int64_t>();
+
+        // Ensure that no more than available is distributed
+        if ((amount - sent_so_far) < should_receive) {
+            will_really_receive = amount - sent_so_far;
+        } else {
+            will_really_receive = should_receive;
+        }
+
+        sent_so_far += will_really_receive;
+
+        if (msc_debug_sto) {
+            PrintToLog("%14d = %s, temp= %38s, should_get= %19d, will_really_get= %14d, sent_so_far= %14d\n",
+                owns, address, temp.str(), should_receive, will_really_receive, sent_so_far);
+        }
+
+        // Stop, once the whole amount is allocated
+        if (will_really_receive > 0) {
+            receiversSet.insert(std::make_pair(will_really_receive, address));
+        } else {
+            break;
+        }
+    }
+
+    uint64_t numberOfOwners = receiversSet.size();
+    PrintToLog("\t    Total Tokens: %s\n", FormatMP(property, totalTokens + senderTokens));
+    PrintToLog("\tExcluding Sender: %s\n", FormatMP(property, totalTokens));
+    PrintToLog("\t          Owners: %d\n", numberOfOwners);
+
+    return receiversSet;
+}
+
+} // namespace mastercore
+

--- a/src/omnicore/sto.h
+++ b/src/omnicore/sto.h
@@ -1,0 +1,28 @@
+#ifndef OMNICORE_STO_H
+#define OMNICORE_STO_H
+
+#include <stdint.h>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace mastercore
+{
+//! Comparator for owner/receiver entries
+struct SendToOwners_compare
+{
+    bool operator()(const std::pair<int64_t, std::string>& p1, const std::pair<int64_t, std::string>& p2) const;
+};
+
+//! Fee required to be paid per owner/receiver, nominated in willets
+const int64_t TRANSFER_FEE_PER_OWNER = 1;
+
+//! Set of owner/receivers, sorted by amount they own or might receive
+typedef std::set<std::pair<int64_t, std::string>, SendToOwners_compare> OwnerAddrType;
+
+/** Determines the receivers and amounts to distribute. */
+OwnerAddrType STO_GetReceivers(const std::string& sender, uint32_t property, int64_t amount);
+}
+
+
+#endif // OMNICORE_STO_H


### PR DESCRIPTION
The restructuring allows to check, whether a "send to owners" transaction is valid, before really executing the transaction.

The new function `STO_GetReceivers()` might further be used as basis for a BTC based STO, since it's now easy to determine owners/receivers.

Given that "send to owners" is fully covered by tests, the move can be considered as safe.