### PR TITLE
Various cleanup, reindexing and resolving LOCK issue

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -6,6 +6,7 @@ OMNICORE_H = \
   omnicore/errors.h \
   omnicore/log.h \
   omnicore/mdex.h \
+  omnicore/notifications.h \
   omnicore/omnicore.h \
   omnicore/parse_string.h \
   omnicore/pending.h \
@@ -28,6 +29,7 @@ OMNICORE_CPP = \
   omnicore/encoding.cpp \
   omnicore/log.cpp \
   omnicore/mdex.cpp \
+  omnicore/notifications.cpp \
   omnicore/omnicore.cpp \
   omnicore/parse_string.cpp \
   omnicore/pending.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -1,6 +1,7 @@
 OMNICORE_TEST_H =
 
 OMNICORE_TEST_CPP = \
+  omnicore/test/alert_tests.cpp \
   omnicore/test/create_payload_tests.cpp \
   omnicore/test/encoding_b_tests.cpp \
   omnicore/test/encoding_c_tests.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1969,9 +1969,7 @@ bool static DisconnectTip(CValidationState &state) {
 
     //! Omni Core: begin block disconnect notification
     LogPrint("handler", "Omni Core handler: block disconnect begin [height: %d, reindex: %d]\n", GetHeight(), (int)fReindex);
-    if (!fReindex) {
-        mastercore_handler_disc_begin(GetHeight(), pindexDelete);
-    }
+    mastercore_handler_disc_begin(GetHeight(), pindexDelete);
 
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
@@ -1981,9 +1979,7 @@ bool static DisconnectTip(CValidationState &state) {
 
     //! Omni Core: end of block disconnect notification
     LogPrint("handler", "Omni Core handler: block disconnect end [height: %d, reindex: %d]\n", GetHeight(), (int)fReindex);
-    if (!fReindex) {
-        mastercore_handler_disc_end(GetHeight(), pindexDelete);
-    }
+    mastercore_handler_disc_end(GetHeight(), pindexDelete);
 
     return true;
 }

--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -4,6 +4,8 @@
 
 #include "omnicore/convert.h"
 
+#include "tinyformat.h"
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -398,6 +400,26 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosyste
     PUSH_BACK_BYTES(payload, propertyIdDesired);
     PUSH_BACK_BYTES(payload, amountDesired);
     PUSH_BACK_BYTES(payload, action);
+
+    return payload;
+}
+
+std::vector<unsigned char> CreatePayload_OmniCoreAlert(int32_t alertType, uint64_t expiryValue, uint32_t typeCheck, uint32_t verCheck, const std::string& alertMessage)
+{
+    std::vector<unsigned char> payload;
+    uint16_t messageType = 65535;
+    uint16_t messageVer = 65535;
+
+    std::string strAlertPacket = strprintf("%d:%d:%d:%d:%s",
+            alertType, expiryValue, typeCheck, verCheck, alertMessage);
+
+    mastercore::swapByteOrder16(messageVer);
+    mastercore::swapByteOrder16(messageType);
+
+    PUSH_BACK_BYTES(payload, messageVer);
+    PUSH_BACK_BYTES(payload, messageType);
+    payload.insert(payload.end(), strAlertPacket.begin(), strAlertPacket.end());
+    payload.push_back('\0');
 
     return payload;
 }

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -24,6 +24,7 @@ std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale
 std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired);
 std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdForSale, uint32_t propertyIdDesired);
 std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem);
+std::vector<unsigned char> CreatePayload_OmniCoreAlert(int32_t alertType, uint64_t expiryValue, uint32_t typeCheck, uint32_t verCheck, const std::string& alertMessage);
 
 
 #endif // OMNICORE_CREATEPAYLOAD_H

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -3,6 +3,7 @@
 #include "omnicore/errors.h"
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
 #include "omnicore/tx.h"
 
 #include "chain.h"

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -1,7 +1,6 @@
 #ifndef OMNICORE_MDEX_H
 #define OMNICORE_MDEX_H
 
-#include "tinyformat.h"
 #include "uint256.h"
 
 #include <boost/lexical_cast.hpp>
@@ -14,7 +13,6 @@
 #include <stdint.h>
 
 #include <fstream>
-#include <limits>
 #include <map>
 #include <set>
 #include <string>
@@ -26,60 +24,9 @@ typedef boost::rational<int128_t> rational_t;
 
 #define DISPLAY_PRECISION_LEN  50
 
-inline bool rangeInt64(const int128_t& value)
-{
-    return (std::numeric_limits<int64_t>::min() <= value && value <= std::numeric_limits<int64_t>::max());
-}
-
-inline bool rangeInt64(const rational_t& value)
-{
-    return (rangeInt64(value.numerator()) && rangeInt64(value.denominator()));
-}
-
-inline std::string xToString(const dec_float& value)
-{
-    return value.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed);
-}
-
-inline std::string xToString(const int128_t& value)
-{
-    return strprintf("%s", boost::lexical_cast<std::string>(value));
-}
-
-inline std::string xToString(const rational_t& value)
-{
-    if (rangeInt64(value)) {
-        int64_t num = value.numerator().convert_to<int64_t>();
-        int64_t denom = value.denominator().convert_to<int64_t>();
-        dec_float x = dec_float(num) / dec_float(denom);
-        return xToString(x);
-    } else {
-        return strprintf("%s / %s", xToString(value.numerator()), xToString(value.denominator()));
-    }
-}
-
-inline int128_t xToInt128(const rational_t& value, bool fRoundUp)
-{
-    // for integer rounding up: ceil(num / denom) => 1 + (num - 1) / denom
-    int128_t result(0);
-
-    if (!fRoundUp) {
-        result = value.numerator() / value.denominator();
-    } else {
-        result = int128_t(1) + (value.numerator() - int128_t(1)) / value.denominator();
-    }
-
-    return result;
-}
-
-inline int64_t xToInt64(const rational_t& value, bool fRoundUp)
-{
-    int128_t result = xToInt128(value, fRoundUp);
-
-    assert(rangeInt64(result));
-
-    return result.convert_to<int64_t>();
-}
+std::string xToString(const dec_float& value);
+std::string xToString(const int128_t& value);
+std::string xToString(const rational_t& value);
 
 /** A trade on the distributed exchange.
  */
@@ -163,6 +110,7 @@ typedef std::map<rational_t, md_Set> md_PricesMap;
 //! Map of properties; there is a map of prices for each property
 typedef std::map<uint32_t, md_PricesMap> md_PropertiesMap;
 
+//! Global map for price and order data
 extern md_PropertiesMap metadex;
 
 // TODO: explore a property-pair, instead of a single property as map's key........

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -21,6 +21,57 @@ namespace mastercore
 static std::string global_alert_message;
 
 /**
+ * Determines whether the sender is an authorized source for Omni Core alerts.
+ *
+ * The option "-alertallowsender=source" can be used to whitelist additional sources,
+ * and the option "-alertignoresender=source" can be used to ignore a source.
+ *
+ * To consider any alert as authorized, "-alertallowsender=any" can be used. This
+ * should only be done for testing purposes!
+ */
+bool CheckAlertAuthorization(const std::string& sender)
+{
+    std::set<std::string> whitelisted;
+
+    // TODO: check email addresses
+    // TODO: add dexX7 <dexx@bitwatch.co>
+    // TODO: rename option to be more Omni Core specific
+
+    // Mainnet
+    whitelisted.insert("16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj"); // Craig   <craig@omni.foundation>
+    whitelisted.insert("1MicH2Vu4YVSvREvxW1zAx2XKo2GQomeXY"); // Michael <michael@omni.foundation>
+    whitelisted.insert("1zAtHRASgdHvZDfHs6xJquMghga4eG7gy");  // Zathras <zathras@omni.foundation>
+    whitelisted.insert("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"); // Exodus (who has access?)
+
+    // Testnet
+    whitelisted.insert("mpDex4kSX4iscrmiEQ8fBiPoyeTH55z23j"); // Michael <michael@omni.foundation>
+    whitelisted.insert("mpZATHupfCLqet5N1YL48ByCM1ZBfddbGJ"); // Zathras <zathras@omni.foundation>
+
+    // Add manually whitelisted sources
+    if (mapArgs.count("-alertallowsender")) {
+        const std::vector<std::string>& sources = mapMultiArgs["-alertallowsender"];
+
+        for (std::vector<std::string>::const_iterator it = sources.begin(); it != sources.end(); ++it) {
+            whitelisted.insert(*it);
+        }
+    }
+
+    // Remove manually ignored sources
+    if (mapArgs.count("-alertignoresender")) {
+        const std::vector<std::string>& sources = mapMultiArgs["-alertignoresender"];
+
+        for (std::vector<std::string>::const_iterator it = sources.begin(); it != sources.end(); ++it) {
+            whitelisted.erase(*it);
+        }
+    }
+
+    bool fAuthorized = (whitelisted.count(sender) ||
+                        whitelisted.count("any"));
+
+    return fAuthorized;
+}
+
+/**
  * Alert string including meta data.
  */
 std::string getMasterCoreAlertString()

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -14,13 +14,16 @@
 #include <string>
 #include <vector>
 
+namespace mastercore
+{
+
 //! Stores alert messages for Omni Core
 static std::string global_alert_message;
 
 /**
  * Alert string including meta data.
  */
-std::string mastercore::getMasterCoreAlertString()
+std::string getMasterCoreAlertString()
 {
     return global_alert_message;
 }
@@ -28,7 +31,7 @@ std::string mastercore::getMasterCoreAlertString()
 /**
  * Human readable alert message.
  */
-std::string mastercore::getMasterCoreAlertTextOnly()
+std::string getMasterCoreAlertTextOnly()
 {
     std::string message;
     std::vector<std::string> vstr;
@@ -47,7 +50,7 @@ std::string mastercore::getMasterCoreAlertTextOnly()
 /**
  * Sets the alert string.
  */
-void mastercore::setOmniCoreAlert(const std::string& alertMessage)
+void setOmniCoreAlert(const std::string& alertMessage)
 {
     global_alert_message = alertMessage;
 }
@@ -55,7 +58,7 @@ void mastercore::setOmniCoreAlert(const std::string& alertMessage)
 /**
  * Expires any alerts that need expiring.
  */
-bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
+bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
 {
     int32_t alertType = 0;
     uint64_t expiryValue = 0;
@@ -74,7 +77,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                         return true;
                     }
                     break;
-                case 2: //Text based alert only expiring by block time, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
+                case 2: //Text baseDEBUG d alert only expiring by block time, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
                     if (curTime > expiryValue) {
                         //the alert has expired, clear the global alert string
                         PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
@@ -138,7 +141,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
 /**
  * Parses an alert string.
  */
-bool mastercore::parseAlertMessage(const std::string& rawAlertStr, int32_t* alertType, uint64_t* expiryValue, uint32_t* typeCheck, uint32_t* verCheck, std::string* alertMessage)
+bool parseAlertMessage(const std::string& rawAlertStr, int32_t* alertType, uint64_t* expiryValue, uint32_t* typeCheck, uint32_t* verCheck, std::string* alertMessage)
 {
     std::vector<std::string> vstr;
     boost::split(vstr, rawAlertStr, boost::is_any_of(":"), boost::token_compress_on);
@@ -162,3 +165,5 @@ bool mastercore::parseAlertMessage(const std::string& rawAlertStr, int32_t* aler
     return false;
 }
 
+
+} // namespace mastercore

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -74,7 +74,7 @@ bool CheckAlertAuthorization(const std::string& sender)
 /**
  * Alert string including meta data.
  */
-std::string getMasterCoreAlertString()
+std::string GetOmniCoreAlertString()
 {
     return global_alert_message;
 }
@@ -82,7 +82,7 @@ std::string getMasterCoreAlertString()
 /**
  * Human readable alert message.
  */
-std::string getMasterCoreAlertTextOnly()
+std::string GetOmniCoreAlertTextOnly()
 {
     std::string message;
     std::vector<std::string> vstr;
@@ -101,7 +101,7 @@ std::string getMasterCoreAlertTextOnly()
 /**
  * Sets the alert string.
  */
-void setOmniCoreAlert(const std::string& alertMessage)
+void SetOmniCoreAlert(const std::string& alertMessage)
 {
     global_alert_message = alertMessage;
 }
@@ -109,7 +109,7 @@ void setOmniCoreAlert(const std::string& alertMessage)
 /**
  * Expires any alerts that need expiring.
  */
-bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
+bool CheckExpiredAlerts(unsigned int curBlock, uint64_t curTime)
 {
     int32_t alertType = 0;
     uint64_t expiryValue = 0;
@@ -117,7 +117,7 @@ bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
     uint32_t verCheck = 0;
     std::string alertMessage;
     if (!global_alert_message.empty()) {
-        bool parseSuccess = parseAlertMessage(global_alert_message, &alertType, &expiryValue, &typeCheck, &verCheck, &alertMessage);
+        bool parseSuccess = ParseAlertMessage(global_alert_message, alertType, expiryValue, typeCheck, verCheck, alertMessage);
         if (parseSuccess) {
             switch (alertType) {
                 case 1: //Text based alert only expiring by block number, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
@@ -165,7 +165,7 @@ bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                         PrintToLog("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message);
                         PrintToConsole("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message); // echo to screen
                         if (!GetBoolArg("-overrideforcedshutdown", false)) {
-                            std::string msgText = "Shutting down due to alert: " + getMasterCoreAlertTextOnly();
+                            std::string msgText = "Shutting down due to alert: " + GetOmniCoreAlertTextOnly();
                             AbortNode(msgText, msgText); // show same message to user as that which is logged
                         }
                         return false;
@@ -192,22 +192,22 @@ bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
 /**
  * Parses an alert string.
  */
-bool parseAlertMessage(const std::string& rawAlertStr, int32_t* alertType, uint64_t* expiryValue, uint32_t* typeCheck, uint32_t* verCheck, std::string* alertMessage)
+bool ParseAlertMessage(const std::string& rawAlertStr, int32_t& alertType, uint64_t& expiryValue, uint32_t& typeCheck, uint32_t& verCheck, std::string& alertMessage)
 {
     std::vector<std::string> vstr;
     boost::split(vstr, rawAlertStr, boost::is_any_of(":"), boost::token_compress_on);
     if (5 == vstr.size()) {
         try {
-            *alertType = boost::lexical_cast<int32_t>(vstr[0]);
-            *expiryValue = boost::lexical_cast<uint64_t>(vstr[1]);
-            *typeCheck = boost::lexical_cast<uint32_t>(vstr[2]);
-            *verCheck = boost::lexical_cast<uint32_t>(vstr[3]);
+            alertType = boost::lexical_cast<int32_t>(vstr[0]);
+            expiryValue = boost::lexical_cast<uint64_t>(vstr[1]);
+            typeCheck = boost::lexical_cast<uint32_t>(vstr[2]);
+            verCheck = boost::lexical_cast<uint32_t>(vstr[3]);
         } catch (const boost::bad_lexical_cast& e) {
-            PrintToLog("DEBUG ALERT - error in converting values from global alert string\n");
+            PrintToLog("DEBUG ALERT - error in converting values from global alert string: %s\n", e.what());
             return false;
         }
-        *alertMessage = vstr[4];
-        if ((*alertType < 1) || (*alertType > 4) || (*expiryValue == 0)) {
+        alertMessage = vstr[4];
+        if ((alertType < 1) || (alertType > 4) || (expiryValue == 0)) {
             PrintToLog("DEBUG ALERT ERROR - Something went wrong decoding the global alert string, values are not as expected.\n");
             return false;
         }

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -37,6 +37,8 @@ bool CheckAlertAuthorization(const std::string& sender)
     // TODO: add dexX7 <dexx@bitwatch.co>
     // TODO: rename option to be more Omni Core specific
 
+    // TODO: update unit tests, if a source is updated
+
     // Mainnet
     whitelisted.insert("16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj"); // Craig   <craig@omni.foundation>
     whitelisted.insert("1MicH2Vu4YVSvREvxW1zAx2XKo2GQomeXY"); // Michael <michael@omni.foundation>

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -1,0 +1,164 @@
+#include "omnicore/notifications.h"
+
+#include "omnicore/log.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/version.h"
+
+#include "main.h"
+#include "util.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+//! Stores alert messages for Omni Core
+static std::string global_alert_message;
+
+/**
+ * Alert string including meta data.
+ */
+std::string mastercore::getMasterCoreAlertString()
+{
+    return global_alert_message;
+}
+
+/**
+ * Human readable alert message.
+ */
+std::string mastercore::getMasterCoreAlertTextOnly()
+{
+    std::string message;
+    std::vector<std::string> vstr;
+    if (!global_alert_message.empty()) {
+        boost::split(vstr, global_alert_message, boost::is_any_of(":"), boost::token_compress_on);
+        // make sure there are 5 tokens, 5th is text message
+        if (5 == vstr.size()) {
+            message = vstr[4];
+        } else {
+            PrintToLog("DEBUG ALERT ERROR - Something went wrong decoding the global alert string, there are not 5 tokens\n");
+        }
+    }
+    return message;
+}
+
+/**
+ * Sets the alert string.
+ */
+void mastercore::setOmniCoreAlert(const std::string& alertMessage)
+{
+    global_alert_message = alertMessage;
+}
+
+/**
+ * Expires any alerts that need expiring.
+ */
+bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
+{
+    int32_t alertType = 0;
+    uint64_t expiryValue = 0;
+    uint32_t typeCheck = 0;
+    uint32_t verCheck = 0;
+    std::string alertMessage;
+    if (!global_alert_message.empty()) {
+        bool parseSuccess = parseAlertMessage(global_alert_message, &alertType, &expiryValue, &typeCheck, &verCheck, &alertMessage);
+        if (parseSuccess) {
+            switch (alertType) {
+                case 1: //Text based alert only expiring by block number, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
+                    if (curBlock > expiryValue) {
+                        //the alert has expired, clear the global alert string
+                        PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
+                        global_alert_message = "";
+                        return true;
+                    }
+                    break;
+                case 2: //Text based alert only expiring by block time, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
+                    if (curTime > expiryValue) {
+                        //the alert has expired, clear the global alert string
+                        PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
+                        global_alert_message = "";
+                        return true;
+                    }
+                    break;
+                case 3: //Text based alert only expiring by client version, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
+                    if (OMNICORE_VERSION > expiryValue) {
+                        //the alert has expired, clear the global alert string
+                        PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
+                        global_alert_message = "";
+                        return true;
+                    }
+                    break;
+                case 4: //Update alert, show upgrade alert in UI and getalert_MP call + use isTransactionTypeAllowed to verify client support and shutdown if not present
+                    //check of the new tx type is supported at live block
+                    bool txSupported = isTransactionTypeAllowed(expiryValue + 1, OMNI_PROPERTY_MSC, typeCheck, verCheck);
+
+                    // TODO: should be curBlock, not chainActive.Height()?
+                    // TODO: should be curBlock, not chainActive.Height()?
+                    // TODO: should be curBlock, not chainActive.Height()?
+
+                    //check if we are at/past the live blockheight                    
+                    bool txLive = (chainActive.Height()>(int64_t) expiryValue);
+
+                    //testnet allows all types of transactions, so override this here for testing
+                    //txSupported = false; //testing
+                    //txLive = true; //testing
+
+                    if ((!txSupported) && (txLive)) {
+                        // we know we have transactions live we don't understand
+                        // can't be trusted to provide valid data, shutdown
+                        PrintToLog("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message);
+                        PrintToConsole("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message); // echo to screen
+                        if (!GetBoolArg("-overrideforcedshutdown", false)) {
+                            std::string msgText = "Shutting down due to alert: " + getMasterCoreAlertTextOnly();
+                            AbortNode(msgText, msgText); // show same message to user as that which is logged
+                        }
+                        return false;
+                    }
+
+                    if ((!txSupported) && (!txLive)) {
+                        // warn the user this version does not support the new coming TX and they will need to update
+                        // we don't actually need to take any action here, we leave the alert string in place and simply don't expire it
+                    }
+
+                    if (txSupported) {
+                        // we can simply expire this update as this version supports the new coming TX
+                        PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
+                        global_alert_message = "";
+                        return true;
+                    }
+                    break;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Parses an alert string.
+ */
+bool mastercore::parseAlertMessage(const std::string& rawAlertStr, int32_t* alertType, uint64_t* expiryValue, uint32_t* typeCheck, uint32_t* verCheck, std::string* alertMessage)
+{
+    std::vector<std::string> vstr;
+    boost::split(vstr, rawAlertStr, boost::is_any_of(":"), boost::token_compress_on);
+    if (5 == vstr.size()) {
+        try {
+            *alertType = boost::lexical_cast<int32_t>(vstr[0]);
+            *expiryValue = boost::lexical_cast<uint64_t>(vstr[1]);
+            *typeCheck = boost::lexical_cast<uint32_t>(vstr[2]);
+            *verCheck = boost::lexical_cast<uint32_t>(vstr[3]);
+        } catch (const boost::bad_lexical_cast& e) {
+            PrintToLog("DEBUG ALERT - error in converting values from global alert string\n");
+            return false;
+        }
+        *alertMessage = vstr[4];
+        if ((*alertType < 1) || (*alertType > 4) || (*expiryValue == 0)) {
+            PrintToLog("DEBUG ALERT ERROR - Something went wrong decoding the global alert string, values are not as expected.\n");
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -23,10 +23,10 @@ static std::string global_alert_message;
 /**
  * Determines whether the sender is an authorized source for Omni Core alerts.
  *
- * The option "-alertallowsender=source" can be used to whitelist additional sources,
- * and the option "-alertignoresender=source" can be used to ignore a source.
+ * The option "-omnialertallowsender=source" can be used to whitelist additional sources,
+ * and the option "-omnialertignoresender=source" can be used to ignore a source.
  *
- * To consider any alert as authorized, "-alertallowsender=any" can be used. This
+ * To consider any alert as authorized, "-omnialertallowsender=any" can be used. This
  * should only be done for testing purposes!
  */
 bool CheckAlertAuthorization(const std::string& sender)
@@ -34,7 +34,6 @@ bool CheckAlertAuthorization(const std::string& sender)
     std::set<std::string> whitelisted;
 
     // TODO: check email addresses
-    // TODO: rename option to be more Omni Core specific
 
     // Mainnet
     whitelisted.insert("16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj"); // Craig   <craig@omni.foundation>
@@ -49,8 +48,8 @@ bool CheckAlertAuthorization(const std::string& sender)
     whitelisted.insert("mk5SSx4kdexENHzLxk9FLhQdbbBexHUFTW"); // dexX7   <dexx@bitwatch.co>
 
     // Add manually whitelisted sources
-    if (mapArgs.count("-alertallowsender")) {
-        const std::vector<std::string>& sources = mapMultiArgs["-alertallowsender"];
+    if (mapArgs.count("-omnialertallowsender")) {
+        const std::vector<std::string>& sources = mapMultiArgs["-omnialertallowsender"];
 
         for (std::vector<std::string>::const_iterator it = sources.begin(); it != sources.end(); ++it) {
             whitelisted.insert(*it);
@@ -58,8 +57,8 @@ bool CheckAlertAuthorization(const std::string& sender)
     }
 
     // Remove manually ignored sources
-    if (mapArgs.count("-alertignoresender")) {
-        const std::vector<std::string>& sources = mapMultiArgs["-alertignoresender"];
+    if (mapArgs.count("-omnialertignoresender")) {
+        const std::vector<std::string>& sources = mapMultiArgs["-omnialertignoresender"];
 
         for (std::vector<std::string>::const_iterator it = sources.begin(); it != sources.end(); ++it) {
             whitelisted.erase(*it);
@@ -129,7 +128,7 @@ bool CheckExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                         return true;
                     }
                     break;
-                case 2: //Text baseDEBUG d alert only expiring by block time, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
+                case 2: //Text based alert only expiring by block time, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
                     if (curTime > expiryValue) {
                         //the alert has expired, clear the global alert string
                         PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
@@ -149,12 +148,8 @@ bool CheckExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                     //check of the new tx type is supported at live block
                     bool txSupported = isTransactionTypeAllowed(expiryValue + 1, OMNI_PROPERTY_MSC, typeCheck, verCheck);
 
-                    // TODO: should be curBlock, not chainActive.Height()?
-                    // TODO: should be curBlock, not chainActive.Height()?
-                    // TODO: should be curBlock, not chainActive.Height()?
-
                     //check if we are at/past the live blockheight                    
-                    bool txLive = (chainActive.Height()>(int64_t) expiryValue);
+                    bool txLive = (curBlock > (int64_t) expiryValue);
 
                     //testnet allows all types of transactions, so override this here for testing
                     //txSupported = false; //testing

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -34,20 +34,19 @@ bool CheckAlertAuthorization(const std::string& sender)
     std::set<std::string> whitelisted;
 
     // TODO: check email addresses
-    // TODO: add dexX7 <dexx@bitwatch.co>
     // TODO: rename option to be more Omni Core specific
-
-    // TODO: update unit tests, if a source is updated
 
     // Mainnet
     whitelisted.insert("16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj"); // Craig   <craig@omni.foundation>
     whitelisted.insert("1MicH2Vu4YVSvREvxW1zAx2XKo2GQomeXY"); // Michael <michael@omni.foundation>
     whitelisted.insert("1zAtHRASgdHvZDfHs6xJquMghga4eG7gy");  // Zathras <zathras@omni.foundation>
+    whitelisted.insert("1dexX7zmPen1yBz2H9ZF62AK5TGGqGTZH");  // dexX7   <dexx@bitwatch.co>
     whitelisted.insert("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"); // Exodus (who has access?)
 
     // Testnet
     whitelisted.insert("mpDex4kSX4iscrmiEQ8fBiPoyeTH55z23j"); // Michael <michael@omni.foundation>
     whitelisted.insert("mpZATHupfCLqet5N1YL48ByCM1ZBfddbGJ"); // Zathras <zathras@omni.foundation>
+    whitelisted.insert("mk5SSx4kdexENHzLxk9FLhQdbbBexHUFTW"); // dexX7   <dexx@bitwatch.co>
 
     // Add manually whitelisted sources
     if (mapArgs.count("-alertallowsender")) {

--- a/src/omnicore/notifications.h
+++ b/src/omnicore/notifications.h
@@ -6,6 +6,9 @@
 
 namespace mastercore
 {
+/** Determines whether the sender is an authorized source for Omni Core alerts. */
+bool CheckAlertAuthorization(const std::string& sender);
+
 /** Alert string including meta data. */
 std::string getMasterCoreAlertString();
 

--- a/src/omnicore/notifications.h
+++ b/src/omnicore/notifications.h
@@ -10,19 +10,19 @@ namespace mastercore
 bool CheckAlertAuthorization(const std::string& sender);
 
 /** Alert string including meta data. */
-std::string getMasterCoreAlertString();
+std::string GetOmniCoreAlertString();
 
 /** Human readable alert message. */
-std::string getMasterCoreAlertTextOnly();
+std::string GetOmniCoreAlertTextOnly();
 
 /** Sets the alert string. */
-void setOmniCoreAlert(const std::string& alertMessage);
+void SetOmniCoreAlert(const std::string& alertMessage);
 
 /** Expires any alerts that need expiring. */
-bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime);
+bool CheckExpiredAlerts(unsigned int curBlock, uint64_t curTime);
 
 /** Parses an alert string. */
-bool parseAlertMessage(const std::string& rawAlertStr, int32_t* alertType, uint64_t* expiryValue, uint32_t* typeCheck, uint32_t* verCheck, std::string* alertMessage);
+bool ParseAlertMessage(const std::string& rawAlertStr, int32_t& alertType, uint64_t& expiryValue, uint32_t& typeCheck, uint32_t& verCheck, std::string& alertMessage);
 }
 
 #endif // OMNICORE_NOTIFICATIONS_H

--- a/src/omnicore/notifications.h
+++ b/src/omnicore/notifications.h
@@ -1,0 +1,25 @@
+#ifndef OMNICORE_NOTIFICATIONS_H
+#define OMNICORE_NOTIFICATIONS_H
+
+#include <stdint.h>
+#include <string>
+
+namespace mastercore
+{
+/** Alert string including meta data. */
+std::string getMasterCoreAlertString();
+
+/** Human readable alert message. */
+std::string getMasterCoreAlertTextOnly();
+
+/** Sets the alert string. */
+void setOmniCoreAlert(const std::string& alertMessage);
+
+/** Expires any alerts that need expiring. */
+bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime);
+
+/** Parses an alert string. */
+bool parseAlertMessage(const std::string& rawAlertStr, int32_t* alertType, uint64_t* expiryValue, uint32_t* typeCheck, uint32_t* verCheck, std::string* alertMessage);
+}
+
+#endif // OMNICORE_NOTIFICATIONS_H

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -308,8 +308,6 @@ AcceptMap mastercore::my_accepts;
 CMPSPInfo *mastercore::_my_sps;
 CrowdMap mastercore::my_crowds;
 
-PendingMap mastercore::my_pending;
-
 // this is the master list of all amounts for all addresses for all properties, map is sorted by Bitcoin address
 std::map<std::string, CMPTally> mastercore::mp_tally_map;
 
@@ -2073,6 +2071,7 @@ static void clear_all_state()
     my_accepts.clear();
     my_crowds.clear();
     metadex.clear();
+    my_pending.clear();
 
     // LevelDB based storage
     _my_sps->Clear();

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2324,12 +2324,12 @@ int CMPTxList::setLastAlert(int blockHeight)
            {
                if (atoi(vstr[0]) == 1) // is it valid?
                {
-                   if ( (atoi(vstr[1]) > lastAlertBlock) && (atoi(vstr[1]) < blockHeight) ) // is it the most recent and within our parsed range?
-                   {
-                      lastAlertTxid = skey.ToString();
-                      lastAlertData = svalue.ToString();
-                      lastAlertBlock = atoi(vstr[1]);
-                   }
+                    if ((atoi(vstr[1]) > lastAlertBlock) && (atoi(vstr[1]) <= blockHeight)) // is it the most recent and within our parsed range?
+                    {
+                        lastAlertTxid = skey.ToString();
+                        lastAlertData = svalue.ToString();
+                        lastAlertBlock = atoi(vstr[1]);
+                    }
                }
            }
        }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2365,12 +2365,15 @@ int CMPTxList::setLastAlert(int blockHeight)
                 {
                     if(65535 == mp_obj.getType())
                     {
+                        // TODO: use new parsing/interpretation functions
                         if (0 == mp_obj.step2_Alert(&new_global_alert_message))
                         {
-                            setOmniCoreAlert(new_global_alert_message);
+                            SetOmniCoreAlert(new_global_alert_message);
                             // check if expired
-                            CBlockIndex* mpBlockIndex = chainActive[blockHeight];
-                            (void) checkExpiredAlerts(blockHeight, mpBlockIndex->GetBlockTime());
+                            CBlockIndex* pBlockIndex = chainActive[blockHeight];
+                            if (pBlockIndex != NULL) {
+                                CheckExpiredAlerts(blockHeight, pBlockIndex->GetBlockTime());
+                            }
                         }
                     }
                 }
@@ -3301,7 +3304,7 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     set_wallet_totals();
 
     // check the alert status, do we need to do anything else here?
-    checkExpiredAlerts(nBlockNow, pBlockIndex->GetBlockTime());
+    CheckExpiredAlerts(nBlockNow, pBlockIndex->GetBlockTime());
 
     // force an update of the UI once per processed block containing Omni transactions
     if (countMP > 0) { // there were Omni transactions in this block

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2219,7 +2219,10 @@ static bool UseEncodingClassC(size_t nDataSize)
 {
     size_t nTotalSize = nDataSize + 2; // Marker "om"
     bool fDataEnabled = GetBoolArg("-datacarrier", true);
-
+    int nBlockNow = GetHeight();
+    if (!isAllowedOutputType(TX_NULL_DATA, nBlockNow)) {
+        fDataEnabled = false;
+    }
     return nTotalSize <= nMaxDatacarrierBytes && fDataEnabled;
 }
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -255,15 +255,6 @@ inline bool UnitTest()
     return Params().NetworkIDString() == "unittest";
 }
 
-string FormatPriceMP(double n)
-{
-  string str = strprintf("%lf", n);
-  // clean up trailing zeros - good for RPC not so much for UI
-  str.erase ( str.find_last_not_of('0') + 1, std::string::npos );
-  if (str.length() > 0) { std::string::iterator it = str.end() - 1; if (*it == '.') { str.erase(it); } } //get rid of trailing dot if non decimal
-return str;
-}
-
 string FormatDivisibleShortMP(int64_t n)
 {
 int64_t n_abs = (n > 0 ? n : -n);
@@ -363,31 +354,6 @@ int64_t pending = getMPbalance(Address, property, PENDING);
   }
 
   return money;
-}
-
-bool isRangeOK(const uint64_t input)
-{
-  if (MAX_INT_8_BYTES < input) return false;
-
-  return true;
-}
-
-// returns false if we are out of range and/or overflow
-// call just before multiplying large numbers
-bool isMultiplicationOK(const uint64_t a, const uint64_t b)
-{
-  if (!a || !b) return true;
-
-  if (MAX_INT_8_BYTES < a) return false;
-  if (MAX_INT_8_BYTES < b) return false;
-
-  const uint64_t result = a*b;
-
-  if (MAX_INT_8_BYTES < result) return false;
-
-  if ((0 != a) && (result / a != b)) return false;
-
-  return true;
 }
 
 bool mastercore::isTestEcosystemProperty(unsigned int property)

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1970,17 +1970,10 @@ int mastercore_init()
         }
     }
 
-    // TODO: the databases should be wiped, when reindexing, but currently,
-    // due to the block disconnect handlers, this results in different state,
-    // which is not correct. Util this is resolved, the original behavior is
-    // mirrored.
-    //
-    // See discussion: https://github.com/OmniLayer/omnicore/pull/25
-
-    t_tradelistdb = new CMPTradeList(GetDataDir() / "MP_tradelist", false);
-    s_stolistdb = new CMPSTOList(GetDataDir() / "MP_stolist", false);
-    p_txlistdb = new CMPTxList(GetDataDir() / "MP_txlist", false);
-    _my_sps = new CMPSPInfo(GetDataDir() / "MP_spinfo", false);
+    t_tradelistdb = new CMPTradeList(GetDataDir() / "MP_tradelist", fReindex);
+    s_stolistdb = new CMPSTOList(GetDataDir() / "MP_stolist", fReindex);
+    p_txlistdb = new CMPTxList(GetDataDir() / "MP_txlist", fReindex);
+    _my_sps = new CMPSPInfo(GetDataDir() / "MP_spinfo", fReindex);
 
     MPPersistencePath = GetDataDir() / "MP_persist";
     TryCreateDirectory(MPPersistencePath);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -749,8 +749,10 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
           GetScriptPushes(wtx.vout[i].scriptPubKey, temp_op_return_script_data);
           if (temp_op_return_script_data.size() > 0) {
               if (temp_op_return_script_data[0].size() > 8) {
+                  // only v0/v1 (and alert) txs are live, add 6f6d0002 to parse a v2 tx when one goes live
                   if(("6f6d0000" == temp_op_return_script_data[0].substr(0,8)) ||
-                     ("6f6d0001" == temp_op_return_script_data[0].substr(0,8))) { // only v0/v1 txs are live, add 6f6d0002 to parse a v2 tx when one goes live
+                     ("6f6d0001" == temp_op_return_script_data[0].substr(0,8)) ||
+                     ("6f6dffff" == temp_op_return_script_data[0].substr(0,8))) {
                       hasOmniBytes = true;
                   }
               }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2286,7 +2286,6 @@ int mastercore::ClassAgnosticWalletTXBuilder(const string &senderAddress, const 
     // Now we have what we need to pass to the wallet to create the transaction, perform some checks first
     if (!wallet) return MP_ERR_WALLET_ACCESS;
     if (!coinControl.HasSelected()) return MP_ERR_INPUTSELECT_FAIL;
-    LOCK(wallet->cs_wallet);
 
     // Ask the wallet to create the transaction (note mining fee determined by Bitcoin Core params)
     if (!wallet->CreateTransaction(vecSend, wtxNew, reserveKey, nFeeRet, strFailReason, &coinControl)) { return MP_ERR_CREATE_TX; }

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -380,22 +380,6 @@ public:
     bool isMPinBlockRange(int, int, bool);
 };
 
-class CMPPending
-{
-public:
-  string src; // the FromAddress
-  unsigned int prop;
-  int64_t amount;
-  int64_t type;
-  string desc; // the description
-
-  void print(uint256 txid) const
-  {
-    PrintToConsole("%s : %s %d %ld %ld %s\n", txid.GetHex(), src, prop, amount, type, desc);
-  }
- 
-};
-
 extern uint64_t global_metadex_market;
 //! Available balances of wallet properties in the main ecosystem
 extern std::map<uint32_t, int64_t> global_balance_money_maineco;
@@ -432,8 +416,6 @@ extern CMPTxList *p_txlistdb;
 extern CMPTradeList *t_tradelistdb;
 extern CMPSTOList *s_stolistdb;
 
-typedef std::map<uint256, CMPPending> PendingMap;
-extern PendingMap my_pending;
 string strMPProperty(unsigned int i);
 
 int GetHeight(void);

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -438,7 +438,6 @@ uint32_t GetNextPropertyId(bool maineco);
 CMPTally *getTally(const string & address);
 
 int64_t getTotalTokens(unsigned int propertyId, int64_t *n_owners_total = NULL);
-bool checkExpiredAlerts(unsigned int curBlock, uint64_t curTime);
 int set_wallet_totals();
 
 char *c_strMasterProtocolTXType(int i);
@@ -448,10 +447,7 @@ bool isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 
 bool update_tally_map(string who, unsigned int which_currency, int64_t amount, TallyType ttype);
-void setOmniCoreAlert(const std::string& alertMessage);
-std::string getMasterCoreAlertString();
-std::string getMasterCoreAlertTextOnly();
-bool parseAlertMessage(std::string rawAlertStr, int32_t *alertType, uint64_t *expiryValue, uint32_t *typeCheck, uint32_t *verCheck, std::string *alertMessage);
+
 std::string getTokenLabel(unsigned int propertyId);
 }
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -420,11 +420,9 @@ string strMPProperty(unsigned int i);
 int GetHeight(void);
 uint32_t GetLatestBlockTime(void);
 CBlockIndex* GetBlockIndex(const uint256& hash);
-bool isPropertyDivisible(unsigned int propertyId);
-string getPropertyName(unsigned int propertyId);
-bool isCrowdsaleActive(unsigned int propertyId);
-bool isCrowdsalePurchase(uint256 txid, string address, int64_t *propertyId = NULL, int64_t *userTokens = NULL, int64_t *issuerTokens = NULL);
+
 bool isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound);
+
 std::string FormatIndivisibleMP(int64_t n);
 
 int ClassAgnosticWalletTXBuilder(const string &senderAddress, const string &receiverAddress, const string &redemptionAddress,
@@ -432,7 +430,7 @@ int ClassAgnosticWalletTXBuilder(const string &senderAddress, const string &rece
 
 bool isTestEcosystemProperty(unsigned int property);
 bool isMainEcosystemProperty(unsigned int property);
-uint32_t GetNextPropertyId(bool maineco);
+uint32_t GetNextPropertyId(bool maineco); // maybe move into sp
 
 CMPTally *getTally(const string & address);
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -65,9 +65,8 @@ int const MAX_STATE_HISTORY = 50;
 // Maximum outputs per BTC Transaction
 #define MAX_BTC_OUTPUTS 16
 
-#define MAX_SHA256_OBFUSCATION_TIMES  255
-
 #define MIN_PAYLOAD_SIZE     8
+
 #define PACKET_SIZE_CLASS_A 19
 #define PACKET_SIZE         31
 #define MAX_PACKETS         64

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -155,11 +155,9 @@ enum FILETYPES {
 #define OMNI_PROPERTY_TMSC  2
 
 // forward declarations
-std::string FormatPriceMP(double n);
 std::string FormatDivisibleMP(int64_t n, bool fSign = false);
 std::string FormatDivisibleShortMP(int64_t);
 std::string FormatMP(unsigned int, int64_t n, bool fSign = false);
-uint256 send_MP(const string &FromAddress, const string &ToAddress, const string &RedeemAddress, unsigned int PropertyID, uint64_t Amount);
 int64_t feeCheck(const string &address);
 
 /** Returns the Exodus address. */
@@ -411,8 +409,6 @@ extern std::map<uint32_t, int64_t> global_balance_reserved_testeco;
 int64_t getMPbalance(const string &Address, unsigned int property, TallyType ttype);
 int64_t getUserAvailableMPbalance(const string &Address, unsigned int property);
 bool IsMyAddress(const std::string &address);
-bool isRangeOK(const uint64_t input);
-int pendingAdd(const uint256 &txid, const string &FromAddress, unsigned int propId, int64_t Amount, int64_t type, const string &txDesc);
 
 string getLabel(const string &address);
 

--- a/src/omnicore/pending.cpp
+++ b/src/omnicore/pending.cpp
@@ -2,6 +2,7 @@
 
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
 
 #include "uint256.h"
 

--- a/src/omnicore/pending.h
+++ b/src/omnicore/pending.h
@@ -2,16 +2,42 @@
 #define OMNICORE_PENDING_H
 
 class uint256;
+class CMPPending;
 
 #include <stdint.h>
+#include <map>
 #include <string>
+
+namespace mastercore
+{
+//! Map of pending transaction objects
+typedef std::map<uint256, CMPPending> PendingMap;
+//! Global map of pending transaction objects
+extern PendingMap my_pending;
 
 /** Adds a transaction to the pending map using supplied parameters. */
 void PendingAdd(const uint256& txid, const std::string& sendingAddress, const std::string& refAddress, uint16_t type, uint32_t propertyId, int64_t amount, uint32_t propertyIdDesired = 0, int64_t amountDesired = 0, int64_t action = 0);
 
 /** Deletes a transaction from the pending map and credits the amount back to the pending tally for the address. */
 void PendingDelete(const uint256& txid);
+}
+
+/** Structure to hold information about pending transactions.
+ */
+struct CMPPending
+{
+    std::string src;  // the source address
+    uint32_t prop;
+    int64_t amount;
+    uint32_t type;
+    std::string desc; // the description
+
+    /** Default constructor. */
+    CMPPending() : prop(0), amount(0), type(0) {};
+
+    /** Prints information about a pending transaction object. */
+    void print(const uint256& txid) const;
+};
 
 
 #endif // OMNICORE_PENDING_H
-

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -8,6 +8,7 @@
 #include "omnicore/errors.h"
 #include "omnicore/log.h"
 #include "omnicore/mdex.h"
+#include "omnicore/notifications.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/parse_string.h"
 #include "omnicore/rpcrequirements.h"

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1749,7 +1749,7 @@ Value getinfo_MP(const Array& params, bool fHelp)
 
     // handle alerts
     Object alertResponse;
-    std::string global_alert_message = getMasterCoreAlertString();
+    std::string global_alert_message = GetOmniCoreAlertString();
 
     if (!global_alert_message.empty()) {
         int32_t alertType = 0;
@@ -1758,7 +1758,7 @@ Value getinfo_MP(const Array& params, bool fHelp)
         uint32_t verCheck = 0;
         std::string alertTypeStr;
         std::string alertMessage;
-        bool parseSuccess = parseAlertMessage(global_alert_message, &alertType, &expiryValue, &typeCheck, &verCheck, &alertMessage);
+        bool parseSuccess = ParseAlertMessage(global_alert_message, alertType, expiryValue, typeCheck, verCheck, alertMessage);
         if (parseSuccess) {
             switch (alertType) {
                 case 0: alertTypeStr = "error";

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -6,23 +6,13 @@
 #include "omnicore/persistence.h"
 
 class CBlockIndex;
+class uint256;
 
-#include "base58.h"
-#include "tinyformat.h"
-#include "uint256.h"
-#include "utiltime.h"
-
-#include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <openssl/sha.h>
 
-#include "json/json_spirit_reader_template.h"
 #include "json/json_spirit_value.h"
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -32,474 +22,156 @@ class CBlockIndex;
 #include <string>
 #include <vector>
 
-using boost::algorithm::token_compress_on;
-
-using json_spirit::Object;
-using json_spirit::Pair;
-using json_spirit::Value;
-using json_spirit::read_string;
-using json_spirit::obj_type;
-
-using std::string;
-
 /** LevelDB based storage for currencies, smart properties and tokens.
  */
 class CMPSPInfo : public CDBBase
 {
 public:
-  struct Entry {
-    // common SP data
-    string issuer;
-    unsigned short prop_type;
-    unsigned int prev_prop_id;
-    string category;
-    string subcategory;
-    string name;
-    string url;
-    string data;
-    uint64_t num_tokens;
+    struct Entry {
+        // common SP data
+        std::string issuer;
+        unsigned short prop_type;
+        unsigned int prev_prop_id;
+        std::string category;
+        std::string subcategory;
+        std::string name;
+        std::string url;
+        std::string data;
+        uint64_t num_tokens;
 
-    // Crowdsale generated SP
+        // crowdsale generated SP
+        unsigned int property_desired;
+        uint64_t deadline;
+        unsigned char early_bird;
+        unsigned char percentage;
+
+        // closedearly states, if the SP was a crowdsale and closed due to MAXTOKENS or CLOSE command
+        bool close_early;
+        bool max_tokens;
+        uint64_t missedTokens;
+        uint64_t timeclosed;
+        uint256 txid_close;
+
+        // other information
+        uint256 txid;
+        uint256 creation_block;
+        uint256 update_block;
+        bool fixed;
+        bool manual;
+
+        // for crowdsale properties, schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
+        // for manual properties, schema is 'txid:grantAmount:revokeAmount;'
+        std::map<std::string, std::vector<uint64_t> > historicalData;
+
+        Entry();
+
+        json_spirit::Object toJSON() const;
+        void fromJSON(const json_spirit::Object& json);
+        bool isDivisible() const;
+        void print() const;
+    };
+
+private:
+    // implied version of msc and tmsc so they don't hit the leveldb
+    Entry implied_msc;
+    Entry implied_tmsc;
+
+    unsigned int next_spid;
+    unsigned int next_test_spid;
+
+public:
+    CMPSPInfo(const boost::filesystem::path& path, bool fWipe);
+    virtual ~CMPSPInfo();
+
+    void init(unsigned int nextSPID = 0x3UL, unsigned int nextTestSPID = TEST_ECO_PROPERTY_1);
+
+    unsigned int peekNextSPID(unsigned char ecosystem) const;
+    unsigned int updateSP(unsigned int propertyID, const Entry& info);
+    unsigned int putSP(unsigned char ecosystem, const Entry& info);
+    bool getSP(unsigned int spid, Entry& info) const;
+    bool hasSP(unsigned int spid) const;
+    unsigned int findSPByTX(const uint256& txid) const;
+
+    int popBlock(const uint256& block_hash);
+
+    static std::string const watermarkKey;
+    void setWatermark(const uint256& watermark);
+    int getWatermark(uint256& watermark) const;
+
+    void printAll() const;
+};
+
+/** A live crowdsale.
+ */
+class CMPCrowd
+{
+private:
+    unsigned int propertyId;
+
+    uint64_t nValue;
+
     unsigned int property_desired;
     uint64_t deadline;
     unsigned char early_bird;
     unsigned char percentage;
 
-    //We need this. Closedearly states if the SP was a crowdsale and closed due to MAXTOKENS or CLOSE command
-    bool close_early;
-    bool max_tokens;
-    uint64_t  missedTokens;
-    uint64_t timeclosed;
-    uint256 txid_close;
+    uint64_t u_created;
+    uint64_t i_created;
 
-    // other information
-    uint256 txid;
-    uint256 creation_block;
-    uint256 update_block;
-    bool fixed;
-    bool manual;
+    uint256 txid; // NOTE: not persisted as it doesnt seem used
 
-    // for crowdsale properties, schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
-    // for manual properties, schema is 'txid:grantAmount:revokeAmount;'
-    std::map<std::string, std::vector<uint64_t> > historicalData;
-    
-    Entry()
-    : issuer()
-    , prop_type(0)
-    , prev_prop_id(0)
-    , category()
-    , subcategory()
-    , name()
-    , url()
-    , data()
-    , num_tokens(0)
-    , property_desired(0)
-    , deadline(0)
-    , early_bird(0)
-    , percentage(0)
-    , close_early(0)
-    , max_tokens(0)
-    , missedTokens(0)
-    , timeclosed(0)
-    , txid_close()
-    , txid()
-    , creation_block()
-    , update_block()
-    , fixed(false)
-    , manual(false)
-    , historicalData()
-    {
-    }
-
-    Object toJSON() const
-    {
-      Object spInfo;
-      spInfo.push_back(Pair("issuer", issuer));
-      spInfo.push_back(Pair("prop_type", prop_type));
-      spInfo.push_back(Pair("prev_prop_id", (uint64_t)prev_prop_id));
-      spInfo.push_back(Pair("category", category));
-      spInfo.push_back(Pair("subcategory", subcategory));
-      spInfo.push_back(Pair("name", name));
-      spInfo.push_back(Pair("url", url));
-      spInfo.push_back(Pair("data", data));
-      spInfo.push_back(Pair("fixed", fixed));
-      spInfo.push_back(Pair("manual", manual));
-
-      spInfo.push_back(Pair("num_tokens", strprintf("%d", num_tokens)));
-      if (false == fixed && false == manual) {
-        spInfo.push_back(Pair("property_desired", (uint64_t)property_desired));
-        spInfo.push_back(Pair("deadline", strprintf("%d", deadline)));
-        spInfo.push_back(Pair("early_bird", (int)early_bird));
-        spInfo.push_back(Pair("percentage", (int)percentage));
-
-        spInfo.push_back(Pair("close_early", (int)close_early));
-        spInfo.push_back(Pair("max_tokens", (int)max_tokens));
-        spInfo.push_back(Pair("missedTokens", (int) missedTokens));
-        spInfo.push_back(Pair("timeclosed", strprintf("%d", timeclosed)));
-        spInfo.push_back(Pair("txid_close", txid_close.ToString()));
-      }
-
-      //Initialize values
-      std::map<std::string, std::vector<uint64_t> >::const_iterator it;
-      
-      std::string values_long = "";
-      std::string values = "";
-
-      //Iterate through fundraiser data, serializing it with txid:val:val:val:val;
-      bool crowdsale = !fixed && !manual;
-      for(it = historicalData.begin(); it != historicalData.end(); it++) {
-         values += it->first;
-         if (crowdsale) {
-           values += ":" + boost::lexical_cast<std::string>(it->second.at(0));
-           values += ":" + boost::lexical_cast<std::string>(it->second.at(1));
-           values += ":" + boost::lexical_cast<std::string>(it->second.at(2));
-           values += ":" + boost::lexical_cast<std::string>(it->second.at(3));
-         } else if (manual) {
-           values += ":" + boost::lexical_cast<std::string>(it->second.at(0));
-           values += ":" + boost::lexical_cast<std::string>(it->second.at(1));
-         }
-         values += ";";
-         values_long += values;
-      }
-
-      spInfo.push_back(Pair("historicalData", values_long));
-      spInfo.push_back(Pair("txid", txid.ToString()));
-      spInfo.push_back(Pair("creation_block", creation_block.ToString()));
-      spInfo.push_back(Pair("update_block", update_block.ToString()));
-      return spInfo;
-    }
-
-    void fromJSON(Object const &json)
-    {
-      unsigned int idx = 0;
-      issuer = json[idx++].value_.get_str();
-      prop_type = (unsigned short)json[idx++].value_.get_int();
-      prev_prop_id = (unsigned int)json[idx++].value_.get_uint64();
-      category = json[idx++].value_.get_str();
-      subcategory = json[idx++].value_.get_str();
-      name = json[idx++].value_.get_str();
-      url = json[idx++].value_.get_str();
-      data = json[idx++].value_.get_str();
-      fixed = json[idx++].value_.get_bool();
-      manual = json[idx++].value_.get_bool();
-
-      num_tokens = boost::lexical_cast<uint64_t>(json[idx++].value_.get_str());
-      if (false == fixed && false == manual) {
-        property_desired = (unsigned int)json[idx++].value_.get_uint64();
-        deadline = boost::lexical_cast<uint64_t>(json[idx++].value_.get_str());
-        early_bird = (unsigned char)json[idx++].value_.get_int();
-        percentage = (unsigned char)json[idx++].value_.get_int();
-
-        close_early = (unsigned char)json[idx++].value_.get_int();
-        max_tokens = (unsigned char)json[idx++].value_.get_int();
-        missedTokens = (unsigned char)json[idx++].value_.get_int();
-        timeclosed = boost::lexical_cast<uint64_t>(json[idx++].value_.get_str());
-        txid_close = uint256(json[idx++].value_.get_str());
-      }
-
-      //reconstruct database
-      std::string longstr = json[idx++].value_.get_str();
-
-      std::vector<std::string> strngs_vec;
-      
-      //split serialized form up
-      boost::split(strngs_vec, longstr, boost::is_any_of(";"));
-
-      //Go through and deserialize the database
-      bool crowdsale = !fixed && !manual;
-      for(std::vector<std::string>::size_type i = 0; i != strngs_vec.size(); i++) {
-        if (strngs_vec[i].empty()) {
-          continue;
-        }
-        
-        std::vector<std::string> str_split_vec;
-        boost::split(str_split_vec, strngs_vec[i], boost::is_any_of(":"));
-
-        std::vector<uint64_t> txDataVec;
-
-        if ( crowdsale && str_split_vec.size() == 5) {
-          txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(1) ));
-          txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(2) ));
-          txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(3) ));
-          txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(4) ));
-        } else if (manual && str_split_vec.size() == 3) {
-          txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(1) ));
-          txDataVec.push_back(boost::lexical_cast<uint64_t>( str_split_vec.at(2) ));
-        }
-
-        historicalData.insert(std::make_pair( str_split_vec.at(0), txDataVec ) ) ;
-      }
-      txid = uint256(json[idx++].value_.get_str());
-      creation_block = uint256(json[idx++].value_.get_str());
-      update_block = uint256(json[idx++].value_.get_str());
-    }
-
-    bool isDivisible() const
-    {
-      switch (prop_type)
-      {
-        case MSC_PROPERTY_TYPE_DIVISIBLE:
-        case MSC_PROPERTY_TYPE_DIVISIBLE_REPLACING:
-        case MSC_PROPERTY_TYPE_DIVISIBLE_APPENDING:
-          return true;
-      }
-      return false;
-    }
-
-    void print() const
-    {
-      PrintToConsole("%s:%s(Fixed=%s,Divisible=%s):%lu:%s/%s, %s %s\n",
-        issuer,
-        name,
-        fixed ? "Yes" : "No",
-        isDivisible() ? "Yes" : "No",
-        num_tokens,
-        category, subcategory, url, data);
-    }
-
-  };
-
-private:
-  // implied version of msc and tmsc so they don't hit the leveldb
-  Entry implied_msc;
-  Entry implied_tmsc;
-
-  unsigned int next_spid;
-  unsigned int next_test_spid;
+    std::map<std::string, std::vector<uint64_t> > txFundraiserData; // schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
 
 public:
-  CMPSPInfo(const boost::filesystem::path& path, bool fWipe)
-  {
-    leveldb::Status status = Open(path, fWipe);
-    PrintToConsole("Loading smart property database: %s\n", status.ToString());
+    CMPCrowd();
+    CMPCrowd(unsigned int pid, uint64_t nv, unsigned int cd, uint64_t dl, unsigned char eb, unsigned char per, uint64_t uct, uint64_t ict);
 
-    // special cases for constant SPs MSC and TMSC
-    implied_msc.issuer = ExodusAddress().ToString();
-    implied_msc.prop_type = MSC_PROPERTY_TYPE_DIVISIBLE;
-    implied_msc.num_tokens = 700000;
-    implied_msc.category = "N/A";
-    implied_msc.subcategory = "N/A";
-    implied_msc.name = "MasterCoin";
-    implied_msc.url = "www.mastercoin.org";
-    implied_msc.data = "***data***";
-    implied_tmsc.issuer = ExodusAddress().ToString();
-    implied_tmsc.prop_type = MSC_PROPERTY_TYPE_DIVISIBLE;
-    implied_tmsc.num_tokens = 700000;
-    implied_tmsc.category = "N/A";
-    implied_tmsc.subcategory = "N/A";
-    implied_tmsc.name = "Test MasterCoin";
-    implied_tmsc.url = "www.mastercoin.org";
-    implied_tmsc.data = "***data***";
+    unsigned int getPropertyId() const { return propertyId; }
 
-    init();
-  }
+    uint64_t getDeadline() const { return deadline; }
+    uint64_t getCurrDes() const { return property_desired; }
 
-  virtual ~CMPSPInfo()
-  {
-    if (msc_debug_persistence) PrintToLog("CMPSPInfo closed\n");
-  }
+    void incTokensUserCreated(uint64_t amount) { u_created += amount; }
+    void incTokensIssuerCreated(uint64_t amount) { i_created += amount; }
 
-  void init(unsigned int nextSPID = 0x3UL, unsigned int nextTestSPID = TEST_ECO_PROPERTY_1)
-  {
-    next_spid = nextSPID;
-    next_test_spid = nextTestSPID;
-  }
+    uint64_t getUserCreated() const { return u_created; }
+    uint64_t getIssuerCreated() const { return i_created; }
 
-  unsigned int peekNextSPID(unsigned char ecosystem)
-  {
-    unsigned int nextId = 0;
+    void insertDatabase(const std::string& txhash, const std::vector<uint64_t>& txdata);
+    std::map<std::string, std::vector<uint64_t> > getDatabase() const { return txFundraiserData; }
 
-    switch(ecosystem) {
-    case OMNI_PROPERTY_MSC: // mastercoin ecosystem, MSC: 1, TMSC: 2, First available SP = 3
-      nextId = next_spid;
-      break;
-    case OMNI_PROPERTY_TMSC: // Test MSC ecosystem, same as above with high bit set
-      nextId = next_test_spid;
-      break;
-    default: // non standard ecosystem, ID's start at 0
-      nextId = 0;
-    }
-
-    return nextId;
-  }
-
-  unsigned int updateSP(unsigned int propertyID, Entry const &info);
-  unsigned int putSP(unsigned char ecosystem, Entry const &info);
-  bool getSP(unsigned int spid, Entry &info);
-  bool hasSP(unsigned int spid);
-
-  unsigned int findSPByTX(uint256 const &txid);
-
-  int popBlock(uint256 const &block_hash);
-
-  static string const watermarkKey;
-  void setWatermark(uint256 const &watermark)
-  {
-    leveldb::WriteBatch commitBatch;
-    commitBatch.Delete(watermarkKey);
-    commitBatch.Put(watermarkKey, watermark.ToString());
-    pdb->Write(syncoptions, &commitBatch);
-  }
-
-  int getWatermark(uint256 &watermark)
-  {
-    string watermarkVal;
-    if (pdb->Get(readoptions, watermarkKey, &watermarkVal).ok()) {
-      watermark.SetHex(watermarkVal);
-      return 0;
-    } else {
-      return -1;
-    }
-  }
-
-  void printAll()
-  {
-    // print off the hard coded MSC and TMSC entries
-    for (unsigned int idx = OMNI_PROPERTY_MSC; idx <= OMNI_PROPERTY_TMSC; idx++ ) {
-      Entry info;
-      PrintToConsole("%10d => ", idx);
-      if (getSP(idx, info)) {
-        info.print();
-      } else {
-        PrintToConsole("<Internal Error on implicit SP>\n");
-      }
-    }
-
-    leveldb::Iterator *iter = NewIterator();
-    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-      if (iter->key().starts_with("sp-")) {
-        std::vector<std::string> vstr;
-        std::string key = iter->key().ToString();
-        boost::split(vstr, key, boost::is_any_of("-"), token_compress_on);
-
-        PrintToConsole("%10s => ", vstr[1]);
-
-        // parse the encoded json, failing if it doesnt parse or is an object
-        Value spInfoVal;
-        if (read_string(iter->value().ToString(), spInfoVal) && spInfoVal.type() == obj_type ) {
-          Entry info;
-          info.fromJSON(spInfoVal.get_obj());
-          info.print();
-        } else {
-          PrintToConsole("<Malformed JSON in DB>\n");
-        }
-      }
-    }
-
-    // clean up the iterator
-    delete iter;
-  }
+    void print(const std::string& address, FILE* fp = stdout) const;
+    void saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& addr) const;
 };
-
-// live crowdsales are these objects in a map
-class CMPCrowd
-{
-private:
-  unsigned int propertyId;
-
-  uint64_t nValue;
-
-  unsigned int property_desired;
-  uint64_t deadline;
-  unsigned char early_bird;
-  unsigned char percentage;
-
-  uint64_t u_created;
-  uint64_t i_created;
-
-  uint256 txid;  // NOTE: not persisted as it doesnt seem used
-
-  std::map<std::string, std::vector<uint64_t> > txFundraiserData;  // schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
-public:
-  CMPCrowd():propertyId(0),nValue(0),property_desired(0),deadline(0),early_bird(0),percentage(0),u_created(0),i_created(0)
-  {
-  }
-
-  CMPCrowd(unsigned int pid, uint64_t nv, unsigned int cd, uint64_t dl, unsigned char eb, unsigned char per, uint64_t uct, uint64_t ict):
-   propertyId(pid),nValue(nv),property_desired(cd),deadline(dl),early_bird(eb),percentage(per),u_created(uct),i_created(ict)
-  {
-  }
-
-  unsigned int getPropertyId() const { return propertyId; }
-
-  uint64_t getDeadline() const { return deadline; }
-  uint64_t getCurrDes() const { return property_desired; }
-
-  void incTokensUserCreated(uint64_t amount) { u_created += amount; }
-  void incTokensIssuerCreated(uint64_t amount) { i_created += amount; }
-
-  uint64_t getUserCreated() const { return u_created; }
-  uint64_t getIssuerCreated() const { return i_created; }
-
-  void insertDatabase(std::string txhash, std::vector<uint64_t> txdata ) { txFundraiserData.insert(std::make_pair<std::string, std::vector<uint64_t>& >(txhash,txdata)); }
-  std::map<std::string, std::vector<uint64_t> > getDatabase() const { return txFundraiserData; }
-
-  void print(const std::string& address, FILE *fp = stdout) const
-  {
-    fprintf(fp, "%34s : id=%u=%X; prop=%u, value= %lu, deadline: %s (%lX)\n", address.c_str(), propertyId, propertyId,
-     property_desired, nValue, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline).c_str(), deadline);
-  }
-
-  void saveCrowdSale(std::ofstream &file, SHA256_CTX *shaCtx, std::string const &addr) const
-  {
-    // compose the outputline
-    // addr,propertyId,nValue,property_desired,deadline,early_bird,percentage,created,mined
-    std::string lineOut = strprintf("%s,%d,%d,%d,%d,%d,%d,%d,%d",
-      addr,
-      propertyId,
-      nValue,
-      property_desired,
-      deadline,
-      (int)early_bird,
-      (int)percentage,
-      u_created,
-      i_created);
-
-    // append N pairs of address=nValue;blockTime for the database
-    std::map<std::string, std::vector<uint64_t> >::const_iterator iter;
-    for (iter = txFundraiserData.begin(); iter != txFundraiserData.end(); ++iter) {
-      lineOut.append(strprintf(",%s=", (*iter).first));
-      std::vector<uint64_t> const &vals = (*iter).second;
-
-      std::vector<uint64_t>::const_iterator valIter;
-      for (valIter = vals.begin(); valIter != vals.end(); ++valIter) {
-        if (valIter != vals.begin()) {
-          lineOut.append(";");
-        }
-
-        lineOut.append(strprintf("%d", *valIter));
-      }
-    }
-
-    // add the line to the hash
-    SHA256_Update(shaCtx, lineOut.c_str(), lineOut.length());
-
-    // write the line
-    file << lineOut << std::endl;
-  }
-};  // end of CMPCrowd class
 
 namespace mastercore
 {
-extern CMPSPInfo *_my_sps;
+typedef std::map<std::string, CMPCrowd> CrowdMap;
 
-typedef std::map<string, CMPCrowd> CrowdMap;
-
+extern CMPSPInfo* _my_sps;
 extern CrowdMap my_crowds;
 
-char *c_strPropertyType(int i);
+const char* c_strPropertyType(int propertyType);
 
-CMPCrowd *getCrowd(const string & address);
+std::string getPropertyName(unsigned int propertyId);
+bool isPropertyDivisible(unsigned int propertyId);
 
+CMPCrowd* getCrowd(const std::string& address);
+
+bool isCrowdsaleActive(unsigned int propertyId);
+bool isCrowdsalePurchase(const uint256& txid, const std::string& address, int64_t* propertyId, int64_t* userTokens, int64_t* issuerTokens);
+
+// TODO: check, if this could be combined with the other calculate* functions
 int calculateFractional(unsigned short int propType, unsigned char bonusPerc, uint64_t fundraiserSecs, 
-  uint64_t numProps, unsigned char issuerPerc, const std::map<std::string, std::vector<uint64_t> > txFundraiserData, 
-  const uint64_t amountPremined  );
+  uint64_t numProps, unsigned char issuerPerc, const std::map<std::string, std::vector<uint64_t> >& txFundraiserData, 
+  const uint64_t amountPremined);
 
-void eraseMaxedCrowdsale(const string &address, uint64_t blockTime, int block);
+void eraseMaxedCrowdsale(const std::string& address, uint64_t blockTime, int block);
 
-unsigned int eraseExpiredCrowdsale(CBlockIndex const * pBlockIndex);
+unsigned int eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex);
 
-void dumpCrowdsaleInfo(const string &address, CMPCrowd &crowd, bool bExpired = false);
+// TODO: depreciate
+void dumpCrowdsaleInfo(const std::string& address, const CMPCrowd& crowd, bool bExpired = false);
 }
 
 

--- a/src/omnicore/test/alert_tests.cpp
+++ b/src/omnicore/test/alert_tests.cpp
@@ -25,11 +25,13 @@ BOOST_AUTO_TEST_CASE(alert_positive_authorization)
     BOOST_CHECK(CheckAlertAuthorization("16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj")); // Craig   <craig@omni.foundation>
     BOOST_CHECK(CheckAlertAuthorization("1MicH2Vu4YVSvREvxW1zAx2XKo2GQomeXY")); // Michael <michael@omni.foundation>
     BOOST_CHECK(CheckAlertAuthorization("1zAtHRASgdHvZDfHs6xJquMghga4eG7gy"));  // Zathras <zathras@omni.foundation>
+    BOOST_CHECK(CheckAlertAuthorization("1dexX7zmPen1yBz2H9ZF62AK5TGGqGTZH"));  // dexX7   <dexx@bitwatch.co>
     BOOST_CHECK(CheckAlertAuthorization("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P")); // Exodus (who has access?)
 
     // Confirm authorized sources for testnet
     BOOST_CHECK(CheckAlertAuthorization("mpDex4kSX4iscrmiEQ8fBiPoyeTH55z23j")); // Michael <michael@omni.foundation>
     BOOST_CHECK(CheckAlertAuthorization("mpZATHupfCLqet5N1YL48ByCM1ZBfddbGJ")); // Zathras <zathras@omni.foundation>
+    BOOST_CHECK(CheckAlertAuthorization("mk5SSx4kdexENHzLxk9FLhQdbbBexHUFTW")); // dexX7   <dexx@bitwatch.co>
 }
 
 BOOST_AUTO_TEST_CASE(alert_unauthorized_source)

--- a/src/omnicore/test/alert_tests.cpp
+++ b/src/omnicore/test/alert_tests.cpp
@@ -45,16 +45,16 @@ BOOST_AUTO_TEST_CASE(alert_manual_sources)
     std::map<std::string, std::string> mapArgsOriginal = mapArgs;
     std::map<std::string, std::vector<std::string> > mapMultiArgsOriginal = mapMultiArgs;
 
-    mapArgs["-alertallowsender"] = "";
-    mapArgs["-alertignoresender"] = "";
+    mapArgs["-omnialertallowsender"] = "";
+    mapArgs["-omnialertignoresender"] = "";
 
     // Add 1JwSSu as allowed source for alerts
-    mapMultiArgs["-alertallowsender"].push_back("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T");
+    mapMultiArgs["-omnialertallowsender"].push_back("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T");
     BOOST_CHECK(CheckAlertAuthorization("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T"));
 
     // Then ignore some sources explicitly
-    mapMultiArgs["-alertignoresender"].push_back("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T");
-    mapMultiArgs["-alertignoresender"].push_back("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
+    mapMultiArgs["-omnialertignoresender"].push_back("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T");
+    mapMultiArgs["-omnialertignoresender"].push_back("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
     BOOST_CHECK(CheckAlertAuthorization("1zAtHRASgdHvZDfHs6xJquMghga4eG7gy")); // should still be authorized
     BOOST_CHECK(!CheckAlertAuthorization("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T"));
     BOOST_CHECK(!CheckAlertAuthorization("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
@@ -68,10 +68,10 @@ BOOST_AUTO_TEST_CASE(alert_authorize_any_source)
     std::map<std::string, std::string> mapArgsOriginal = mapArgs;
     std::map<std::string, std::vector<std::string> > mapMultiArgsOriginal = mapMultiArgs;
 
-    mapArgs["-alertallowsender"] = "";
+    mapArgs["-omnialertallowsender"] = "";
 
     // Allow any source (e.g. for tests!)
-    mapMultiArgs["-alertallowsender"].push_back("any");
+    mapMultiArgs["-omnialertallowsender"].push_back("any");
     BOOST_CHECK(CheckAlertAuthorization("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T"));
     BOOST_CHECK(CheckAlertAuthorization("137uFtQ5EgMsreg4FVvL3xuhjkYGToVPqs"));
     BOOST_CHECK(CheckAlertAuthorization("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));

--- a/src/omnicore/test/alert_tests.cpp
+++ b/src/omnicore/test/alert_tests.cpp
@@ -1,0 +1,174 @@
+#include "omnicore/notifications.h"
+#include "omnicore/version.h"
+
+#include "util.h"
+#include "tinyformat.h"
+
+#include <stdint.h>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+// Is only temporarily modified and restored after each test
+extern std::map<std::string, std::string> mapArgs;
+extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
+
+BOOST_AUTO_TEST_SUITE(omnicore_alert_tests)
+
+BOOST_AUTO_TEST_CASE(alert_positive_authorization)
+{
+    // Confirm authorized sources for mainnet
+    BOOST_CHECK(CheckAlertAuthorization("16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj")); // Craig   <craig@omni.foundation>
+    BOOST_CHECK(CheckAlertAuthorization("1MicH2Vu4YVSvREvxW1zAx2XKo2GQomeXY")); // Michael <michael@omni.foundation>
+    BOOST_CHECK(CheckAlertAuthorization("1zAtHRASgdHvZDfHs6xJquMghga4eG7gy"));  // Zathras <zathras@omni.foundation>
+    BOOST_CHECK(CheckAlertAuthorization("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P")); // Exodus (who has access?)
+
+    // Confirm authorized sources for testnet
+    BOOST_CHECK(CheckAlertAuthorization("mpDex4kSX4iscrmiEQ8fBiPoyeTH55z23j")); // Michael <michael@omni.foundation>
+    BOOST_CHECK(CheckAlertAuthorization("mpZATHupfCLqet5N1YL48ByCM1ZBfddbGJ")); // Zathras <zathras@omni.foundation>
+}
+
+BOOST_AUTO_TEST_CASE(alert_unauthorized_source)
+{
+    // Confirm unauthorized sources are not accepted
+    BOOST_CHECK(!CheckAlertAuthorization("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T"));
+}
+
+BOOST_AUTO_TEST_CASE(alert_manual_sources)
+{
+    std::map<std::string, std::string> mapArgsOriginal = mapArgs;
+    std::map<std::string, std::vector<std::string> > mapMultiArgsOriginal = mapMultiArgs;
+
+    mapArgs["-alertallowsender"] = "";
+    mapArgs["-alertignoresender"] = "";
+
+    // Add 1JwSSu as allowed source for alerts
+    mapMultiArgs["-alertallowsender"].push_back("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T");
+    BOOST_CHECK(CheckAlertAuthorization("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T"));
+
+    // Then ignore some sources explicitly
+    mapMultiArgs["-alertignoresender"].push_back("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T");
+    mapMultiArgs["-alertignoresender"].push_back("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
+    BOOST_CHECK(CheckAlertAuthorization("1zAtHRASgdHvZDfHs6xJquMghga4eG7gy")); // should still be authorized
+    BOOST_CHECK(!CheckAlertAuthorization("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T"));
+    BOOST_CHECK(!CheckAlertAuthorization("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+
+    mapMultiArgs = mapMultiArgsOriginal;
+    mapArgs = mapArgsOriginal;
+}
+
+BOOST_AUTO_TEST_CASE(alert_authorize_any_source)
+{
+    std::map<std::string, std::string> mapArgsOriginal = mapArgs;
+    std::map<std::string, std::vector<std::string> > mapMultiArgsOriginal = mapMultiArgs;
+
+    mapArgs["-alertallowsender"] = "";
+
+    // Allow any source (e.g. for tests!)
+    mapMultiArgs["-alertallowsender"].push_back("any");
+    BOOST_CHECK(CheckAlertAuthorization("1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T"));
+    BOOST_CHECK(CheckAlertAuthorization("137uFtQ5EgMsreg4FVvL3xuhjkYGToVPqs"));
+    BOOST_CHECK(CheckAlertAuthorization("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+
+    mapMultiArgs = mapMultiArgsOriginal;
+    mapArgs = mapArgsOriginal;
+}
+
+BOOST_AUTO_TEST_CASE(alert_parsing)
+{
+    int32_t alertType = 0;
+    uint64_t expiryValue = 0;
+    uint32_t typeCheck = 0;
+    uint32_t verCheck = 0;
+    std::string alertMessage;
+
+    // Malformed alerts
+    BOOST_CHECK(!ParseAlertMessage("", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(!ParseAlertMessage("test", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(!ParseAlertMessage("x:x:x:x:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(!ParseAlertMessage("1:1:0:0:x:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(!ParseAlertMessage("0:1:0:0:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(!ParseAlertMessage("5:1:0:0:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(!ParseAlertMessage("2:0:0:0:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+
+    // Valid alerts
+    BOOST_CHECK(ParseAlertMessage("1:1:0:0:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(ParseAlertMessage("2:1:0:0:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(ParseAlertMessage("3:1:0:0:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK(ParseAlertMessage("4:1:1:1:x", alertType, expiryValue, typeCheck, verCheck, alertMessage));
+
+    // Confrim correct values
+    std::string testAlert = "4:350000:99:0:Transaction type 99v0 is not supported";
+    BOOST_CHECK(ParseAlertMessage(testAlert, alertType, expiryValue, typeCheck, verCheck, alertMessage));
+    BOOST_CHECK_EQUAL(alertType, 4);
+    BOOST_CHECK_EQUAL(expiryValue, 350000);
+    BOOST_CHECK_EQUAL(typeCheck, 99);
+    BOOST_CHECK_EQUAL(verCheck, 0);
+    BOOST_CHECK_EQUAL(alertMessage, "Transaction type 99v0 is not supported");
+}
+
+BOOST_AUTO_TEST_CASE(alert_expiration_by_block)
+{
+    std::string testAlertMessage = "This alert expires after block 350000";
+    std::string testAlertRaw = "1:350000:0:0:" + testAlertMessage;
+
+    SetOmniCoreAlert(testAlertRaw);
+    BOOST_CHECK_EQUAL(GetOmniCoreAlertString(), testAlertRaw);
+    BOOST_CHECK_EQUAL(GetOmniCoreAlertTextOnly(), testAlertMessage);
+    BOOST_CHECK(!CheckExpiredAlerts(0, 0));
+    BOOST_CHECK(!CheckExpiredAlerts(350000, 0));
+
+    // Expire the the alert
+    BOOST_CHECK(CheckExpiredAlerts(350001, 0));
+    BOOST_CHECK(GetOmniCoreAlertString().empty());
+    BOOST_CHECK(GetOmniCoreAlertTextOnly().empty());
+}
+
+BOOST_AUTO_TEST_CASE(alert_expiration_by_timestamp)
+{
+    std::string testAlertMessage = "This alert expires after timestamp 2147483648";
+    std::string testAlertRaw = "2:2147483648:0:0:" + testAlertMessage;
+
+    SetOmniCoreAlert(testAlertRaw);
+    BOOST_CHECK_EQUAL(GetOmniCoreAlertString(), testAlertRaw);
+    BOOST_CHECK_EQUAL(GetOmniCoreAlertTextOnly(), testAlertMessage);
+    BOOST_CHECK(!CheckExpiredAlerts(0, 0));
+    BOOST_CHECK(!CheckExpiredAlerts(2147483648, 0));
+    BOOST_CHECK(!CheckExpiredAlerts(350000, 2147483648));
+
+    // Expire the the alert
+    BOOST_CHECK(CheckExpiredAlerts(350001, 2147483649));
+    BOOST_CHECK(GetOmniCoreAlertString().empty());
+    BOOST_CHECK(GetOmniCoreAlertTextOnly().empty());
+}
+
+BOOST_AUTO_TEST_CASE(alert_expiration_by_version)
+{
+    // Set an old version and and expire the alert
+    std::string testAlertMessage = "This alert is already expired";
+    std::string testAlertRaw = strprintf("3:%d:0:0:%s", OMNICORE_VERSION - 1, testAlertMessage);
+    SetOmniCoreAlert(testAlertRaw);
+    BOOST_CHECK(CheckExpiredAlerts(358867, 1433110322));
+    BOOST_CHECK(GetOmniCoreAlertString().empty());
+    BOOST_CHECK(GetOmniCoreAlertTextOnly().empty());
+
+    // Target the current version
+    testAlertMessage = strprintf("This alert is visible to version %s", OmniCoreVersion());
+    testAlertRaw = strprintf("3:%d:0:0:%s", OMNICORE_VERSION, testAlertMessage);
+    SetOmniCoreAlert(testAlertRaw);
+    BOOST_CHECK(!CheckExpiredAlerts(358867, 1433110322));
+    BOOST_CHECK_EQUAL(GetOmniCoreAlertString(), testAlertRaw);
+    BOOST_CHECK_EQUAL(GetOmniCoreAlertTextOnly(), testAlertMessage);
+
+    // Clear alert
+    SetOmniCoreAlert("");
+    BOOST_CHECK(GetOmniCoreAlertString().empty());
+    BOOST_CHECK(GetOmniCoreAlertTextOnly().empty());
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -371,5 +371,18 @@ BOOST_AUTO_TEST_CASE(payload_change_property_manager)
     BOOST_CHECK_EQUAL(HexStr(vch), "000000460000000d");
 }
 
+BOOST_AUTO_TEST_CASE(payload_omnicore_alert)
+{
+    // Omni Core client notification [type 65535, version 65535]
+    std::vector<unsigned char> vch = CreatePayload_OmniCoreAlert(
+        static_cast<int32_t>(3),            // alert target: by client version
+        static_cast<uint64_t>(900100),      // expiry value: v0.0.9.1
+        static_cast<uint16_t>(0),           // transaction type: none
+        static_cast<uint16_t>(0),           // transaction version: none
+        static_cast<std::string>("test"));  // alert message: test
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "ffffffff333a3930303130303a303a303a7465737400");
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -6,6 +6,7 @@
 #include "omnicore/dex.h"
 #include "omnicore/log.h"
 #include "omnicore/mdex.h"
+#include "omnicore/notifications.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/sp.h"
 #include "omnicore/sto.h"

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -77,19 +77,7 @@ int CMPTransaction::step2_Alert(std::string *new_global_alert_message)
   char alertString[SP_STRING_FIELD_LEN];
 
   // is sender authorized?
-  bool authorized = false;
-  if (
-     // TESTNET
-     (sender == "mpDex4kSX4iscrmiEQ8fBiPoyeTH55z23j") || // Michael
-     (sender == "mCraigAddress") || // Craig
-     (sender == "mpZATHupfCLqet5N1YL48ByCM1ZBfddbGJ") || // Zathras
-     // MAINNET
-     (sender == "1MicH2Vu4YVSvREvxW1zAx2XKo2GQomeXY") || // Michael
-     (sender == "16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj") || // Craig
-     (sender == "1zAtHRASgdHvZDfHs6xJquMghga4eG7gy") || // Zathras
-     (sender == "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P") // Exodus
-     //(sender=="1Anyone2Else3Who4Should5Be6Here") // Who else?  JR? David? DexX?
-     ) authorized = true;
+  bool authorized = CheckAlertAuthorization(sender);
 
   if(!authorized)
   {
@@ -1476,19 +1464,7 @@ int CMPTransaction::logicMath_Alert()
     }
 
     // is sender authorized?
-    bool authorized = false;
-    if (
-        // TESTNET
-        (sender == "mpDex4kSX4iscrmiEQ8fBiPoyeTH55z23j") || // Michael
-        (sender == "mCraigAddress") || // Craig
-        (sender == "mpZATHupfCLqet5N1YL48ByCM1ZBfddbGJ") || // Zathras
-        // MAINNET
-        (sender == "1MicH2Vu4YVSvREvxW1zAx2XKo2GQomeXY") || // Michael
-        (sender == "16Zwbujf1h3v1DotKcn9XXt1m7FZn2o4mj") || // Craig
-        (sender == "1zAtHRASgdHvZDfHs6xJquMghga4eG7gy") || // Zathras
-        (sender == "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P") // Exodus
-        //(sender=="1Anyone2Else3Who4Should5Be6Here") // Who else?  JR? David? DexX?
-        ) authorized = true;
+    bool authorized = CheckAlertAuthorization(sender);
 
     if (!authorized) {
         // not authorized, ignore alert

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1505,7 +1505,7 @@ int CMPTransaction::logicMath_Alert()
     PrintToLog("\t   alert message: %s\n", alertMessage);
 
     // copy the alert string into the global_alert_message and return a 0 rc
-    setOmniCoreAlert(alertString);
+    SetOmniCoreAlert(alertString);
 
     // we have a new alert, fire a notify event if needed
     CAlert::Notify(alertMessage, true);

--- a/src/omnicore/utils.cpp
+++ b/src/omnicore/utils.cpp
@@ -7,8 +7,6 @@
 
 #include "omnicore/utils.h"
 
-#include "omnicore/omnicore.h" // MAX_SHA256_OBFUSCATION_TIMES
-
 #include "utilstrencodings.h"
 
 // TODO: use crypto/sha256 instead of openssl

--- a/src/omnicore/utils.h
+++ b/src/omnicore/utils.h
@@ -1,9 +1,9 @@
 #ifndef OMNICORE_UTILS_H
 #define OMNICORE_UTILS_H
 
-#include "omnicore/omnicore.h" // MAX_SHA256_OBFUSCATION_TIMES
-
 #include <string>
+
+#define MAX_SHA256_OBFUSCATION_TIMES  255
 
 /** Generates hashes used for obfuscation via ToUpper(HexStr(SHA256(x))). */
 void PrepareObfuscatedHashes(const std::string& strSeed, std::string(&vstrHashes)[1+MAX_SHA256_OBFUSCATION_TIMES]);

--- a/src/qt/balancesdialog.cpp
+++ b/src/qt/balancesdialog.cpp
@@ -8,6 +8,7 @@
 #include "guiutil.h"
 
 #include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
 
 #include "amount.h"
 #include "sync.h"

--- a/src/qt/lookupaddressdialog.cpp
+++ b/src/qt/lookupaddressdialog.cpp
@@ -8,6 +8,7 @@
 #include "guiutil.h"
 
 #include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
 
 #include "base58.h"
 

--- a/src/qt/metadexcanceldialog.cpp
+++ b/src/qt/metadexcanceldialog.cpp
@@ -15,6 +15,7 @@
 #include "omnicore/errors.h"
 #include "omnicore/mdex.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
 
 #include <stdint.h>
 #include <stdio.h> // printf!

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -16,6 +16,7 @@
 
 #include "omnicore/notifications.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
 
 #include "main.h"
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -429,7 +429,7 @@ void OverviewPage::updateAlerts()
     // override to check alert directly rather than passing in param as we won't always be calling from bitcoin in
     // the clientmodel emit for alertsChanged
     QString warnings = QString::fromStdString(GetWarnings("statusbar")); // get current bitcoin alert/warning directly
-    QString alertMessage = QString::fromStdString(getMasterCoreAlertTextOnly()); // just return the text message from alert
+    QString alertMessage = QString::fromStdString(GetOmniCoreAlertTextOnly()); // just return the text message from alert
     // any BitcoinCore or MasterCore alerts to display?
     if((!alertMessage.isEmpty()) || (!warnings.isEmpty())) showAlert = true;
     this->ui->labelAlerts->setVisible(showAlert);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -14,6 +14,7 @@
 #include "transactiontablemodel.h"
 #include "walletmodel.h"
 
+#include "omnicore/notifications.h"
 #include "omnicore/omnicore.h"
 
 #include "main.h"

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -15,6 +15,7 @@
 #include "omnicore/omnicore.h"
 #include "omnicore/parse_string.h"
 #include "omnicore/pending.h"
+#include "omnicore/sp.h"
 
 #include "amount.h"
 #include "base58.h"

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -15,6 +15,7 @@
 #include "omnicore/omnicore.h"
 #include "omnicore/pending.h"
 #include "omnicore/rpc.h"
+#include "omnicore/sp.h"
 #include "omnicore/tx.h"
 
 #include "amount.h"

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -146,6 +146,10 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendgrant_OMNI", 2 },
     { "sendrevoke_OMNI", 1 },
     { "sendchangeissuer_OMNI", 2 },
+    { "sendalert_OMNI", 1 },
+    { "sendalert_OMNI", 2 },
+    { "sendalert_OMNI", 3 },
+    { "sendalert_OMNI", 4 },
 };
 
 class CRPCConvertTable

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -392,6 +392,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer",   "sendrevoke_OMNI",              &sendrevoke_OMNI,               false,  false,  true },
     { "omni layer",   "sendclosecrowdsale_OMNI",      &sendclosecrowdsale_OMNI,       false,  false,  true },
     { "omni layer",   "sendchangeissuer_OMNI",        &sendchangeissuer_OMNI,         false,  false,  true },
+    { "hidden",       "sendalert_OMNI",               &sendalert_OMNI,                true,   false,  true },
 #endif // ENABLE_WALLET [required by Omni Core for now]
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -269,6 +269,7 @@ extern json_spirit::Value sendtrade_OMNI(const json_spirit::Array& params, bool 
 extern json_spirit::Value sendcanceltradesbyprice_OMNI(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendcanceltradesbypair_OMNI(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendcancelalltrades_OMNI(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value sendalert_OMNI(const json_spirit::Array& params, bool fHelp);
 
 // in rest.cpp
 extern bool HTTPReq_REST(AcceptedConnection *conn,


### PR DESCRIPTION
Notable changes:

 - Removal of unused, or old code, which very likely isn't going to be used anymore
 - Formatting, restructuring here and there
 - Moving code from headers into cpp files
 - Split alert/notification code
 - Enable block disconnect handlers during reindex, and wipe DBs during reindex

Alert related:

 - Authorize mainnet address: `1dexX7zmPen1yBz2H9ZF62AK5TGGqGTZH` (resolves #53)
 - Authorize testnet address: `mk5SSx4kdexENHzLxk9FLhQdbbBexHUFTW` (resolves #53)
 - Alert payloads can be created via `CreatePayload_OmniCoreAlert()`
 - There is a hidden RPC call `"sendalert_OMNI"` to create alerts
 -  `"-alertignoresender=address"` can be used to backlist specific alert senders
 - `"-alertallowsender=address"` can be used to whitelist specific alert senders
 - `"-alertallowsender=any"` can be used to consider any source as authorized (for tests!)

Fixes:

 - Resolve wallet LOCK issue
 - Only create class C transactions, if they are also accepted (resolves #69)
 - Extend marker check to cover alerts as well (resolves #70)
 - Fix height check of `CMPTxList::setLastAlert()`