### PR TITLE
Update MetaDEx network/transaction fields

### DIFF
--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -298,9 +298,8 @@ std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale
 {
     std::vector<unsigned char> payload;
 
-    uint16_t messageType = 21;
+    uint16_t messageType = 25;
     uint16_t messageVer = 0;
-    uint8_t action = 1; // ADD
 
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder16(messageType);
@@ -315,7 +314,6 @@ std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale
     PUSH_BACK_BYTES(payload, amountForSale);
     PUSH_BACK_BYTES(payload, propertyIdDesired);
     PUSH_BACK_BYTES(payload, amountDesired);
-    PUSH_BACK_BYTES(payload, action);
 
     return payload;
 }
@@ -324,9 +322,8 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdF
 {
     std::vector<unsigned char> payload;
 
-    uint16_t messageType = 21;
+    uint16_t messageType = 26;
     uint16_t messageVer = 0;
-    uint8_t action = 2; // CANCEL_AT_PRICE
 
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder16(messageType);
@@ -341,7 +338,6 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdF
     PUSH_BACK_BYTES(payload, amountForSale);
     PUSH_BACK_BYTES(payload, propertyIdDesired);
     PUSH_BACK_BYTES(payload, amountDesired);
-    PUSH_BACK_BYTES(payload, action);
 
     return payload;
 }
@@ -350,26 +346,18 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdFo
 {
     std::vector<unsigned char> payload;
 
-    uint16_t messageType = 21;
+    uint16_t messageType = 27;
     uint16_t messageVer = 0;
-    uint64_t amountForSale = 0;
-    uint64_t amountDesired = 0;
-    uint8_t action = 3; // CANCEL_ALL_FOR_PAIR
 
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder16(messageType);
     mastercore::swapByteOrder32(propertyIdForSale);
-    mastercore::swapByteOrder64(amountForSale);
     mastercore::swapByteOrder32(propertyIdDesired);
-    mastercore::swapByteOrder64(amountDesired);
 
     PUSH_BACK_BYTES(payload, messageVer);
     PUSH_BACK_BYTES(payload, messageType);
     PUSH_BACK_BYTES(payload, propertyIdForSale);
-    PUSH_BACK_BYTES(payload, amountForSale);
     PUSH_BACK_BYTES(payload, propertyIdDesired);
-    PUSH_BACK_BYTES(payload, amountDesired);
-    PUSH_BACK_BYTES(payload, action);
 
     return payload;
 }
@@ -378,28 +366,15 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosyste
 {
     std::vector<unsigned char> payload;
 
-    uint16_t messageType = 21;
+    uint16_t messageType = 28;
     uint16_t messageVer = 0;
-    uint32_t propertyIdForSale = ecosystem;
-    uint64_t amountForSale = 0;
-    uint32_t propertyIdDesired = ecosystem;
-    uint64_t amountDesired = 0;
-    uint8_t action = 4; // CANCEL_EVERYTHING
 
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder32(propertyIdForSale);
-    mastercore::swapByteOrder64(amountForSale);
-    mastercore::swapByteOrder32(propertyIdDesired);
-    mastercore::swapByteOrder64(amountDesired);
 
     PUSH_BACK_BYTES(payload, messageVer);
     PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyIdForSale);
-    PUSH_BACK_BYTES(payload, amountForSale);
-    PUSH_BACK_BYTES(payload, propertyIdDesired);
-    PUSH_BACK_BYTES(payload, amountDesired);
-    PUSH_BACK_BYTES(payload, action);
+    PUSH_BACK_BYTES(payload, ecosystem);
 
     return payload;
 }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -140,7 +140,10 @@ static const int txRestrictionsRules[][3] = {
   {MSC_TYPE_CREATE_PROPERTY_VARIABLE, MSC_SP_BLOCK,       MP_TX_PKT_V1},
   {MSC_TYPE_CLOSE_CROWDSALE,          MSC_SP_BLOCK,       MP_TX_PKT_V0},
   {MSC_TYPE_SEND_TO_OWNERS,           MSC_STO_BLOCK,      MP_TX_PKT_V0},
-  {MSC_TYPE_METADEX,                  MSC_METADEX_BLOCK,  MP_TX_PKT_V0},
+  {MSC_TYPE_METADEX_TRADE,            MSC_METADEX_BLOCK,  MP_TX_PKT_V0},
+  {MSC_TYPE_METADEX_CANCEL_PRICE,     MSC_METADEX_BLOCK,  MP_TX_PKT_V0},
+  {MSC_TYPE_METADEX_CANCEL_PAIR,      MSC_METADEX_BLOCK,  MP_TX_PKT_V0},
+  {MSC_TYPE_METADEX_CANCEL_ECOSYSTEM, MSC_METADEX_BLOCK,  MP_TX_PKT_V0},
   {MSC_TYPE_OFFER_ACCEPT_A_BET,       MSC_BET_BLOCK,      MP_TX_PKT_V0},
   {MSC_TYPE_CREATE_PROPERTY_MANUAL,   MSC_MANUALSP_BLOCK,      MP_TX_PKT_V0},
   {MSC_TYPE_GRANT_PROPERTY_TOKENS,    MSC_MANUALSP_BLOCK,      MP_TX_PKT_V0},
@@ -3376,8 +3379,15 @@ int CMPTransaction::interpretPacket(CMPOffer* obj_o, CMPMetaDEx* mdex_o)
         return -777; // can't fill in the Offer object !
     }
 
-    if (mdex_o && MSC_TYPE_METADEX != type) {
-        return -778; // can't fill in the MetaDEx object !
+    if (mdex_o) {
+        if (type != MSC_TYPE_METADEX_TRADE
+                && type != MSC_TYPE_METADEX_CANCEL_PRICE
+                && type != MSC_TYPE_METADEX_CANCEL_PAIR
+                && type != MSC_TYPE_METADEX_CANCEL_ECOSYSTEM) {
+            return -778; // can't fill in the MetaDEx object !
+        } else {
+            return logicMath_MetaDEx(mdex_o); // temp
+        }
     }
 
     switch (type) {
@@ -3390,11 +3400,20 @@ int CMPTransaction::interpretPacket(CMPOffer* obj_o, CMPMetaDEx* mdex_o)
         case MSC_TYPE_TRADE_OFFER:
             return logicMath_TradeOffer(obj_o);
 
-        case MSC_TYPE_METADEX:
-            return logicMath_MetaDEx(mdex_o);
-
         case MSC_TYPE_ACCEPT_OFFER_BTC:
             return logicMath_AcceptOffer_BTC();
+
+        case MSC_TYPE_METADEX_TRADE:
+            return logicMath_MetaDExTrade();
+
+        case MSC_TYPE_METADEX_CANCEL_PRICE:
+            return logicMath_MetaDExCancelPrice();
+
+        case MSC_TYPE_METADEX_CANCEL_PAIR:
+            return logicMath_MetaDExCancelPair();
+
+        case MSC_TYPE_METADEX_CANCEL_ECOSYSTEM:
+            return logicMath_MetaDExCancelEcosystem();
 
         case MSC_TYPE_CREATE_PROPERTY_FIXED:
             return logicMath_CreatePropertyFixed();

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -65,8 +65,7 @@ int const MAX_STATE_HISTORY = 50;
 // Maximum outputs per BTC Transaction
 #define MAX_BTC_OUTPUTS 16
 
-#define MIN_PAYLOAD_SIZE     8
-
+#define MIN_PAYLOAD_SIZE     5
 #define PACKET_SIZE_CLASS_A 19
 #define PACKET_SIZE         31
 #define MAX_PACKETS         64
@@ -81,8 +80,11 @@ enum TransactionType {
   MSC_TYPE_RATELIMITED_MARK         = 12,
   MSC_TYPE_AUTOMATIC_DISPENSARY     = 15,
   MSC_TYPE_TRADE_OFFER              = 20,
-  MSC_TYPE_METADEX                  = 21,
   MSC_TYPE_ACCEPT_OFFER_BTC         = 22,
+  MSC_TYPE_METADEX_TRADE            = 25,
+  MSC_TYPE_METADEX_CANCEL_PRICE     = 26,
+  MSC_TYPE_METADEX_CANCEL_PAIR      = 27,
+  MSC_TYPE_METADEX_CANCEL_ECOSYSTEM = 28,
   MSC_TYPE_NOTIFICATION             = 31,
   MSC_TYPE_OFFER_ACCEPT_A_BET       = 40,
   MSC_TYPE_CREATE_PROPERTY_FIXED    = 50,

--- a/src/omnicore/pending.cpp
+++ b/src/omnicore/pending.cpp
@@ -58,7 +58,10 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, const st
             txobj.push_back(Pair("btcamountdesired", amountDStr));
             txobj.push_back(Pair("action", action));
         break;
-        case MSC_TYPE_METADEX:
+        case MSC_TYPE_METADEX_TRADE:
+        case MSC_TYPE_METADEX_CANCEL_PRICE:
+        case MSC_TYPE_METADEX_CANCEL_PAIR:
+        case MSC_TYPE_METADEX_CANCEL_ECOSYSTEM:
             divisible = isPropertyDivisible(propertyId);
             divisibleDesired = isPropertyDivisible(propertyIdDesired);
             if (divisible) { amountStr = FormatDivisibleMP(amount); } else { amountStr = FormatIndivisibleMP(amount); }

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1267,7 +1267,10 @@ int populateRPCTransactionObject(const uint256& txid, Object *txobj, std::string
                     //populate based on type of tx
                     switch (MPTxTypeInt)
                     {
-                        case MSC_TYPE_METADEX:
+                        case MSC_TYPE_METADEX_TRADE:
+                        case MSC_TYPE_METADEX_CANCEL_PRICE:
+                        case MSC_TYPE_METADEX_CANCEL_PAIR:
+                        case MSC_TYPE_METADEX_CANCEL_ECOSYSTEM:
                              if (0 == mp_obj.step2_Value())
                              {
                                  propertyId = mp_obj.getProperty();
@@ -1448,13 +1451,31 @@ int populateRPCTransactionObject(const uint256& txid, Object *txobj, std::string
         txobj->push_back(Pair("version", (int64_t)mp_obj.getVersion()));
         txobj->push_back(Pair("type_int", (int64_t)mp_obj.getType()));
         txobj->push_back(Pair("type", MPTxType));
-        if (MSC_TYPE_METADEX != MPTxTypeInt) txobj->push_back(Pair("propertyid", propertyId));
+        if (MSC_TYPE_METADEX_TRADE != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_PRICE != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_PAIR != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_ECOSYSTEM != MPTxTypeInt)
+        {
+            txobj->push_back(Pair("propertyid", propertyId));
+        }
         if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_MANUAL == MPTxTypeInt))
         {
             txobj->push_back(Pair("propertyname", propertyName));
         }
-        if (MSC_TYPE_METADEX != MPTxTypeInt) txobj->push_back(Pair("divisible", divisible));
-        if (MSC_TYPE_METADEX != MPTxTypeInt) txobj->push_back(Pair("amount", FormatMP(propertyId, amount)));
+        if (MSC_TYPE_METADEX_TRADE != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_PRICE != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_PAIR != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_ECOSYSTEM != MPTxTypeInt)
+        {
+            txobj->push_back(Pair("divisible", divisible));
+        }
+        if (MSC_TYPE_METADEX_TRADE != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_PRICE != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_PAIR != MPTxTypeInt
+                && MSC_TYPE_METADEX_CANCEL_ECOSYSTEM != MPTxTypeInt)
+        {
+            txobj->push_back(Pair("amount", FormatMP(propertyId, amount)));
+        }
         if (crowdPurchase)
         {
             txobj->push_back(Pair("purchasedpropertyid", crowdPropertyId));
@@ -1472,7 +1493,10 @@ int populateRPCTransactionObject(const uint256& txid, Object *txobj, std::string
             if (3 == sell_subaction) txobj->push_back(Pair("subaction", "Cancel"));
             txobj->push_back(Pair("bitcoindesired", ValueFromAmount(sell_btcdesired)));
         }
-        if (MSC_TYPE_METADEX == MPTxTypeInt)
+        if (MSC_TYPE_METADEX_TRADE == MPTxTypeInt
+                || MSC_TYPE_METADEX_CANCEL_PRICE == MPTxTypeInt
+                || MSC_TYPE_METADEX_CANCEL_PAIR == MPTxTypeInt
+                || MSC_TYPE_METADEX_CANCEL_ECOSYSTEM == MPTxTypeInt)
         {
             txobj->push_back(Pair("propertyidforsale", propertyId));
             txobj->push_back(Pair("propertyidforsaleisdivisible", mdex_propertyId_Div));

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -737,8 +737,7 @@ Value sendtrade_OMNI(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            uint8_t action = CMPTransaction::ADD; // TODO: move into pending creation
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, action);
+            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_TRADE, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, CMPTransaction::ADD);
             return txid.GetHex();
         }
     }
@@ -792,8 +791,7 @@ Value sendcanceltradesbyprice_OMNI(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            uint8_t action = CMPTransaction::CANCEL_AT_PRICE; // TODO: move into pending creation
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, action);
+            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_PRICE, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, CMPTransaction::CANCEL_AT_PRICE);
             return txid.GetHex();
         }
     }
@@ -843,10 +841,7 @@ Value sendcanceltradesbypair_OMNI(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            uint8_t action = CMPTransaction::CANCEL_ALL_FOR_PAIR; // TODO: move into pending creation
-            int64_t amountForSale = 0;
-            int64_t amountDesired = 0;
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, action);
+            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_PAIR, propertyIdForSale, 0, propertyIdDesired, 0, CMPTransaction::CANCEL_ALL_FOR_PAIR);
             return txid.GetHex();
         }
     }
@@ -890,12 +885,7 @@ Value sendcancelalltrades_OMNI(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            uint8_t action = CMPTransaction::CANCEL_EVERYTHING; // TODO: move into pending creation
-            int64_t amountForSale = 0;
-            int64_t amountDesired = 0;
-            uint32_t propertyIdForSale = ecosystem;
-            uint32_t propertyIdDesired = ecosystem;
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, action);
+            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_ECOSYSTEM, ecosystem, 0, ecosystem, 0, CMPTransaction::CANCEL_EVERYTHING);
             return txid.GetHex();
         }
     }

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -47,59 +47,49 @@ BOOST_AUTO_TEST_CASE(payload_dex_offer)
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_new_trade)
 {
-    // Trade tokens for tokens [type 21, version 0]
+    // Trade tokens for tokens [type 25, version 0]
     std::vector<unsigned char> vch = CreatePayload_MetaDExTrade(
         static_cast<uint32_t>(1),          // property: MSC
         static_cast<int64_t>(250000000),   // amount for sale: 2.5 MSC
         static_cast<uint32_t>(31),         // property desired: TetherUS
         static_cast<int64_t>(5000000000)); // amount desired: 50.0 TetherUS
-                                           // sub-action: (1) new-offer
 
     BOOST_CHECK_EQUAL(HexStr(vch),
-        "0000001500000001000000000ee6b2800000001f000000012a05f20001");
+        "0000001900000001000000000ee6b2800000001f000000012a05f200");
 }
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_at_price)
 {
-    // Trade tokens for tokens [type 21, version 0]
+    // Trade tokens for tokens [type 26, version 0]
     std::vector<unsigned char> vch = CreatePayload_MetaDExCancelPrice(
         static_cast<uint32_t>(1),          // property: MSC
         static_cast<int64_t>(250000000),   // amount for sale: 2.5 MSC
         static_cast<uint32_t>(31),         // property desired: TetherUS
         static_cast<int64_t>(5000000000)); // amount desired: 50.0 TetherUS
-                                           // sub-action: (2) cancel-at-price
 
     BOOST_CHECK_EQUAL(HexStr(vch),
-        "0000001500000001000000000ee6b2800000001f000000012a05f20002");
+        "0000001a00000001000000000ee6b2800000001f000000012a05f200");
 }
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_pair)
 {
-    // Trade tokens for tokens [type 21, version 0]
+    // Trade tokens for tokens [type 27, version 0]
     std::vector<unsigned char> vch = CreatePayload_MetaDExCancelPair(
         static_cast<uint32_t>(1),          // property: MSC
-                                           // amount for sale: 0.0 MSC
         static_cast<uint32_t>(31));        // property desired: TetherUS
-                                           // amount desired: 0.0 TetherUS
-                                           // sub-action: (3) cancel-pair
 
     BOOST_CHECK_EQUAL(HexStr(vch),
-        "000000150000000100000000000000000000001f000000000000000003");
+        "0000001b000000010000001f");
 }
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_ecosystem)
 {
-    // Trade tokens for tokens [type 21, version 0]
+    // Trade tokens for tokens [type 28, version 0]
     std::vector<unsigned char> vch = CreatePayload_MetaDExCancelEcosystem(
         static_cast<uint8_t>(1));          // ecosystem: Main
-                                           // property: MSC
-                                           // amount for sale: 0.0 MSC
-                                           // property desired: MSC
-                                           // amount for sale: 0.0 MSC
-                                           // sub-action: (4) cancel-ecosystem
 
     BOOST_CHECK_EQUAL(HexStr(vch),
-        "0000001500000001000000000000000000000001000000000000000004");
+        "0000001c01");
 }
 
 BOOST_AUTO_TEST_CASE(payload_accept_dex_offer)

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -55,8 +55,10 @@ private:
     // CreatePropertyMananged, GrantTokens, RevokeTokens, ChangeIssuer
     unsigned int property;
 
-    // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged
+    // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged, MetaDEx
     unsigned char ecosystem;
+
+    // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged
     unsigned short prop_type;
     unsigned int prev_prop_id;
     char category[SP_STRING_FIELD_LEN];
@@ -71,7 +73,7 @@ private:
     // MetaDEx
     unsigned int desired_property;
     uint64_t desired_value;
-    unsigned char action;
+    unsigned char action; // depreciated
 
     // TradeOffer
     uint64_t amount_desired;
@@ -176,7 +178,10 @@ public:
     bool interpret_SimpleSend();
     bool interpret_SendToOwners();
     bool interpret_TradeOffer();
-    bool interpret_MetaDEx();
+    bool interpret_MetaDExTrade();
+    bool interpret_MetaDExCancelPrice();
+    bool interpret_MetaDExCancelPair();
+    bool interpret_MetaDExCancelEcosystem();
     bool interpret_AcceptOfferBTC();
     bool interpret_CreatePropertyFixed();
     bool interpret_CreatePropertyVariable();
@@ -195,6 +200,10 @@ public:
     int logicMath_TradeOffer(CMPOffer*);
     int logicMath_MetaDEx(CMPMetaDEx*);
     int logicMath_AcceptOffer_BTC();
+    int logicMath_MetaDExTrade();
+    int logicMath_MetaDExCancelPrice();
+    int logicMath_MetaDExCancelPair();
+    int logicMath_MetaDExCancelEcosystem();
     int logicMath_CreatePropertyFixed();
     int logicMath_CreatePropertyVariable();
     int logicMath_CloseCrowdsale();

--- a/src/qt/metadexdialog.cpp
+++ b/src/qt/metadexdialog.cpp
@@ -624,7 +624,7 @@ void MetaDExDialog::sendTrade(bool sell)
         if (!autoCommit) {
             PopulateSimpleDialog(rawHex, "Raw Hex (auto commit is disabled)", "Raw transaction hex");
         } else {
-            PendingAdd(txid, strFromAddress, "", MSC_TYPE_METADEX, propertyIdSell, amountSell, propertyIdDes, amountDes, 1);
+            PendingAdd(txid, strFromAddress, "", MSC_TYPE_METADEX_TRADE, propertyIdSell, amountSell, propertyIdDes, amountDes, 1);
             PopulateTXSentDialog(txid.GetHex());
         }
     }

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -231,7 +231,12 @@ int TradeHistoryDialog::PopulateTradeHistoryMap()
 
         // grab pending object, extract details and skip if not a metadex trade
         CMPPending *p_pending = &(it->second);
-        if (p_pending->type != MSC_TYPE_METADEX) continue;
+        if (p_pending->type != MSC_TYPE_METADEX_TRADE
+                && p_pending->type != MSC_TYPE_METADEX_CANCEL_PRICE
+                && p_pending->type != MSC_TYPE_METADEX_CANCEL_PAIR
+                && p_pending->type != MSC_TYPE_METADEX_CANCEL_ECOSYSTEM) {
+            continue;
+        }
         uint32_t propertyId = p_pending->prop;
         int64_t amount = p_pending->amount;
 
@@ -272,7 +277,12 @@ int TradeHistoryDialog::PopulateTradeHistoryMap()
         std::vector<std::string> vstr;
         boost::split(vstr, tempStrValue, boost::is_any_of(":"), boost::token_compress_on);
         if (vstr.size() > 2) {
-            if (atoi(vstr[2]) != MSC_TYPE_METADEX) continue;
+            if (atoi(vstr[2]) != MSC_TYPE_METADEX_TRADE
+                    && atoi(vstr[2]) != MSC_TYPE_METADEX_CANCEL_PRICE
+                    && atoi(vstr[2]) != MSC_TYPE_METADEX_CANCEL_PAIR
+                    && atoi(vstr[2]) != MSC_TYPE_METADEX_CANCEL_ECOSYSTEM) {
+                continue;
+            }
         }
 
         // check historyMap, if this tx exists don't waste resources doing anymore work on it

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -186,8 +186,17 @@ int TXHistoryDialog::PopulateHistoryMap()
             htxo.blockByteOffset = pendingWTx->nOrderPos;
         }
         htxo.valid = true; // all pending transactions are assumed to be valid while awaiting confirmation since all pending are outbound and we wouldn't let them be sent if invalid
-        if (p_pending->type == 0) { htxo.txType = "Send"; htxo.fundsMoved = true; } // we don't have a CMPTransaction class here so manually set the type for now
-        if (p_pending->type == 21) { htxo.txType = "MetaDEx Trade"; htxo.fundsMoved = false; } // send and metadex trades are the only supported outbound txs (thus only possible pending) for now
+        if (p_pending->type == MSC_TYPE_SIMPLE_SEND) {
+            htxo.txType = "Send";
+            htxo.fundsMoved = true;
+        } // we don't have a CMPTransaction class here so manually set the type for now
+        if (p_pending->type == MSC_TYPE_METADEX_TRADE
+                || p_pending->type == MSC_TYPE_METADEX_CANCEL_PRICE
+                || p_pending->type == MSC_TYPE_METADEX_CANCEL_PAIR
+                || p_pending->type == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM) {
+            htxo.txType = "MetaDEx Trade";
+            htxo.fundsMoved = false;
+        } // send and metadex trades are the only supported outbound txs (thus only possible pending) for now
         htxo.address = senderAddress; // always sender, all pending are outbound
         if(isPropertyDivisible(propertyId)) {htxo.amount = "-"+FormatDivisibleShortMP(amount)+getTokenLabel(propertyId);} else {htxo.amount="-"+FormatIndivisibleMP(amount)+getTokenLabel(propertyId);} // pending always outbound
         txHistoryMap.insert(std::make_pair(txid, htxo));
@@ -578,8 +587,12 @@ std::string TXHistoryDialog::shrinkTxType(int txType, bool *fundsMoved)
         case MSC_TYPE_RATELIMITED_MARK: displayType = "Rate Limit"; break;
         case MSC_TYPE_AUTOMATIC_DISPENSARY: displayType = "Auto Dispense"; break;
         case MSC_TYPE_TRADE_OFFER: displayType = "DEx Trade"; *fundsMoved = false; break;
-        case MSC_TYPE_METADEX: displayType = "MetaDEx Trade"; *fundsMoved = false; break;
         case MSC_TYPE_ACCEPT_OFFER_BTC: displayType = "DEx Accept"; *fundsMoved = false; break;
+        case MSC_TYPE_METADEX_TRADE:
+        case MSC_TYPE_METADEX_CANCEL_PRICE:
+        case MSC_TYPE_METADEX_CANCEL_PAIR:
+        case MSC_TYPE_METADEX_CANCEL_ECOSYSTEM:
+            displayType = "MetaDEx Trade"; *fundsMoved = false; break;
         case MSC_TYPE_CREATE_PROPERTY_FIXED: displayType = "Create Property"; break;
         case MSC_TYPE_CREATE_PROPERTY_VARIABLE: displayType = "Create Property"; break;
         case MSC_TYPE_PROMOTE_PROPERTY: displayType = "Promo Property"; break;


### PR DESCRIPTION
This PR removes the action byte on a transaction level.

The new transaction format:
```
Add:
[version=0] [type=25] [property] [number] [property] [number]

Cancel-All-At-Price:
[version=0] [type=26] [property] [number] [property] [number]

Cancel-All-Of-Currency-Pair:
[version=0] [type=27] [property] [property]

Cancel-Everything:
[version=0] [type=28] [ecosystem]
```

There is still some use of action bytes here and there, and until those parts are also updated, it can be completely removed, but this seems to be out of scope for now.

It resolves #47.