### PR TITLE
RPC, test, and test coverage related updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,12 +88,16 @@ qrc_*.cpp
 # Qt creator
 *.pro.user
 
+# NetBeans
+nbproject/
+
 # Mac specific
 .DS_Store
 build
 
 #lcov
 *.gcno
+*.gcda
 /*.info
 test_bitcoin.coverage/
 total.coverage/
@@ -107,6 +111,7 @@ qa/pull-tester/run-bitcoind-for-test.sh
 qa/pull-tester/tests-config.sh
 qa/pull-tester/cache/*
 qa/pull-tester/test.*/*
+qa/tmp
 
 !src/leveldb*/Makefile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ env:
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
     - SDK_URL=https://s3.amazonaws.com/ci.omnicore.private/depends-sources/sdks
     - WINEDEBUG=fixme-all
-    - RUN_SPOCK_TESTS=false
-    - SPOCK_TEST_URL=https://github.com/OmniLayer/OmniJ.git
+    - RUN_OMNIJ_TESTS=false
 sudo: false
 cache:
   ccache: true
@@ -36,7 +35,7 @@ matrix:
           packages:
             - bc
     - compiler: ": 64-bit"
-      env: HOST=x86_64-unknown-linux-gnu RUN_SPOCK_TESTS=true RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
+      env: HOST=x86_64-unknown-linux-gnu RUN_OMNIJ_TESTS=true RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
     - compiler: ": Win64"
       env: HOST=x86_64-w64-mingw32 GOAL="install" BITCOIN_CONFIG="--enable-gui" MAKEJOBS="-j2"
       addons:
@@ -99,12 +98,4 @@ script:
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ]; then make check; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.sh; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then DATADIR=/tmp/datadir-$HOST; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then mkdir -p $DATADIR; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then $OUTDIR/bin/bitcoind -datadir="$DATADIR" -regtest -txindex -server -daemon -rpcuser=bitcoinrpc -rpcpassword=pass -discover=0 -listen=0; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then git clone $SPOCK_TEST_URL qa/omnicore-rpc-tests; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then cd qa/omnicore-rpc-tests; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then $OUTDIR/bin/bitcoin-cli -datadir="$DATADIR" -rpcuser=bitcoinrpc -rpcpassword=pass -regtest -rpcwait getinfo; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then $OUTDIR/bin/bitcoin-cli -datadir="$DATADIR" -rpcuser=bitcoinrpc -rpcpassword=pass -regtest -rpcwait getinfo_MP; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then ./gradlew --console plain :omnij-rpc:regTest; fi
-    - if [ "$RUN_SPOCK_TESTS" = "true" ]; then $OUTDIR/bin/bitcoin-cli -datadir="$DATADIR" -rpcuser=bitcoinrpc -rpcpassword=pass -regtest -rpcwait stop; fi
+    - if [ "$RUN_OMNIJ_TESTS" = "true" ]; then qa/pull-tester/omnicore-rpc-tests.sh; fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ OSX_PACKAGING = $(OSX_DEPLOY_SCRIPT) $(OSX_FANCY_PLIST) $(OSX_INSTALLER_ICONS) \
 
 COVERAGE_INFO = baseline_filtered_combined.info baseline.info block_test.info \
   leveldb_baseline.info test_bitcoin_filtered.info total_coverage.info \
-  baseline_filtered.info block_test_filtered.info \
+  baseline_filtered.info block_test_filtered.info omnicore_test.info omnicore_test_filtered.info \
   leveldb_baseline_filtered.info test_bitcoin_coverage.info test_bitcoin.info
 
 dist-hook:
@@ -167,11 +167,20 @@ block_test.info: test_bitcoin_filtered.info
 block_test_filtered.info: block_test.info
 	$(LCOV) -r $< "/usr/include/*" -o $@
 
+omnicore_test.info: test_bitcoin_filtered.info
+	-@TIMEOUT=15 qa/pull-tester/omnicore-rpc-tests.sh
+	$(LCOV) -c -d $(abs_builddir)/src --t OmniCoreRPCTest -o $@
+	$(LCOV) -z -d $(abs_builddir)/src
+	$(LCOV) -z -d $(abs_builddir)/src/leveldb
+
+omnicore_test_filtered.info: omnicore_test.info
+	$(LCOV) -r $< "/usr/include/*" -o $@
+
 test_bitcoin_coverage.info: baseline_filtered_combined.info test_bitcoin_filtered.info
 	$(LCOV) -a baseline_filtered.info -a leveldb_baseline_filtered.info -a test_bitcoin_filtered.info -o $@
 
-total_coverage.info:  baseline_filtered_combined.info test_bitcoin_filtered.info block_test_filtered.info
-	$(LCOV) -a baseline_filtered.info -a leveldb_baseline_filtered.info -a test_bitcoin_filtered.info -a block_test_filtered.info -o $@ | $(GREP) "\%" | $(AWK) '{ print substr($$3,2,50) "/" $$5 }' > coverage_percent.txt
+total_coverage.info:  baseline_filtered_combined.info test_bitcoin_filtered.info block_test_filtered.info omnicore_test_filtered.info
+	$(LCOV) -a baseline_filtered.info -a leveldb_baseline_filtered.info -a test_bitcoin_filtered.info -a block_test_filtered.info -a omnicore_test_filtered.info -o $@ | $(GREP) "\%" | $(AWK) '{ print substr($$3,2,50) "/" $$5 }' > coverage_percent.txt
 
 test_bitcoin.coverage/.dirstamp:  test_bitcoin_coverage.info
 	$(GENHTML) -s $< -o $(@D)

--- a/Makefile.am
+++ b/Makefile.am
@@ -198,4 +198,4 @@ CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
 .INTERMEDIATE: $(COVERAGE_INFO)
 
 clean-local:
-	rm -rf test_bitcoin.coverage/ total.coverage/ $(OSX_APP)
+	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ qa/tmp $(OSX_APP)

--- a/Makefile.am
+++ b/Makefile.am
@@ -191,7 +191,7 @@ check-local:
 	@qa/pull-tester/run-bitcoind-for-test.sh $(JAVA) -jar $(JAVA_COMPARISON_TOOL) qa/tmp/compTool $(COMPARISON_TOOL_REORG_TESTS) 2>&1
 endif
 
-EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.sh qa/pull-tester/run-bitcoin-cli qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING)
+EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.sh qa/pull-tester/omnicore-rpc-tests.sh qa/pull-tester/run-bitcoin-cli qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING)
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
 

--- a/qa/pull-tester/omnicore-rpc-tests.sh
+++ b/qa/pull-tester/omnicore-rpc-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Get BUILDDIR and REAL_BITCOIND
+CURDIR=$(cd $(dirname "$0"); pwd)
+. "${CURDIR}/tests-config.sh"
+
+TESTDIR="$BUILDDIR/qa/tmp/omnicore-rpc-tests"
+DATADIR="$TESTDIR/.bitcoin"
+
+# Start clean
+rm -rf "$TESTDIR"
+
+git clone https://github.com/OmniLayer/OmniJ.git $TESTDIR
+mkdir -p "$DATADIR/regtest"
+touch "$DATADIR/regtest/omnicore.log"
+cd $TESTDIR
+echo "Omni Core RPC test dir: "$TESTDIR
+echo "Last OmniJ commit: "$(git log -n 1 --format="%H Author: %cn <%ce>")
+$REAL_BITCOIND -regtest -txindex -server -daemon -rpcuser=bitcoinrpc -rpcpassword=pass -discover=0 -listen=0 -datadir="$DATADIR"
+$REAL_BITCOINCLI -regtest -rpcuser=bitcoinrpc -rpcpassword=pass -rpcwait getinfo
+$REAL_BITCOINCLI -regtest -rpcuser=bitcoinrpc -rpcpassword=pass -rpcwait getinfo_MP
+./gradlew --console plain :omnij-rpc:regTest
+STATUS=$?
+$REAL_BITCOINCLI -regtest -rpcuser=bitcoinrpc -rpcpassword=pass -rpcwait stop
+
+# If $STATUS is not 0, the test failed.
+if [ $STATUS -ne 0 ]; then tail -n 200 $DATADIR/regtest/omnicore.log; fi
+
+
+exit $STATUS

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -385,7 +385,13 @@ libbitcoinconsensus_la_LIBADD += secp256k1/libsecp256k1.la
 endif
 endif
 
-CLEANFILES = leveldb/libleveldb.a leveldb/libmemenv.a *.gcda *.gcno
+CLEANFILES = leveldb/libleveldb.a leveldb/libmemenv.a
+CLEANFILES += *.gcda *.gcno
+CLEANFILES += compat/*.gcda compat/*.gcno
+CLEANFILES += crypto/*.gcda crypto/*.gcno
+CLEANFILES += primitives/*.gcda primitives/*.gcno
+CLEANFILES += script/*.gcda script/*.gcno
+CLEANFILES += univalue/*.gcda univalue/*.gcno
 
 DISTCLEANFILES = obj/build.h
 
@@ -394,7 +400,7 @@ EXTRA_DIST = leveldb
 clean-local:
 	-$(MAKE) -C leveldb clean
 	-$(MAKE) -C secp256k1 clean
-	rm -f leveldb/*/*.gcno leveldb/helpers/memenv/*.gcno
+	rm -f leveldb/*/*.gcda leveldb/*/*.gcno leveldb/helpers/memenv/*.gcda leveldb/helpers/memenv/*.gcno
 	-rm -f config.h
 
 .rc.o:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -256,10 +256,6 @@ libbitcoin_common_a_SOURCES = \
   script/script_error.cpp \
   $(BITCOIN_CORE_H)
 
-# Omni Core
-include Makefile.omnicore.include
-#
-
 # util: shared between all executables.
 # This library *must* be included to make sure that the glibc
 # backward-compatibility objects and their sanity checks are linked.
@@ -426,3 +422,7 @@ endif
 if ENABLE_QT_TESTS
 include Makefile.qttest.include
 endif
+
+# Omni Core
+include Makefile.omnicore.include
+#

--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -48,3 +48,11 @@ libbitcoin_server_a_SOURCES += \
   $(OMNICORE_H)
 
 omnicore/libbitcoin_server_a-version.$(OBJEXT): obj/build.h # build info
+
+CLEAN_OMNICORE = omnicore/*.gcda omnicore/*.gcno
+
+CLEANFILES += $(CLEAN_OMNICORE)
+
+if ENABLE_TESTS
+include Makefile.omnitest.include
+endif

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -5,6 +5,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/encoding_c_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
+  omnicore/test/rpc_value_tests.cpp \
   omnicore/test/script_dust_tests.cpp \
   omnicore/test/script_extraction_tests.cpp \
   omnicore/test/script_solver_tests.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -14,3 +14,7 @@ OMNICORE_TEST_CPP = \
 BITCOIN_TESTS += \
   $(OMNICORE_TEST_CPP) \
   $(OMNICORE_TEST_H)
+
+CLEAN_OMNICORE_TEST = omnicore/test/*.gcda omnicore/test/*.gcno
+
+CLEANFILES += $(CLEAN_OMNICORE_TEST)

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -5,6 +5,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/encoding_c_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
+  omnicore/test/rpc_requirements_tests.cpp \
   omnicore/test/rpc_value_tests.cpp \
   omnicore/test/script_dust_tests.cpp \
   omnicore/test/script_extraction_tests.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -2,6 +2,7 @@ OMNICORE_TEST_H =
 
 OMNICORE_TEST_CPP = \
   omnicore/test/create_payload_tests.cpp \
+  omnicore/test/encoding_b_tests.cpp \
   omnicore/test/encoding_c_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -80,10 +80,6 @@ BITCOIN_TESTS += \
   test/rpc_wallet_tests.cpp
 endif
 
-# Omni Core tests
-include Makefile.omnitest.include
-#
-
 test_test_bitcoin_SOURCES = $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)
 test_test_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) -I$(builddir)/test/ $(TESTDEFS)
 test_test_bitcoin_LDADD = $(LIBBITCOIN_SERVER) $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CRYPTO) $(LIBBITCOIN_UNIVALUE) $(LIBLEVELDB) $(LIBMEMENV) \

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -250,6 +250,11 @@ inline bool RegTest()
     return Params().NetworkIDString() == "regtest";
 }
 
+inline bool UnitTest()
+{
+    return Params().NetworkIDString() == "unittest";
+}
+
 string FormatPriceMP(double n)
 {
   string str = strprintf("%lf", n);
@@ -2133,7 +2138,7 @@ int mastercore_init()
   InitDebugLogLevels();
   ShrinkDebugLog();
 
-  if (isNonMainNet())
+  if (isNonMainNet() && !UnitTest())
   {
     exodus_address = exodus_testnet;
   }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2994,7 +2994,7 @@ unsigned int n_found = 0;
     }
   }
 
-  PrintToConsole("%s(%d, %d); n_found= %d\n", __FUNCTION__, starting_block, ending_block, n_found);
+  PrintToLog("%s(%d, %d); n_found= %d\n", __FUNCTION__, starting_block, ending_block, n_found);
 
   delete it;
 
@@ -3243,7 +3243,7 @@ int CMPSTOList::deleteAboveBlock(int blockNum)
     }
   }
 
-  PrintToConsole("%s(%d); stodb n_found= %d\n", __FUNCTION__, blockNum, n_found);
+  PrintToLog("%s(%d); stodb n_found= %d\n", __FUNCTION__, blockNum, n_found);
 
   delete it;
 
@@ -3385,7 +3385,7 @@ int CMPTradeList::deleteAboveBlock(int blockNum)
     }
   }
 
-  PrintToConsole("%s(%d); tradedb n_found= %d\n", __FUNCTION__, blockNum, n_found);
+  PrintToLog("%s(%d); tradedb n_found= %d\n", __FUNCTION__, blockNum, n_found);
 
   delete it;
 

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -45,6 +45,20 @@ void RequireExistingProperty(uint32_t propertyId)
     }
 }
 
+void RequireSameEcosystem(uint32_t propertyId, uint32_t otherId)
+{
+    if (mastercore::isTestEcosystemProperty(propertyId) != mastercore::isTestEcosystemProperty(otherId)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Properties must be in the same ecosystem");
+    }
+}
+
+void RequireDifferentIds(uint32_t propertyId, uint32_t otherId)
+{
+    if (propertyId == otherId) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifiers must not be the same");
+    }
+}
+
 void RequireCrowdsale(uint32_t propertyId)
 {
     CMPSPInfo::Entry sp;

--- a/src/omnicore/rpcrequirements.h
+++ b/src/omnicore/rpcrequirements.h
@@ -8,6 +8,8 @@ void RequireBalance(const std::string& address, uint32_t propertyId, int64_t amo
 void RequirePrimaryToken(uint32_t propertyId);
 void RequirePropertyName(const std::string& name);
 void RequireExistingProperty(uint32_t propertyId);
+void RequireSameEcosystem(uint32_t propertyId, uint32_t otherId);
+void RequireDifferentIds(uint32_t propertyId, uint32_t otherId);
 void RequireCrowdsale(uint32_t propertyId);
 void RequireActiveCrowdsale(uint32_t propertyId);
 void RequireManagedProperty(uint32_t propertyId);

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -65,7 +65,7 @@ Value send_OMNI(const Array& params, bool fHelp)
     std::string toAddress = ParseAddress(params[1]);
     uint32_t propertyId = ParsePropertyId(params[2]);
     int64_t amount = ParseAmount(params[3], isPropertyDivisible(propertyId));
-    std::string redeemAddress = (params.size() > 4) ? ParseAddress(params[4]): "";
+    std::string redeemAddress = (params.size() > 4 && !ParseText(params[4]).empty()) ? ParseAddress(params[4]): "";
     int64_t referenceAmount = (params.size() > 5) ? ParseAmount(params[5], true): 0;
 
     // perform checks
@@ -451,7 +451,7 @@ Value sendsto_OMNI(const Array& params, bool fHelp)
     std::string fromAddress = ParseAddress(params[0]);
     uint32_t propertyId = ParsePropertyId(params[1]);
     int64_t amount = ParseAmount(params[2], isPropertyDivisible(propertyId));
-    std::string redeemAddress = (params.size() > 3) ? ParseAddress(params[3]): "";
+    std::string redeemAddress = (params.size() > 3 && !ParseText(params[3]).empty()) ? ParseAddress(params[3]): "";
 
     // perform checks
     RequireBalance(fromAddress, propertyId, amount);
@@ -499,7 +499,7 @@ Value sendgrant_OMNI(const Array& params, bool fHelp)
 
     // obtain parameters & info
     std::string fromAddress = ParseAddress(params[0]);
-    std::string toAddress = ParseText(params[1]).size() ? ParseAddress(params[1]): "";
+    std::string toAddress = !ParseText(params[1]).empty() ? ParseAddress(params[1]): "";
     uint32_t propertyId = ParsePropertyId(params[2]);
     int64_t amount = ParseAmount(params[3], isPropertyDivisible(propertyId));
     std::string memo = (params.size() > 4) ? ParseText(params[4]): "";
@@ -870,7 +870,7 @@ Value sendcancelalltrades_OMNI(const Array& params, bool fHelp)
 
     // obtain parameters & info
     std::string fromAddress = ParseAddress(params[0]);
-    uint8_t ecosystem = ParseEcosystem(params[1]);
+    uint8_t ecosystem = (params[1].get_int() != 0) ? ParseEcosystem(params[1]): 0;
 
     // perform checks
     // TODO: check, if there are matching offers to cancel

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -719,8 +719,8 @@ Value sendtrade_OMNI(const Array& params, bool fHelp)
     RequireExistingProperty(propertyIdForSale);
     RequireExistingProperty(propertyIdDesired);
     RequireBalance(fromAddress, propertyIdForSale, amountForSale);
-    if (isTestEcosystemProperty(propertyIdForSale) != isTestEcosystemProperty(propertyIdDesired)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be in the same ecosystem");
-    if (propertyIdForSale == propertyIdDesired) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be different");
+    RequireSameEcosystem(propertyIdForSale, propertyIdDesired);
+    RequireDifferentIds(propertyIdForSale, propertyIdDesired);
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExTrade(propertyIdForSale, amountForSale, propertyIdDesired, amountDesired);
@@ -773,8 +773,8 @@ Value sendcanceltradesbyprice_OMNI(const Array& params, bool fHelp)
     // perform checks
     RequireExistingProperty(propertyIdForSale);
     RequireExistingProperty(propertyIdDesired);
-    if (isTestEcosystemProperty(propertyIdForSale) != isTestEcosystemProperty(propertyIdDesired)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be in the same ecosystem");
-    if (propertyIdForSale == propertyIdDesired) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be different");
+    RequireSameEcosystem(propertyIdForSale, propertyIdDesired);
+    RequireDifferentIds(propertyIdForSale, propertyIdDesired);
     // TODO: check, if there are matching offers to cancel
 
     // create a payload for the transaction
@@ -824,8 +824,8 @@ Value sendcanceltradesbypair_OMNI(const Array& params, bool fHelp)
     // perform checks
     RequireExistingProperty(propertyIdForSale);
     RequireExistingProperty(propertyIdDesired);
-    if (isTestEcosystemProperty(propertyIdForSale) != isTestEcosystemProperty(propertyIdDesired)) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be in the same ecosystem");
-    if (propertyIdForSale == propertyIdDesired) throw JSONRPCError(RPC_INVALID_PARAMETER, "Property for sale and property desired must be different");
+    RequireSameEcosystem(propertyIdForSale, propertyIdDesired);
+    RequireDifferentIds(propertyIdForSale, propertyIdDesired);
     // TODO: check, if there are matching offers to cancel
 
     // create a payload for the transaction

--- a/src/omnicore/test/encoding_b_tests.cpp
+++ b/src/omnicore/test/encoding_b_tests.cpp
@@ -1,0 +1,185 @@
+#include "omnicore/encoding.h"
+
+#include "omnicore/script.h"
+
+#include "base58.h"
+#include "pubkey.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(omnicore_encoding_b_tests)
+
+BOOST_AUTO_TEST_CASE(class_b_empty)
+{
+    const std::string strSeed;
+    const CPubKey pubKey;
+    const std::vector<unsigned char> vchPayload;
+
+    std::vector<std::pair<CScript, int64_t> > vTxOuts;
+    BOOST_CHECK(OmniCore_Encode_ClassB(strSeed, pubKey, vchPayload, vTxOuts));
+    BOOST_CHECK_EQUAL(vTxOuts.size(), 1);
+
+    const CScript& scriptPubKey = vTxOuts[0].first;
+    CTxDestination dest;
+    BOOST_CHECK(ExtractDestination(scriptPubKey, dest));
+    BOOST_CHECK_EQUAL(CBitcoinAddress(dest).ToString(), "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
+}
+
+BOOST_AUTO_TEST_CASE(class_b_maidsafe)
+{
+    // Transaction hash (mainnet):
+    // 86f214055a7f4f5057922fd1647e00ef31ab0a3ff15217f8b90e295f051873a7
+    const std::string strSeed("1ARjWDkZ7kT9fwjPrjcQyvbXDkEySzKHwu");
+
+    const std::vector<unsigned char> vchPubKey = ParseHex(
+        "02619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf");
+
+    const CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
+
+    const std::vector<unsigned char> vchPayload = ParseHex(
+        // Transaction version: 0
+        "0000"
+        // Transaction type: Create Crowdsale (51)
+        "0033"
+        // Eco system: Main (1)
+        "01"
+        // Property type: Indivisible tokens (1)
+        "0001"
+        // Previous property identifier: None (0)
+        "00000000"
+        // Category: "Crowdsale"
+        "43726f776473616c6500"
+        // Sub category: "MaidSafe"
+        "4d6169645361666500"
+        // Property name: "MaidSafeCoin"
+        "4d61696453616665436f696e00"
+        // URL: "www.buysafecoins.com"
+        "7777772e62757973616665636f696e732e636f6d00"
+        // Information: "SAFE Network Crowdsale (MSAFE)"
+        "53414645204e6574776f726b2043726f776473616c6520284d534146452900"
+        // Desired property: Mastercoin (SP #1)
+        "00000001"
+        // Amount per unit invested: 3400
+        "0000000000000d48"
+        // Deadline: Thu, 22 May 2014 09:00:00 UTC (1400749200)
+        "00000000537dbc90"
+        // Early bird bonus: 10 % per week
+        "0a"
+        // Percentage for issuer: 0 %
+        "00");
+
+    std::vector<std::pair<CScript, int64_t> > vTxOuts;
+    BOOST_CHECK(OmniCore_Encode_ClassB(strSeed, pubKey, vchPayload, vTxOuts));
+    BOOST_CHECK_EQUAL(vTxOuts.size(), 3);
+
+    const CScript& scriptPubKeyA = vTxOuts[0].first;
+    const CScript& scriptPubKeyB = vTxOuts[1].first;
+    const CScript& scriptPubKeyC = vTxOuts[2].first;
+
+    txnouttype outtypeA;
+    BOOST_CHECK(GetOutputType(scriptPubKeyA, outtypeA));
+    BOOST_CHECK_EQUAL(outtypeA, TX_MULTISIG);
+    txnouttype outtypeB;
+    BOOST_CHECK(GetOutputType(scriptPubKeyB, outtypeB));
+    BOOST_CHECK_EQUAL(outtypeB, TX_MULTISIG);
+    txnouttype outtypeC;
+    BOOST_CHECK(GetOutputType(scriptPubKeyC, outtypeC));
+    BOOST_CHECK_EQUAL(outtypeC, TX_PUBKEYHASH);
+
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(scriptPubKeyA, vstrSolutions));
+    BOOST_CHECK(GetScriptPushes(scriptPubKeyB, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 6);
+
+    // Vout 0
+    BOOST_CHECK_EQUAL(vstrSolutions[0],
+            "02619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf");
+    BOOST_CHECK_EQUAL(vstrSolutions[1].substr(2, 62), // Remove prefix ...
+            "6766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a9");
+    BOOST_CHECK_EQUAL(vstrSolutions[2].substr(2, 62), // ... and ECDSA byte
+            "959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da2");
+    // Vout 1
+    BOOST_CHECK_EQUAL(vstrSolutions[3],
+            "02619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf");
+    BOOST_CHECK_EQUAL(vstrSolutions[4].substr(2, 62), // Because these ...
+            "61a017029ec4688ec9bf33c44ad2e595f83aaf3ed4f3032d1955715f5ffaf6");
+    BOOST_CHECK_EQUAL(vstrSolutions[5].substr(2, 62), // ... are semi-random
+            "dc1a0afc933d703557d9f5e86423a5cec9fee4bfa850b3d02ceae721171788");
+}
+
+BOOST_AUTO_TEST_CASE(class_b_tetherus)
+{
+    // Transaction hash (mainnet):
+    // 5ed3694e8a4fa8d3ec5c75eb6789492c69e65511522b220e94ab51da2b6dd53f
+    const std::string strSeed("3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL");
+
+    const std::vector<unsigned char> vchPubKey = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+
+    const CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
+
+    const std::vector<unsigned char> vchPayload = ParseHex(
+        "000000360100020000000046696e616e6369616c20616e6420696e737572"
+        "616e63652061637469766974696573004163746976697469657320617578"
+        "696c6961727920746f2066696e616e6369616c207365727669636520616e"
+        "6420696e737572616e636520616374697669746965730054657468657255"
+        "530068747470733a2f2f7465746865722e746f00546865206e6578742070"
+        "6172616469676d206f66206d6f6e65792e00");
+
+    std::vector<std::pair<CScript, int64_t> > vTxOuts;
+    BOOST_CHECK(OmniCore_Encode_ClassB(strSeed, pubKey, vchPayload, vTxOuts));
+    BOOST_CHECK_EQUAL(vTxOuts.size(), 4);
+
+    const CScript& scriptPubKeyA = vTxOuts[0].first;
+    const CScript& scriptPubKeyB = vTxOuts[1].first;
+    const CScript& scriptPubKeyC = vTxOuts[2].first;
+    const CScript& scriptPubKeyD = vTxOuts[3].first;
+
+    txnouttype outtypeA;
+    BOOST_CHECK(GetOutputType(scriptPubKeyA, outtypeA));
+    BOOST_CHECK_EQUAL(outtypeA, TX_MULTISIG);
+    txnouttype outtypeB;
+    BOOST_CHECK(GetOutputType(scriptPubKeyB, outtypeB));
+    BOOST_CHECK_EQUAL(outtypeB, TX_MULTISIG);
+    txnouttype outtypeC;
+    BOOST_CHECK(GetOutputType(scriptPubKeyC, outtypeC));
+    BOOST_CHECK_EQUAL(outtypeC, TX_MULTISIG);
+    txnouttype outtypeD;
+    BOOST_CHECK(GetOutputType(scriptPubKeyD, outtypeD));
+    BOOST_CHECK_EQUAL(outtypeD, TX_PUBKEYHASH);
+
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(scriptPubKeyA, vstrSolutions));
+    BOOST_CHECK(GetScriptPushes(scriptPubKeyB, vstrSolutions));
+    BOOST_CHECK(GetScriptPushes(scriptPubKeyC, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 9);
+
+    // Vout 0
+    BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(pubKey.begin(), pubKey.end()));
+    BOOST_CHECK_EQUAL(vstrSolutions[1].substr(2, 62),
+            "f88f01791557f6d57e6b7ddf86d2de2117e6cc4ba325a4e309d4a1a55015d7");
+    BOOST_CHECK_EQUAL(vstrSolutions[2].substr(2, 62),
+            "a94f47f4c3b8c36876399f19ecd61cf452248330fa5da9a1947d6dc7a189a1");
+    // Vout 1
+    BOOST_CHECK_EQUAL(vstrSolutions[3], HexStr(pubKey.begin(), pubKey.end()));
+    BOOST_CHECK_EQUAL(vstrSolutions[4].substr(2, 62),
+            "6d7e7235fc2c6769e351196c9ccdc4c804184b5bb9b210f27d3f0a613654fe");
+    BOOST_CHECK_EQUAL(vstrSolutions[5].substr(2, 62),
+            "8991cff7cc6d93c266615d2a9223cef4d7b11c05c16b0cec12a90ee7b39cf8");
+    // Vout 2
+    BOOST_CHECK_EQUAL(vstrSolutions[6], HexStr(pubKey.begin(), pubKey.end()));
+    BOOST_CHECK_EQUAL(vstrSolutions[7].substr(2, 62),
+            "29b3e0919adc41a316aad4f41444d9bf3a9b639550f2aa735676ffff25ba38");
+    BOOST_CHECK_EQUAL(vstrSolutions[8].substr(2, 62),
+            "f15446771c5c585dd25d8d62df5195b77799aa8eac2f2196c54b73ca05f72f");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/rpc_requirements_tests.cpp
+++ b/src/omnicore/test/rpc_requirements_tests.cpp
@@ -1,0 +1,63 @@
+#include "omnicore/rpcrequirements.h"
+
+#include "json/json_spirit_value.h"
+
+#include <stdint.h>
+#include <limits>
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+using json_spirit::Object;
+
+BOOST_AUTO_TEST_SUITE(omnicore_rpc_requirements_tests)
+
+BOOST_AUTO_TEST_CASE(rpcrequirements_universal)
+{
+    // The following checks should not fail, even with blank state and no previous
+    // transactions.
+    BOOST_CHECK_NO_THROW(RequireBalance("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P", 1, 0));
+    BOOST_CHECK_NO_THROW(RequirePrimaryToken(1));
+    BOOST_CHECK_NO_THROW(RequirePrimaryToken(2));
+    BOOST_CHECK_NO_THROW(RequirePropertyName("TestTokens"));
+    BOOST_CHECK_NO_THROW(RequireExistingProperty(1));
+    BOOST_CHECK_NO_THROW(RequireExistingProperty(2));
+    BOOST_CHECK_NO_THROW(RequireNoOtherDExOffer("137uFtQ5EgMsreg4FVvL3xuhjkYGToVPqs", 1));
+    BOOST_CHECK_NO_THROW(RequireNoOtherDExOffer("332r9K9t581aGVyzMK8uoPQr7ieH26u6J3", 2));
+    BOOST_CHECK_NO_THROW(RequireSaneReferenceAmount(0));
+    BOOST_CHECK_NO_THROW(RequireSaneReferenceAmount(1));
+    BOOST_CHECK_NO_THROW(RequireSaneReferenceAmount(1000000));
+    BOOST_CHECK_NO_THROW(RequireHeightInChain(0));
+}
+
+BOOST_AUTO_TEST_CASE(rpcrequirements_universal_failure)
+{
+    // The following checks are in practise impossible to pass, even with blank state and
+    // no previous transactions.
+    // Some of the checks fail for unrelated reasons, such as the DEx payment window or the
+    // fee check: the offers don't exist, which also raises exceptions.
+    BOOST_CHECK_THROW(RequireBalance("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P", 2, int64_t(9223372036854775807)), Object);
+    BOOST_CHECK_THROW(RequirePrimaryToken(0), Object);
+    BOOST_CHECK_THROW(RequirePrimaryToken(31), Object);
+    BOOST_CHECK_THROW(RequirePropertyName(""), Object);
+    BOOST_CHECK_THROW(RequireExistingProperty(uint32_t(2147483647)), Object); // last main identifier that may be created
+    BOOST_CHECK_THROW(RequireExistingProperty(uint32_t(4294967295)), Object); // last test identifier that may be created
+    BOOST_CHECK_THROW(RequireCrowdsale(uint32_t(2147483647)), Object);
+    BOOST_CHECK_THROW(RequireCrowdsale(uint32_t(4294967295)), Object);
+    BOOST_CHECK_THROW(RequireActiveCrowdsale(uint32_t(2147483647)), Object);
+    BOOST_CHECK_THROW(RequireActiveCrowdsale(uint32_t(4294967295)), Object);
+    BOOST_CHECK_THROW(RequireManagedProperty(uint32_t(2147483647)), Object);
+    BOOST_CHECK_THROW(RequireManagedProperty(uint32_t(4294967295)), Object);
+    BOOST_CHECK_THROW(RequireTokenIssuer("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint32_t(2147483647)), Object);
+    BOOST_CHECK_THROW(RequireSaneDExPaymentWindow("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint32_t(2147483647)), Object);
+    BOOST_CHECK_THROW(RequireSaneDExFee("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint32_t(2147483647)), Object);
+    BOOST_CHECK_THROW(RequireMatchingDExOffer("36fKL6YuaCKkWDkh4gce2E3PsucmDEyrR9", 3), Object);
+    BOOST_CHECK_THROW(RequireMatchingDExOffer("1388enJtLbowR6LRQQUTjptWuChirfrhza", 7), Object);
+    BOOST_CHECK_THROW(RequireSaneReferenceAmount(1000001), Object);
+    BOOST_CHECK_THROW(RequireSaneReferenceAmount(int64_t(210000000000000)), Object);
+    BOOST_CHECK_THROW(RequireHeightInChain(-1), Object);
+    BOOST_CHECK_THROW(RequireHeightInChain(std::numeric_limits<int>::max()), Object);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/rpc_requirements_tests.cpp
+++ b/src/omnicore/test/rpc_requirements_tests.cpp
@@ -22,6 +22,10 @@ BOOST_AUTO_TEST_CASE(rpcrequirements_universal)
     BOOST_CHECK_NO_THROW(RequirePropertyName("TestTokens"));
     BOOST_CHECK_NO_THROW(RequireExistingProperty(1));
     BOOST_CHECK_NO_THROW(RequireExistingProperty(2));
+    BOOST_CHECK_NO_THROW(RequireSameEcosystem(0, 0));
+    BOOST_CHECK_NO_THROW(RequireSameEcosystem(1, 3));
+    BOOST_CHECK_NO_THROW(RequireSameEcosystem(3221225476, 2));
+    BOOST_CHECK_NO_THROW(RequireDifferentIds(100000, 100001));
     BOOST_CHECK_NO_THROW(RequireNoOtherDExOffer("137uFtQ5EgMsreg4FVvL3xuhjkYGToVPqs", 1));
     BOOST_CHECK_NO_THROW(RequireNoOtherDExOffer("332r9K9t581aGVyzMK8uoPQr7ieH26u6J3", 2));
     BOOST_CHECK_NO_THROW(RequireSaneReferenceAmount(0));
@@ -42,6 +46,8 @@ BOOST_AUTO_TEST_CASE(rpcrequirements_universal_failure)
     BOOST_CHECK_THROW(RequirePropertyName(""), Object);
     BOOST_CHECK_THROW(RequireExistingProperty(uint32_t(2147483647)), Object); // last main identifier that may be created
     BOOST_CHECK_THROW(RequireExistingProperty(uint32_t(4294967295)), Object); // last test identifier that may be created
+    BOOST_CHECK_THROW(RequireSameEcosystem(2147483650, 4294967295), Object);
+    BOOST_CHECK_THROW(RequireDifferentIds(4200000000, 4200000000), Object);
     BOOST_CHECK_THROW(RequireCrowdsale(uint32_t(2147483647)), Object);
     BOOST_CHECK_THROW(RequireCrowdsale(uint32_t(4294967295)), Object);
     BOOST_CHECK_THROW(RequireActiveCrowdsale(uint32_t(2147483647)), Object);

--- a/src/omnicore/test/rpc_value_tests.cpp
+++ b/src/omnicore/test/rpc_value_tests.cpp
@@ -1,0 +1,312 @@
+#include "omnicore/rpcvalues.h"
+
+#include "rpcprotocol.h"
+
+#include "json/json_spirit_value.h"
+
+#include <stdint.h>
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+using json_spirit::Value;
+using json_spirit::Object;
+
+BOOST_AUTO_TEST_SUITE(omnicore_rpc_value_tests)
+
+static Value ValueFromString(const std::string& str)
+{
+    Value value;
+    BOOST_CHECK(json_spirit::read_string(str, value));
+    return value;
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_address)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseAddress(Value("1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX")), "1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX");
+    BOOST_CHECK_EQUAL(ParseAddress(Value("1ARjWDkZ7kT9fwjPrjcQyvbXDkEySzKHwu")), "1ARjWDkZ7kT9fwjPrjcQyvbXDkEySzKHwu");
+    BOOST_CHECK_EQUAL(ParseAddress(Value("14gu4rLFn72uCBagKqxdinnVTTiPmnDehk")), "14gu4rLFn72uCBagKqxdinnVTTiPmnDehk");
+    BOOST_CHECK_EQUAL(ParseAddress(Value("3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL")), "3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL");
+    // Invalid CBitcoinAddress
+    BOOST_CHECK_THROW(ParseAddress(Value("NotAnBase58EncodedAdddress")), Object);
+    BOOST_CHECK_THROW(ParseAddress(Value("14gu4rLFn72uCBagKqxdinnVTTiPmnDehj")), Object);
+    BOOST_CHECK_THROW(ParseAddress(Value("9EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseAddress(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAddress(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAddress(ValueFromString("123456789")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAddress(ValueFromString("0.1")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_property_id)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("1")), uint32_t(1));
+    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("31")), uint32_t(31));
+    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("2147483651")), uint32_t(2147483651));
+    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("4294967295")), uint32_t(4294967295));
+    // Out of range
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("0")), Object);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("4294967296")), Object);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("-2")), Object);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("9223372036854775807")), Object);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("9223372036854775809")), Object);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("18446744073709551615")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParsePropertyId(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePropertyId(Value("123")), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("1.0")), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("-0.99")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_indivisible_amounts)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseAmount(Value("1"), false), int64_t(1));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("100000000"), false), int64_t(100000000));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("2147483651"), false), int64_t(2147483651));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("9223372036854775807"), false), int64_t(9223372036854775807));
+    // Out of range
+    BOOST_CHECK_THROW(ParseAmount(Value("0"), false), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("-2"), false), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("-4294967297"), false), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("9223372036854775808"), false), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("-9223372036854775808"), false), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("18446744073709551610"), false), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseAmount(Value(), false), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAmount(ValueFromString("null"), false), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAmount(ValueFromString("9999"), false), std::runtime_error);    
+    BOOST_CHECK_THROW(ParseAmount(ValueFromString("2.50000000"), false), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAmount(ValueFromString("9223372036854775807"), false), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAmount(ValueFromString("-9223372036854775808"), false), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_divisible_amounts)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseAmount(Value("0.00000001"), true), int64_t(1));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("1"), true), int64_t(100000000));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("55555.555555"), true), int64_t(5555555555500));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("21000000.0"), true), int64_t(2100000000000000));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("21000000.00000009"), true), int64_t(2100000000000009));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("92233720368.54775807"), true), int64_t(9223372036854775807));
+    // Out of range
+    BOOST_CHECK_THROW(ParseAmount(Value("0"), true), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("0.000000001"), true), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("0.000000009"), true), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("-0.00000001"), true), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("CAFEBABE"), true), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("0x30303030"), true), Object);
+    BOOST_CHECK_THROW(ParseAmount(Value("92233720368.54775808"), true), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseAmount(Value(), false), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAmount(ValueFromString("null"), false), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAmount(ValueFromString("4294967299"), false), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_amount_by_type_mix)
+{
+    int typeIndivisible = 1;
+    int typeDivisible = 2;
+    BOOST_CHECK_EQUAL(ParseAmount(Value("2976579765"), false), ParseAmount(Value("2976579765"), typeIndivisible));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("4286316807.99194360"), typeDivisible), ParseAmount(Value("4286316807.99194360"), true));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("3221344269"), typeIndivisible), ParseAmount(Value("32.21344269"), true));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("8.00"), typeDivisible), ParseAmount(Value("800000000"), false));
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_payment_window)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseDExPaymentWindow(ValueFromString("1")), uint8_t(1));
+    BOOST_CHECK_EQUAL(ParseDExPaymentWindow(ValueFromString("127")), uint8_t(127));
+    BOOST_CHECK_EQUAL(ParseDExPaymentWindow(ValueFromString("255")), uint8_t(255));
+    // Out of range
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("0")), Object);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("256")), Object);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("-256")), Object);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("-128")), Object);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("1027")), Object);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("4294967297")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(Value("1")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExPaymentWindow(ValueFromString("2554.9995")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_dex_fee)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseDExFee(Value("0")), int64_t(0));
+    BOOST_CHECK_EQUAL(ParseDExFee(Value("0.00000")), int64_t(0));
+    BOOST_CHECK_EQUAL(ParseDExFee(Value("0.00000001")), int64_t(1));
+    BOOST_CHECK_EQUAL(ParseDExFee(Value("777")), int64_t(77700000000));
+    BOOST_CHECK_EQUAL(ParseDExFee(Value("92233720368.54772323")), int64_t(9223372036854772323));
+    // Invalid types
+    BOOST_CHECK_THROW(ParseDExFee(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExFee(ValueFromString("3")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExFee(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExFee(ValueFromString("2554.9995")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_dex_action)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseDExAction(ValueFromString("1")), uint8_t(1));
+    BOOST_CHECK_EQUAL(ParseDExAction(ValueFromString("2")), uint8_t(2));
+    BOOST_CHECK_EQUAL(ParseDExAction(ValueFromString("3")), uint8_t(3));
+    // Out of range
+    BOOST_CHECK_THROW(ParseDExAction(ValueFromString("0")), Object);
+    BOOST_CHECK_THROW(ParseDExAction(ValueFromString("4")), Object);
+    BOOST_CHECK_THROW(ParseDExAction(ValueFromString("-1")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseDExAction(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExAction(Value("2")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExAction(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDExAction(ValueFromString("3.0")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_ecosystem)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseEcosystem(ValueFromString("1")), uint8_t(1));
+    BOOST_CHECK_EQUAL(ParseEcosystem(ValueFromString("2")), uint8_t(2));
+    // Out of range
+    BOOST_CHECK_THROW(ParseEcosystem(ValueFromString("0")), Object);
+    BOOST_CHECK_THROW(ParseEcosystem(ValueFromString("3")), Object);
+    BOOST_CHECK_THROW(ParseEcosystem(ValueFromString("-257")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseEcosystem(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseEcosystem(Value("1")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseEcosystem(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseEcosystem(ValueFromString("1.999999999")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_property_type)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParsePropertyType(ValueFromString("1")), uint16_t(1));
+    BOOST_CHECK_EQUAL(ParsePropertyType(ValueFromString("2")), uint16_t(2));
+    // Out of range
+    BOOST_CHECK_THROW(ParsePropertyType(ValueFromString("0")), Object);
+    BOOST_CHECK_THROW(ParsePropertyType(ValueFromString("3")), Object);
+    BOOST_CHECK_THROW(ParsePropertyType(ValueFromString("-0")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParsePropertyType(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePropertyType(Value("2")), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePropertyType(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePropertyType(ValueFromString("1.50")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_previous_property_id)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParsePreviousPropertyId(ValueFromString("0")), uint32_t(0));
+    // Out of range
+    BOOST_CHECK_THROW(ParsePreviousPropertyId(ValueFromString("1")), Object);
+    BOOST_CHECK_THROW(ParsePreviousPropertyId(ValueFromString("-1")), Object);
+    BOOST_CHECK_THROW(ParsePreviousPropertyId(ValueFromString("9223372036854775808")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParsePreviousPropertyId(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePreviousPropertyId(Value("0")), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePreviousPropertyId(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParsePreviousPropertyId(ValueFromString("0.0")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_text)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseText(Value("")), "");
+    BOOST_CHECK_EQUAL(ParseText(Value("0")), "0");
+    BOOST_CHECK_EQUAL(ParseText(Value("-997.77")), "-997.77");
+    BOOST_CHECK_EQUAL(ParseText(Value("Omni Core Tokens")), "Omni Core Tokens");
+    BOOST_CHECK_EQUAL(ParseText(Value("TBM@e[$Rn)S$a..grahn n{d_}KWe940M-}z<^]{_Z^{~<IQr@Lt81Vq,'v1nseUUm>T'b<lryT^q(B'!FAO}*{E`"
+            "rc)]U[6XpriKassU/)TcO/WQQAkPaK'BJx[l(OCyf24ImF16K`em0n_JSy;w:O0qC]H~lV==,~p0[,@;J?0%Dk+tUV1Z>MYqSu0q^}-V{gG>|kPj(4I"
+            "3,dDUT3p/3b|<ua;~:VVa,!Y;!Ur$k8rOt &'/?qM(=C-i\bkj%")), "TBM@e[$Rn)S$a..grahn n{d_}KWe940M-}z<^]{_Z^{~<IQr@Lt81Vq,'"
+            "v1nseUUm>T'b<lryT^q(B'!FAO}*{E`rc)]U[6XpriKassU/)TcO/WQQAkPaK'BJx[l(OCyf24ImF16K`em0n_JSy;w:O0qC]H~lV==,~p0[,@;J?0%"
+            "Dk+tUV1Z>MYqSu0q^}-V{gG>|kPj(4I3,dDUT3p/3b|<ua;~:VVa,!Y;!Ur$k8rOt &'/?qM(=C-i\bkj%");
+    // Out of range
+    BOOST_CHECK_THROW(ParseText(Value("12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+            "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234"
+            "567890123456789012345678901234567890 <- 240 ... 256!")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseText(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseText(ValueFromString("0")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseText(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseText(ValueFromString("4815162342")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseText(ValueFromString("99.")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_deadline)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseDeadline(ValueFromString("1231006505")), int64_t(1231006505));
+    BOOST_CHECK_EQUAL(ParseDeadline(ValueFromString("2147483648")), int64_t(2147483648));
+    // Out of range
+    BOOST_CHECK_THROW(ParseDeadline(ValueFromString("-1")), Object);
+    BOOST_CHECK_THROW(ParseDeadline(ValueFromString("-2342342342434562345")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseDeadline(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDeadline(Value("11010102332")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDeadline(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseDeadline(ValueFromString("9224323423.25153")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_early_bird_bonus)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseEarlyBirdBonus(ValueFromString("0")), uint8_t(0));
+    BOOST_CHECK_EQUAL(ParseEarlyBirdBonus(ValueFromString("1")), uint8_t(1));
+    BOOST_CHECK_EQUAL(ParseEarlyBirdBonus(ValueFromString("107")), uint8_t(107));
+    BOOST_CHECK_EQUAL(ParseEarlyBirdBonus(ValueFromString("255")), uint8_t(255));
+    // Out of range
+    BOOST_CHECK_THROW(ParseEarlyBirdBonus(ValueFromString("-1")), Object);
+    BOOST_CHECK_THROW(ParseEarlyBirdBonus(ValueFromString("256")), Object);
+    BOOST_CHECK_THROW(ParseEarlyBirdBonus(ValueFromString("45345634745691")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseEarlyBirdBonus(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseEarlyBirdBonus(Value("-50")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseEarlyBirdBonus(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseEarlyBirdBonus(ValueFromString("255.0000000000001")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_issuer_bonus)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseIssuerBonus(ValueFromString("0")), uint8_t(0));
+    BOOST_CHECK_EQUAL(ParseIssuerBonus(ValueFromString("1")), uint8_t(1));
+    BOOST_CHECK_EQUAL(ParseIssuerBonus(ValueFromString("208")), uint8_t(208));
+    BOOST_CHECK_EQUAL(ParseIssuerBonus(ValueFromString("255")), uint8_t(255));
+    // Out of range
+    BOOST_CHECK_THROW(ParseIssuerBonus(ValueFromString("-1")), Object);
+    BOOST_CHECK_THROW(ParseIssuerBonus(ValueFromString("256")), Object);
+    BOOST_CHECK_THROW(ParseIssuerBonus(ValueFromString("65537")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseIssuerBonus(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseIssuerBonus(Value("232.230")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseIssuerBonus(ValueFromString("null")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_meta_dex_action)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseMetaDExAction(ValueFromString("1")), uint8_t(1));
+    BOOST_CHECK_EQUAL(ParseMetaDExAction(ValueFromString("2")), uint8_t(2));
+    BOOST_CHECK_EQUAL(ParseMetaDExAction(ValueFromString("3")), uint8_t(3));
+    BOOST_CHECK_EQUAL(ParseMetaDExAction(ValueFromString("4")), uint8_t(4));
+    // Out of range
+    BOOST_CHECK_THROW(ParseMetaDExAction(ValueFromString("0")), Object);
+    BOOST_CHECK_THROW(ParseMetaDExAction(ValueFromString("-1")), Object);
+    BOOST_CHECK_THROW(ParseMetaDExAction(ValueFromString("5")), Object);
+    BOOST_CHECK_THROW(ParseMetaDExAction(ValueFromString("-3253335464")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseMetaDExAction(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseMetaDExAction(Value("4")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseMetaDExAction(ValueFromString("null")), std::runtime_error);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Most notably:

 - `qa/pull-tester/omnicore-rpc-tests.sh` can be used as one-click test runner for the OmniJ RPC tests, which clones OmniJ, starts `bitcoind` and runs the regtests

 - `./autogen.sh`, `./configure --enable-lcov`, `make`, `make cov` can be used to create a [not-so-shiny line and function coverage report](http://bitwatch.co/uploads/lcov-3316616/total.coverage/src/omnicore/index.html) (may require `apt-get install lcov`)

 - a bunch of new tests

 - more input checks, and slightly improved formatting and documentation of the RPC calls
