### PR TITLE
Tweak and group transaction parsing and handling

### DIFF
--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -12,6 +12,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/output_restriction_tests.cpp \
   omnicore/test/parsing_a_tests.cpp \
+  omnicore/test/parsing_b_tests.cpp \
   omnicore/test/parsing_c_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
   omnicore/test/rpc_requirements_tests.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -10,6 +10,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/marker_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/output_restriction_tests.cpp \
+  omnicore/test/parsing_a_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
   omnicore/test/rpc_requirements_tests.cpp \
   omnicore/test/rpc_value_tests.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -5,6 +5,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/create_payload_tests.cpp \
   omnicore/test/encoding_b_tests.cpp \
   omnicore/test/encoding_c_tests.cpp \
+  omnicore/test/exodus_tests.cpp \
   omnicore/test/lock_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -1,4 +1,5 @@
-OMNICORE_TEST_H =
+OMNICORE_TEST_H = \
+  omnicore/test/utils_tx.h
 
 OMNICORE_TEST_CPP = \
   omnicore/test/alert_tests.cpp \
@@ -22,7 +23,8 @@ OMNICORE_TEST_CPP = \
   omnicore/test/sender_firstin_tests.cpp \
   omnicore/test/strtoint64_tests.cpp \
   omnicore/test/swapbyteorder_tests.cpp \
-  omnicore/test/tally_tests.cpp
+  omnicore/test/tally_tests.cpp \
+  omnicore/test/utils_tx.cpp
 
 BITCOIN_TESTS += \
   $(OMNICORE_TEST_CPP) \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -16,6 +16,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/script_dust_tests.cpp \
   omnicore/test/script_extraction_tests.cpp \
   omnicore/test/script_solver_tests.cpp \
+  omnicore/test/sender_bycontribution_tests.cpp \
   omnicore/test/strtoint64_tests.cpp \
   omnicore/test/swapbyteorder_tests.cpp \
   omnicore/test/tally_tests.cpp

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -9,6 +9,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/lock_tests.cpp \
   omnicore/test/marker_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
+  omnicore/test/output_restriction_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
   omnicore/test/rpc_requirements_tests.cpp \
   omnicore/test/rpc_value_tests.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -7,6 +7,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/encoding_c_tests.cpp \
   omnicore/test/exodus_tests.cpp \
   omnicore/test/lock_tests.cpp \
+  omnicore/test/marker_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
   omnicore/test/rpc_requirements_tests.cpp \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -17,6 +17,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/script_extraction_tests.cpp \
   omnicore/test/script_solver_tests.cpp \
   omnicore/test/sender_bycontribution_tests.cpp \
+  omnicore/test/sender_firstin_tests.cpp \
   omnicore/test/strtoint64_tests.cpp \
   omnicore/test/swapbyteorder_tests.cpp \
   omnicore/test/tally_tests.cpp

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -11,6 +11,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/output_restriction_tests.cpp \
   omnicore/test/parsing_a_tests.cpp \
+  omnicore/test/parsing_c_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
   omnicore/test/rpc_requirements_tests.cpp \
   omnicore/test/rpc_value_tests.cpp \

--- a/src/omnicore/encoding.cpp
+++ b/src/omnicore/encoding.cpp
@@ -75,16 +75,6 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
 }
 
 /**
- * @return The marker for class C transactions.
- */
-static inline std::vector<unsigned char> GetOmMarker()
-{
-    const unsigned char pch[] = {0x6f, 0x6d}; // Hex-encoded: "om"
-
-    return std::vector<unsigned char>(pch, pch + sizeof (pch) / sizeof (pch[0]));
-}
-
-/**
  * Embedds a payload in an OP_RETURN output, prefixed with a transaction marker.
  *
  * The request is rejected, if the size of the payload with marker is larger than

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -146,7 +146,7 @@ bool CheckExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                     break;
                 case 4: //Update alert, show upgrade alert in UI and getalert_MP call + use isTransactionTypeAllowed to verify client support and shutdown if not present
                     //check of the new tx type is supported at live block
-                    bool txSupported = isTransactionTypeAllowed(expiryValue + 1, OMNI_PROPERTY_MSC, typeCheck, verCheck);
+                    bool txSupported = IsTransactionTypeAllowed(expiryValue + 1, OMNI_PROPERTY_MSC, typeCheck, verCheck);
 
                     //check if we are at/past the live blockheight                    
                     bool txLive = (curBlock > (int64_t) expiryValue);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -769,16 +769,15 @@ int mastercore::GetEncodingClass(const CTransaction& tx, int nBlock)
             hasMultisig = true;
         }
         if (outType == TX_NULL_DATA) {
+            // Ensure there is a payload, and the first pushed element equals,
+            // or starts with the "om" marker
             std::vector<std::string> scriptPushes;
-            GetScriptPushes(output.scriptPubKey, scriptPushes);
-            if (scriptPushes.size() > 0) {
-                if (scriptPushes[0].size() > 8) {
-                    // only v0/v1 (and alert) txs are live, add 6f6d0002 to parse a v2 tx when one goes live
-                    if (("6f6d0000" == scriptPushes[0].substr(0,8)) ||
-                        ("6f6d0001" == scriptPushes[0].substr(0,8)) ||
-                        ("6f6dffff" == scriptPushes[0].substr(0,8))) {
-                        hasOpReturn = true;
-                    }
+            if (!GetScriptPushes(output.scriptPubKey, scriptPushes)) {
+                continue;
+            }
+            if (!scriptPushes.empty()) {
+                if ("6f6d" == scriptPushes[0].substr(0,4)) {
+                    hasOpReturn = true;
                 }
             }
         }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1214,7 +1214,6 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                     packet_size += vch.size();
                 }
             }
-            if (packet_size < MIN_PAYLOAD_SIZE) { return -112; }
         }
     }
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -732,7 +732,7 @@ static int getEncodingClass(const CTransaction& tx, int nBlock)
                 if (address == ExodusAddress()) {
                     hasExodus = true;
                 }
-                if (address == MoneyAddress(nBlock)) {
+                if (address == ExodusCrowdsaleAddress(nBlock)) {
                     hasMoney = true;
                 }
             }
@@ -879,7 +879,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
             CTxDestination dest;
             if (ExtractDestination(wtx.vout[n].scriptPubKey, dest)) {
-                if (CBitcoinAddress(dest) == MoneyAddress(nBlock)) {
+                if (CBitcoinAddress(dest) == ExodusCrowdsaleAddress(nBlock)) {
                     BTC_amount = wtx.vout[n].nValue;
                     break; // TODO: maybe sum all values
                 }
@@ -3464,7 +3464,7 @@ const CBitcoinAddress ExodusAddress()
 }
 
 /**
- * Returns the Exodus fundraiser address.
+ * Returns the Exodus crowdsale address.
  *
  * Main network:
  *   1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P
@@ -3475,7 +3475,7 @@ const CBitcoinAddress ExodusAddress()
  *
  * @return The Exodus fundraiser address
  */
-const CBitcoinAddress MoneyAddress(int nBlock)
+const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock)
 {
     static CBitcoinAddress moneysAddress(getmoney_testnet);
     static CBitcoinAddress exodusAddress = ExodusAddress();

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -802,6 +802,530 @@ CCoinsViewCache mastercore::view(&viewDummy);
 static unsigned int nCacheHits = 0;
 static unsigned int nCacheMiss = 0;
 
+namespace legacy {
+
+/**
+ * Legacy code is kept to guarantee a safe transition until a new feature,
+ * or a replacement of consensus critical code is enabled.
+ *
+ * Once the new replacement code is activated on mainnet, and it is conform
+ * with historical consensus, the legacy code can safely be removed.
+ */
+
+static const int MAX_LEGACY_PACKETS = 64;
+static const int MAX_BTC_OUTPUTS    = 16;
+
+static bool isAllowedOutputType(int whichType, int nBlock)
+{
+    int p2shAllowed = 0;
+
+    if (P2SH_BLOCK <= nBlock || isNonMainNet()) {
+        p2shAllowed = 1;
+    }
+    // validTypes:
+    // 1) Pay to pubkey hash
+    // 2) Pay to Script Hash (if P2SH is allowed)
+    if ((TX_PUBKEYHASH == whichType) || (p2shAllowed && (TX_SCRIPTHASH == whichType))) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, unsigned int idx, CMPTransaction& mp_tx, unsigned int nTime = 0)
+{
+    std::string strSender;
+    // class A: data & address storage -- combine them into a structure or something
+    std::vector<std::string> script_data;
+    std::vector<std::string> address_data;
+    std::vector<int64_t> value_data;
+    int64_t ExodusValues[MAX_BTC_OUTPUTS] = {0};
+    int64_t TestNetMoneyValues[MAX_BTC_OUTPUTS] = {0}; // new way to get funded on TestNet, send TBTC to moneyman address
+    std::string strReference;
+    unsigned char single_pkt[MAX_LEGACY_PACKETS * PACKET_SIZE];
+    unsigned int packet_size = 0;
+    int fMultisig = 0;
+    int marker_count = 0, getmoney_count = 0;
+    // class B: multisig data storage
+    std::vector<std::string> multisig_script_data;
+    uint64_t inAll = 0;
+    uint64_t outAll = 0;
+    uint64_t txFee = 0;
+
+    mp_tx.Set(wtx.GetHash(), nBlock, idx, nTime);
+
+    // quickly go through the outputs & ensure there is a marker (a send to the Exodus address)
+    for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+        CTxDestination dest;
+        std::string strAddress;
+
+        outAll += wtx.vout[i].nValue;
+
+        if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
+            strAddress = CBitcoinAddress(dest).ToString();
+
+            if (exodus_address == strAddress) {
+                ExodusValues[marker_count++] = wtx.vout[i].nValue;
+            } else if (isNonMainNet() && (getmoney_testnet == strAddress)) {
+                TestNetMoneyValues[getmoney_count++] = wtx.vout[i].nValue;
+            }
+        }
+    }
+    if ((isNonMainNet() && getmoney_count)) {
+    } else if (!marker_count) {
+        return -1;
+    }
+
+    PrintToLog("____________________________________________________________________________________________________________________________________\n");
+    PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
+
+    // now save output addresses & scripts for later use
+    // also determine if there is a multisig in there, if so = Class B
+    for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+        CTxDestination dest;
+        std::string strAddress;
+
+        if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
+            txnouttype whichType;
+            bool validType = false;
+            if (!GetOutputType(wtx.vout[i].scriptPubKey, whichType)) validType = false;
+            if (isAllowedOutputType(whichType, nBlock)) validType = true;
+
+            strAddress = CBitcoinAddress(dest).ToString();
+
+            if ((exodus_address != strAddress) && (validType)) {
+                if (msc_debug_parser_data) PrintToLog("saving address_data #%d: %s:%s\n", i, strAddress, wtx.vout[i].scriptPubKey.ToString());
+
+                // saving for Class A processing or reference
+                GetScriptPushes(wtx.vout[i].scriptPubKey, script_data);
+                address_data.push_back(strAddress);
+                value_data.push_back(wtx.vout[i].nValue);
+            }
+        } else {
+            // a multisig ?
+            txnouttype type;
+            std::vector<CTxDestination> vDest;
+            int nRequired;
+
+            if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired)) {
+                ++fMultisig;
+            }
+        }
+    }
+
+    if (msc_debug_parser_data) {
+        PrintToLog("address_data.size=%lu\n", address_data.size());
+        PrintToLog("script_data.size=%lu\n", script_data.size());
+        PrintToLog("value_data.size=%lu\n", value_data.size());
+    }
+
+    int inputs_errors = 0; // several types of erroroneous MP TX inputs
+    std::map<std::string, uint64_t> inputs_sum_of_values;
+    // now go through inputs & identify the sender, collect input amounts
+    // go through inputs, find the largest per Mastercoin protocol, the Sender
+
+    // Fetch previous transactions (inputs)
+    BOOST_FOREACH(const CTxIn& txIn, wtx.vin) {
+        unsigned int nOut = txIn.prevout.n;
+        CCoinsModifier coins = view.ModifyCoins(txIn.prevout.hash);
+
+        if (coins->IsAvailable(nOut)) {
+            ++nCacheHits;
+            continue;
+        } else {
+            ++nCacheMiss;
+        }
+
+        CTransaction txPrev;
+        uint256 hashBlock;
+        if (!GetTransaction(txIn.prevout.hash, txPrev, hashBlock, true)) {
+            PrintToConsole("%s() ERROR: failed to get transaction %s\n", __func__, txIn.prevout.hash.GetHex());
+            return -101;
+        }
+
+        if (nOut >= coins->vout.size()) {
+            coins->vout.resize(nOut+1);
+        }
+        coins->vout[nOut].scriptPubKey = txPrev.vout[nOut].scriptPubKey;
+        coins->vout[nOut].nValue = txPrev.vout[nOut].nValue;
+    }
+
+    assert(view.HaveInputs(wtx));
+
+    for (unsigned int i = 0; i < wtx.vin.size(); i++) {
+        if (msc_debug_vin) PrintToLog("vin=%d:%s\n", i, wtx.vin[i].scriptSig.ToString());
+
+        const CTxIn& txIn = wtx.vin[i];
+        const CTxOut& txOut = view.GetOutputFor(txIn);
+
+        assert(!txOut.IsNull());
+
+        CTxDestination source;
+
+        uint64_t nValue = txOut.nValue;
+        txnouttype whichType;
+
+        inAll += nValue;
+
+        if (ExtractDestination(txOut.scriptPubKey, source)) // extract the destination of the previous transaction's vout[n]
+        {
+            // we only allow pay-to-pubkeyhash, pay-to-scripthash & probably pay-to-pubkey (?)
+            {
+                if (!GetOutputType(txOut.scriptPubKey, whichType)) ++inputs_errors;
+                if (!isAllowedOutputType(whichType, nBlock)) ++inputs_errors;
+
+                if (inputs_errors) break;
+            }
+
+            CBitcoinAddress addressSource(source); // convert this to an address
+
+            inputs_sum_of_values[addressSource.ToString()] += nValue;
+        }
+        else ++inputs_errors;
+
+        if (msc_debug_vin) PrintToLog("vin=%d:%s\n", i, txIn.ToString());
+    } // end of inputs for loop
+
+    txFee = inAll - outAll; // this is the fee paid to miners for this TX
+
+    if (inputs_errors) // not a valid MP TX
+    {
+        return -101;
+    }
+
+    // largest by sum of values
+    uint64_t nMax = 0;
+    for (std::map<std::string, uint64_t>::iterator my_it = inputs_sum_of_values.begin(); my_it != inputs_sum_of_values.end(); ++my_it) {
+        uint64_t nTemp = my_it->second;
+
+        if (nTemp > nMax) {
+            strSender = my_it->first;
+            if (msc_debug_exo) PrintToLog("looking for The Sender: %s , nMax=%lu, nTemp=%lu\n", strSender, nMax, nTemp);
+            nMax = nTemp;
+        }
+    }
+
+    if (!strSender.empty()) {
+        if (msc_debug_verbose) PrintToLog("The Sender: %s : His Input Sum of Values= %s ; fee= %s\n",
+                strSender, FormatDivisibleMP(nMax), FormatDivisibleMP(txFee));
+    } else {
+        PrintToLog("The sender is still EMPTY !!! txid: %s\n", wtx.GetHash().GetHex());
+        return -5;
+    }
+
+    // This calculates exodus fundraiser for each tx within a given block
+    int64_t BTC_amount = ExodusValues[0];
+    if (isNonMainNet())
+    {
+        if (MONEYMAN_TESTNET_BLOCK <= nBlock) BTC_amount = TestNetMoneyValues[0];
+    }
+
+    if (RegTest())
+    {
+        if (MONEYMAN_REGTEST_BLOCK <= nBlock) BTC_amount = TestNetMoneyValues[0];
+    }
+
+    if (0 < BTC_amount && !bRPConly) (void) TXExodusFundraiser(wtx, strSender, BTC_amount, nBlock, nTime);
+
+    // go through the outputs
+    for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+        CTxDestination address;
+
+        // if TRUE -- non-multisig
+        if (ExtractDestination(wtx.vout[i].scriptPubKey, address)) {
+        } else {
+            // probably a multisig -- get them
+            txnouttype type;
+            std::vector<CTxDestination> vDest;
+            int nRequired;
+
+            // CScript is a std::vector
+            if (msc_debug_script) PrintToLog("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
+
+            if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired)) {
+                if (msc_debug_script) PrintToLog(" >> multisig: ");
+                BOOST_FOREACH(const CTxDestination &dest, vDest)
+                {
+                    CBitcoinAddress address = CBitcoinAddress(dest);
+                    if (msc_debug_script) PrintToLog("%s ; ", address.ToString());
+                }
+                if (msc_debug_script) PrintToLog("\n");
+                // ignore first public key, as it should belong to the sender
+                // and it be used to avoid the creation of unspendable dust
+                GetScriptPushes(wtx.vout[i].scriptPubKey, multisig_script_data, true);
+            }
+        }
+    } // end of the outputs' for loop
+
+    std::string strObfuscatedHashes[1 + MAX_SHA256_OBFUSCATION_TIMES];
+    PrepareObfuscatedHashes(strSender, strObfuscatedHashes);
+
+    unsigned char packets[MAX_LEGACY_PACKETS][32];
+    int mdata_count = 0; // multisig data count
+    if (!fMultisig) {
+        // ---------------------------------- Class A parsing ---------------------------
+
+        // Init vars
+        std::string strScriptData;
+        std::string strDataAddress;
+        std::string strRefAddress;
+        unsigned char dataAddressSeq = 0xFF;
+        unsigned char seq = 0xFF;
+        int64_t dataAddressValue = 0;
+
+        // Step 1, locate the data packet
+        for (unsigned k = 0; k < script_data.size(); k++) // loop through outputs
+        {
+            txnouttype whichType;
+            if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+            if (!isAllowedOutputType(whichType, nBlock)) break;
+            std::string strSub = script_data[k].substr(2, 16); // retrieve bytes 1-9 of packet for peek & decode comparison
+            seq = (ParseHex(script_data[k].substr(0, 2)))[0]; // retrieve sequence number
+
+            if (("0000000000000001" == strSub) || ("0000000000000002" == strSub)) // peek & decode comparison
+            {
+                if (strScriptData.empty()) // confirm we have not already located a data address
+                {
+                    strScriptData = script_data[k].substr(2 * 1, 2 * PACKET_SIZE_CLASS_A); // populate data packet
+                    strDataAddress = address_data[k]; // record data address
+                    dataAddressSeq = seq; // record data address seq num for reference matching
+                    dataAddressValue = value_data[k]; // record data address amount for reference matching
+                    if (msc_debug_parser_data) PrintToLog("Data Address located - data[%d]:%s: %s (%s)\n", k, script_data[k], address_data[k], FormatDivisibleMP(value_data[k]));
+                } else {
+                    // invalidate - Class A cannot be more than one data packet - possible collision, treat as default (BTC payment)
+                    strDataAddress = ""; //empty strScriptData to block further parsing
+                    if (msc_debug_parser_data) PrintToLog("Multiple Data Addresses found (collision?) Class A invalidated, defaulting to BTC payment\n");
+                    break;
+                }
+            }
+        }
+
+        // Step 2, see if we can locate an address with a seqnum +1 of DataAddressSeq
+        if (!strDataAddress.empty()) // verify Step 1, we should now have a valid data packet, if so continue parsing
+        {
+            unsigned char expectedRefAddressSeq = dataAddressSeq + 1;
+            for (unsigned k = 0; k < script_data.size(); k++) // loop through outputs
+            {
+                txnouttype whichType;
+                if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+                if (!isAllowedOutputType(whichType, nBlock)) break;
+
+                seq = (ParseHex(script_data[k].substr(0, 2)))[0]; // retrieve sequence number
+
+                if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (expectedRefAddressSeq == seq)) // found reference address with matching sequence number
+                {
+                    if (strRefAddress.empty()) // confirm we have not already located a reference address
+                    {
+                        strRefAddress = address_data[k]; // set ref address
+                        if (msc_debug_parser_data) PrintToLog("Reference Address located via seqnum - data[%d]:%s: %s (%s)\n", k, script_data[k], address_data[k], FormatDivisibleMP(value_data[k]));
+                    }
+                    else
+                    {
+                        // can't trust sequence numbers to provide reference address, there is a collision with >1 address with expected seqnum
+                        strRefAddress = ""; // blank ref address
+                        if (msc_debug_parser_data) PrintToLog("Reference Address sequence number collision, will fall back to evaluating matching output amounts\n");
+                        break;
+                    }
+                }
+            }
+            // Step 3, if we still don't have a reference address, see if we can locate an address with matching output amounts
+            if (strRefAddress.empty())
+            {
+                for (unsigned k = 0; k < script_data.size(); k++) // loop through outputs
+                {
+                    txnouttype whichType;
+                    if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+                    if (!isAllowedOutputType(whichType, nBlock)) break;
+
+                    if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (dataAddressValue == value_data[k])) // this output matches data output, check if matches exodus output
+                    {
+                        for (int exodus_idx = 0; exodus_idx < marker_count; exodus_idx++) {
+                            if (value_data[k] == ExodusValues[exodus_idx]) //this output matches data address value and exodus address value, choose as ref
+                            {
+                                if (strRefAddress.empty()) {
+                                    strRefAddress = address_data[k];
+                                    if (msc_debug_parser_data) PrintToLog("Reference Address located via matching amounts - data[%d]:%s: %s (%s)\n", k, script_data[k], address_data[k], FormatDivisibleMP(value_data[k]));
+                                } else {
+                                    strRefAddress = "";
+                                    if (msc_debug_parser_data) PrintToLog("Reference Address collision, multiple potential candidates. Class A invalidated, defaulting to BTC payment\n");
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } // end if (!strDataAddress.empty())
+
+        // Populate expected var strReference with chosen address (if not empty)
+        if (!strRefAddress.empty()) strReference = strRefAddress;
+
+        // Last validation step, if strRefAddress is empty, blank strDataAddress so we default to BTC payment
+        if (strRefAddress.empty()) strDataAddress = "";
+
+        // -------------------------------- End Class A parsing -------------------------
+
+        if (strDataAddress.empty()) // an empty Data Address here means it is not Class A valid and should be defaulted to a BTC payment
+        {
+            // this must be the BTC payment - validate (?)
+            PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
+            PrintToLog("!! this may be the BTC payment for an offer !!\n");
+
+            // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
+
+            int count = 0;
+            // go through the outputs, once again...
+            {
+                for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+                    CTxDestination dest;
+
+                    if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
+                        const std::string strAddress = CBitcoinAddress(dest).ToString();
+
+                        if (exodus_address == strAddress) continue;
+                        PrintToLog("payment #%d %s %11.8lf\n", count, strAddress, (double) wtx.vout[i].nValue / (double) COIN);
+
+                        // check everything & pay BTC for the property we are buying here...
+                        if (bRPConly) count = 55555; // no real way to validate a payment during simple RPC call
+                        else if (0 == DEx_payment(wtx.GetHash(), i, strAddress, strSender, wtx.vout[i].nValue, nBlock)) ++count;
+                    }
+                }
+            }
+            return count ? count : -5678; // return count -- the actual number of payments within this TX or error if none were made
+        }
+        else
+        {
+            // valid Class A packet almost ready
+            if (msc_debug_parser_data) PrintToLog("valid Class A:from=%s:to=%s:data=%s\n", strSender, strReference, strScriptData);
+            packet_size = PACKET_SIZE_CLASS_A;
+            memcpy(single_pkt, &ParseHex(strScriptData)[0], packet_size);
+        }
+    }
+    else // if (fMultisig)
+    {
+        unsigned int k = 0;
+        // gotta find the Reference - Z rewrite - scrappy & inefficient, can be optimized
+
+        if (msc_debug_parser_data) PrintToLog("Beginning reference identification\n");
+
+        bool referenceFound = false; // bool to hold whether we've found the reference yet
+        bool changeRemoved = false; // bool to hold whether we've ignored the first output to sender as change
+        unsigned int potentialReferenceOutputs = 0; // int to hold number of potential reference outputs
+
+        // how many potential reference outputs do we have, if just one select it right here
+        BOOST_FOREACH(const std::string &addr, address_data)
+        {
+            // keep Michael's original debug info & k int as used elsewhere
+            if (msc_debug_parser_data) PrintToLog("ref? data[%d]:%s: %s (%s)\n",
+                    k, script_data[k], addr, FormatDivisibleMP(value_data[k]));
+            ++k;
+
+            if (addr != exodus_address)
+            {
+                ++potentialReferenceOutputs;
+                if (1 == potentialReferenceOutputs)
+                {
+                    strReference = addr;
+                    referenceFound = true;
+                    if (msc_debug_parser_data) PrintToLog("Single reference potentially id'd as follows: %s\n", strReference);
+                }
+                else //as soon as potentialReferenceOutputs > 1 we need to go fishing
+                {
+                    strReference = ""; // avoid leaving strReference populated for sanity
+                    referenceFound = false;
+                    if (msc_debug_parser_data) PrintToLog("More than one potential reference candidate, blanking strReference, need to go fishing\n");
+                }
+            }
+        }
+
+        // do we have a reference now? or do we need to dig deeper
+        if (!referenceFound) // multiple possible reference addresses
+        {
+            if (msc_debug_parser_data) PrintToLog("Reference has not been found yet, going fishing\n");
+
+            BOOST_FOREACH(const string &addr, address_data)
+            {
+                // !!!! address_data is ordered by vout (i think - please confirm that's correct analysis?)
+                if (addr != exodus_address) // removed strSender restriction, not to spec
+                {
+                    if ((addr == strSender) && (!changeRemoved)) {
+                        // per spec ignore first output to sender as change if multiple possible ref addresses
+                        changeRemoved = true;
+                        if (msc_debug_parser_data) PrintToLog("Removed change\n");
+                    } else {
+                        // this may be set several times, but last time will be highest vout
+                        strReference = addr;
+                        if (msc_debug_parser_data) PrintToLog("Resetting strReference as follows: %s\n ", strReference);
+                    }
+                }
+            }
+        }
+
+        if (msc_debug_parser_data) PrintToLog("Ending reference identification\n");
+        if (msc_debug_parser_data) PrintToLog("Final decision on reference identification is: %s\n", strReference);
+
+        // multisig , Class B; get the data packets that are found here
+        for (unsigned int k = 0; k < multisig_script_data.size(); k++) {
+            CPubKey key(ParseHex(multisig_script_data[k]));
+            CKeyID keyID = key.GetID();
+            std::string strAddress = CBitcoinAddress(keyID).ToString();
+            std::string strPacket;
+
+            {
+                // this is a data packet, must deobfuscate now
+                std::vector<unsigned char> hash = ParseHex(strObfuscatedHashes[mdata_count + 1]);
+                std::vector<unsigned char> packet = ParseHex(multisig_script_data[k].substr(2 * 1, 2 * PACKET_SIZE));
+
+                for (unsigned int i = 0; i < packet.size(); i++) {
+                    packet[i] ^= hash[i];
+                }
+
+                memcpy(&packets[mdata_count], &packet[0], PACKET_SIZE);
+                strPacket = HexStr(packet.begin(), packet.end(), false);
+                ++mdata_count;
+
+                if (MAX_LEGACY_PACKETS <= mdata_count) {
+                    PrintToLog("increase MAX_PACKETS ! mdata_count= %d\n", mdata_count);
+                    return -222;
+                }
+            }
+
+            if (msc_debug_parser_data) PrintToLog("multisig_data[%d]:%s: %s\n", k, multisig_script_data[k], strAddress);
+
+            if (!strPacket.empty()) {
+                if (msc_debug_parser) PrintToLog("packet #%d: %s\n", mdata_count, strPacket);
+            }
+        }
+
+        packet_size = mdata_count * (PACKET_SIZE - 1);
+
+        if (sizeof (single_pkt) < packet_size) {
+            return -111;
+        }
+    } // end of if (fMultisig)
+
+    // now decode mastercoin packets
+    for (int m = 0; m < mdata_count; m++) {
+        if (msc_debug_parser) PrintToLog("m=%d: %s\n", m, HexStr(packets[m], PACKET_SIZE + packets[m], false));
+
+        // check to ensure the sequence numbers are sequential and begin with 01 !
+        if (1 + m != packets[m][0]) {
+            if (msc_debug_spec) PrintToLog("Error: non-sequential seqnum ! expected=%d, got=%d\n", 1 + m, packets[m][0]);
+        }
+
+        // now ignoring sequence numbers for Class B packets
+        memcpy(m * (PACKET_SIZE - 1) + single_pkt, 1 + packets[m], PACKET_SIZE - 1);
+    }
+
+    if (msc_debug_verbose) PrintToLog("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt, false));
+
+    mp_tx.Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *) &single_pkt, packet_size, fMultisig, (inAll - outAll));
+
+    return 0;
+}
+
+} // namespace legacy
+
 // idx is position within the block, 0-based
 // int msc_tx_push(const CTransaction &wtx, int nBlock, unsigned int idx)
 // INPUT: bRPConly -- set to true to avoid moving funds; to be called from various RPC calls like this
@@ -810,6 +1334,11 @@ static unsigned int nCacheMiss = 0;
 // RETURNS: >0 if 1 or more payments have been made
 static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, unsigned int idx, CMPTransaction& mp_tx, unsigned int nTime)
 {
+    // Fallback to legacy parsing, if OP_RETURN isn't enabled:
+    if (!IsAllowedOutputType(TX_NULL_DATA, nBlock)) {
+        return legacy::parseTransaction(bRPConly, wtx, nBlock, idx, mp_tx, nTime);
+    }
+
     mp_tx.Set(wtx.GetHash(), nBlock, idx, nTime);
 
     // ### CLASS IDENTIFICATION AND MARKER CHECK ###

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -763,17 +763,7 @@ static int getEncodingClass(const CTransaction& tx, int nBlock)
 // RETURNS: >0 if 1 or more payments have been made
 static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, unsigned int idx, CMPTransaction& mp_tx, unsigned int nTime)
 {
-  string strSender;
-  vector<string>script_data;
-  vector<string>address_data;
-  vector<int64_t>value_data;
-  vector<string>multisig_script_data;
-  vector<string>op_return_script_data;
-  string strReference;
-  unsigned char single_pkt[MAX_PACKETS * PACKET_SIZE];
-  unsigned int packet_size = 0;
   mp_tx.Set(wtx.GetHash(), nBlock, idx, nTime);
-
 
   // ### CLASS IDENTIFICATION AND MARKER CHECK ###
   int omniClass = getEncodingClass(wtx, nBlock);
@@ -785,10 +775,12 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
   PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
 
   // ### SENDER IDENTIFICATION ### - collect input amounts and identify sender via "largest input by sum"
+  std::string strSender;
   int64_t inAll = 0;
   int inputs_errors = 0;  // several types of erroroneous MP TX inputs
-  map <string, uint64_t> inputs_sum_of_values;
-  for (unsigned int i = 0; i < wtx.vin.size(); i++) {
+  std::map<std::string, int64_t> inputs_sum_of_values;
+
+  for (unsigned int i = 0; i < wtx.vin.size(); ++i) {
       if (msc_debug_vin) PrintToLog("vin=%d:%s\n", i, wtx.vin[i].scriptSig.ToString());
       CTransaction txPrev;
       uint256 hashBlock;
@@ -807,19 +799,21 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
       if (msc_debug_vin) PrintToLog("vin=%d:%s\n", i, wtx.vin[i].ToString());
   }
   if (inputs_errors) { return -101; } // not a valid Omni TX, disallowed inputs invalidate the transaction
-  int64_t outAll = wtx.GetValueOut();
-  int64_t txFee = inAll - outAll; // miner fee
-  uint64_t nMax = 0;
-  for(map<string, uint64_t>::iterator my_it = inputs_sum_of_values.begin(); my_it != inputs_sum_of_values.end(); ++my_it) { // find largest by sum
-      uint64_t nTemp = my_it->second;
+
+  int64_t nMax = 0;
+  for (std::map<std::string, int64_t>::iterator it = inputs_sum_of_values.begin(); it != inputs_sum_of_values.end(); ++it) { // find largest by sum
+      int64_t nTemp = it->second;
       if (nTemp > nMax) {
-          strSender = my_it->first;
+          strSender = it->first;
           if (msc_debug_exo) PrintToLog("looking for The Sender: %s , nMax=%lu, nTemp=%lu\n", strSender, nMax, nTemp);
           nMax = nTemp;
       }
   }
+
+  int64_t outAll = wtx.GetValueOut();
+  int64_t txFee = inAll - outAll; // miner fee
   if (!strSender.empty()) {
-      if (msc_debug_verbose) PrintToLog("The Sender: %s : His Input Sum of Values= %lu.%08lu ; fee= %lu.%08lu\n", strSender, nMax / COIN, nMax % COIN, txFee/COIN, txFee%COIN);
+      if (msc_debug_verbose) PrintToLog("The Sender: %s : His Input Sum of Values= %s ; fee= %s\n", strSender, FormatDivisibleMP(nMax), FormatDivisibleMP(txFee));
   } else {
       PrintToLog("The sender is still EMPTY !!! txid: %s\n", wtx.GetHash().GetHex());
       return -5;
@@ -844,21 +838,26 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
   }
 
   // ### DATA POPULATION ### - save output addresses, values and scripts
-  for (unsigned int i = 0; i < wtx.vout.size(); i++) {
-      CTxDestination dest;
-      string strAddress;
+  std::string strReference;
+  unsigned char single_pkt[MAX_PACKETS * PACKET_SIZE];
+  unsigned int packet_size = 0;
+  std::vector<std::string> script_data;
+  std::vector<std::string> address_data;
+  std::vector<int64_t> value_data;
+
+  for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
       txnouttype whichType;
-      bool validType = false;
-      if (!GetOutputType(wtx.vout[i].scriptPubKey, whichType)) validType=false;
-      if (isAllowedOutputType(whichType, nBlock)) validType=true;
-      if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
-          strAddress = CBitcoinAddress(dest).ToString();
-          if ((exodus_address != strAddress) && (validType)) {
-              if (msc_debug_parser_data) PrintToLog("saving address_data #%d: %s:%s\n", i, strAddress, wtx.vout[i].scriptPubKey.ToString());
+      if (!GetOutputType(wtx.vout[n].scriptPubKey, whichType)) { continue; }
+      if (!isAllowedOutputType(whichType, nBlock)) { continue; }
+      CTxDestination dest;
+      if (ExtractDestination(wtx.vout[n].scriptPubKey, dest)) {
+          CBitcoinAddress address(dest);
+          if (!(address == ExodusAddress())) {
               // saving for Class A processing or reference
-              GetScriptPushes(wtx.vout[i].scriptPubKey, script_data);
-              address_data.push_back(strAddress);
-              value_data.push_back(wtx.vout[i].nValue);
+              GetScriptPushes(wtx.vout[n].scriptPubKey, script_data);
+              address_data.push_back(address.ToString());
+              value_data.push_back(wtx.vout[n].nValue);
+              if (msc_debug_parser_data) PrintToLog("saving address_data #%d: %s:%s\n", n, address.ToString(), wtx.vout[n].scriptPubKey.ToString());
           }
       }
   }
@@ -866,17 +865,17 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
 
   // ### CLASS A PARSING ###
   if (omniClass == OMNI_CLASS_A) {
-      string strScriptData;
-      string strDataAddress;
-      string strRefAddress;
+      std::string strScriptData;
+      std::string strDataAddress;
+      std::string strRefAddress;
       unsigned char dataAddressSeq = 0xFF;
       unsigned char seq = 0xFF;
       int64_t dataAddressValue = 0;
-      for (unsigned k = 0; k<script_data.size();k++) { // Step 1, locate the data packet
+      for (unsigned k = 0; k < script_data.size(); ++k) { // Step 1, locate the data packet
           txnouttype whichType;
           if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
           if (!isAllowedOutputType(whichType, nBlock)) break;
-          string strSub = script_data[k].substr(2,16); // retrieve bytes 1-9 of packet for peek & decode comparison
+          std::string strSub = script_data[k].substr(2,16); // retrieve bytes 1-9 of packet for peek & decode comparison
           seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
           if (("0000000000000001" == strSub) || ("0000000000000002" == strSub)) { // peek & decode comparison
               if (strScriptData.empty()) { // confirm we have not already located a data address
@@ -886,7 +885,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                   dataAddressValue = value_data[k]; // record data address amount for reference matching
                   if (msc_debug_parser_data) PrintToLog("Data Address located - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], address_data[k], value_data[k] / COIN, value_data[k] % COIN);
               } else { // invalidate - Class A cannot be more than one data packet - possible collision, treat as default (BTC payment)
-                  strDataAddress = ""; //empty strScriptData to block further parsing
+                  strDataAddress.clear(); //empty strScriptData to block further parsing
                   if (msc_debug_parser_data) PrintToLog("Multiple Data Addresses found (collision?) Class A invalidated, defaulting to BTC payment\n");
                   break;
               }
@@ -894,7 +893,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
       }
       if (!strDataAddress.empty()) { // Step 2, try to locate address with seqnum = DataAddressSeq+1 (also verify Step 1, we should now have a valid data packet)
           unsigned char expectedRefAddressSeq = dataAddressSeq + 1;
-          for (unsigned k = 0; k<script_data.size();k++) { // loop through outputs
+          for (unsigned k = 0; k < script_data.size(); ++k) { // loop through outputs
               txnouttype whichType;
               if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
               if (!isAllowedOutputType(whichType, nBlock)) break;
@@ -904,7 +903,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                       strRefAddress = address_data[k]; // set ref address
                       if (msc_debug_parser_data) PrintToLog("Reference Address located via seqnum - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], address_data[k], value_data[k] / COIN, value_data[k] % COIN);
                   } else { // can't trust sequence numbers to provide reference address, there is a collision with >1 address with expected seqnum
-                      strRefAddress = ""; // blank ref address
+                      strRefAddress.clear(); // blank ref address
                       if (msc_debug_parser_data) PrintToLog("Reference Address sequence number collision, will fall back to evaluating matching output amounts\n");
                       break;
                   }
@@ -920,7 +919,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
               }
           }
           if (strRefAddress.empty()) { // Step 3, if we still don't have a reference address, see if we can locate an address with matching output amounts
-              for (unsigned k = 0; k<script_data.size();k++) { // loop through outputs
+              for (unsigned k = 0; k < script_data.size(); ++k) { // loop through outputs
                   txnouttype whichType;
                   if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
                   if (!isAllowedOutputType(whichType, nBlock)) break;
@@ -931,7 +930,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                                   strRefAddress = address_data[k];
                                   if (msc_debug_parser_data) PrintToLog("Reference Address located via matching amounts - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], address_data[k], value_data[k] / COIN, value_data[k] % COIN);
                               } else {
-                                  strRefAddress = "";
+                                  strRefAddress.clear();
                                   if (msc_debug_parser_data) PrintToLog("Reference Address collision, multiple potential candidates. Class A invalidated, defaulting to BTC payment\n");
                                   break;
                               }
@@ -941,8 +940,8 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
               }
           }
       } // end if (!strDataAddress.empty())
-      if (!strRefAddress.empty()) strReference=strRefAddress; // populate expected var strReference with chosen address (if not empty)
-      if (strRefAddress.empty()) strDataAddress=""; // last validation step, if strRefAddress is empty, blank strDataAddress so we default to BTC payment
+      if (!strRefAddress.empty()) strReference = strRefAddress; // populate expected var strReference with chosen address (if not empty)
+      if (strRefAddress.empty()) strDataAddress.clear(); // last validation step, if strRefAddress is empty, blank strDataAddress so we default to BTC payment
       if (!strDataAddress.empty()) { // valid Class A packet almost ready
           if (msc_debug_parser_data) PrintToLog("valid Class A:from=%s:to=%s:data=%s\n", strSender, strReference, strScriptData);
           packet_size = PACKET_SIZE_CLASS_A;
@@ -953,22 +952,21 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
           PrintToLog("!! this may be the BTC payment for an offer !!\n");
           // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
           int count = 0;
-          for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+          for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
               CTxDestination dest;
-              if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
-                  const string strAddress = CBitcoinAddress(dest).ToString();
-                  if (exodus_address == strAddress) continue;
-                  PrintToLog("payment #%d %s %11.8lf\n", count, strAddress, (double)wtx.vout[i].nValue/(double)COIN);
+              if (ExtractDestination(wtx.vout[n].scriptPubKey, dest)) {
+                  CBitcoinAddress address(dest);
+                  if (address == ExodusAddress()) { continue; }
+                  std::string strAddress = address.ToString();
+                  PrintToLog("payment #%d %s %s\n", count, strAddress, FormatIndivisibleMP(wtx.vout[n].nValue));
                   // check everything & pay BTC for the property we are buying here...
                   if (bRPConly) count = 55555;  // no real way to validate a payment during simple RPC call
-                  else if (0 == DEx_payment(wtx.GetHash(), i, strAddress, strSender, wtx.vout[i].nValue, nBlock)) ++count;
+                  else if (0 == DEx_payment(wtx.GetHash(), n, strAddress, strSender, wtx.vout[n].nValue, nBlock)) ++count;
               }
           }
           return count ? count : -5678; // return count -- the actual number of payments within this TX or error if none were made
       }
   }
-
-
   // ### CLASS B / CLASS C PARSING ###
   if ((omniClass == OMNI_CLASS_B) || (omniClass == OMNI_CLASS_C)) {
       unsigned int k = 0;
@@ -976,8 +974,8 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
       bool referenceFound = false; // bool to hold whether we've found the reference yet
       bool changeRemoved = false; // bool to hold whether we've ignored the first output to sender as change
       unsigned int potentialReferenceOutputs = 0; // int to hold number of potential reference outputs
-      BOOST_FOREACH(const string &addr, address_data) { // how many potential reference outputs do we have, if just one select it right here
-          if (msc_debug_parser_data) PrintToLog("ref? data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], addr, value_data[k] / COIN, value_data[k] % COIN);
+      BOOST_FOREACH(const std::string& addr, address_data) { // how many potential reference outputs do we have, if just one select it right here
+          if (msc_debug_parser_data) PrintToLog("ref? data[%d]:%s: %s (%s)\n", k, script_data[k], addr, FormatIndivisibleMP(value_data[k]));
           ++k;
           if (addr != exodus_address) {
               ++potentialReferenceOutputs;
@@ -986,7 +984,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                   referenceFound = true;
                   if (msc_debug_parser_data) PrintToLog("Single reference potentially id'd as follows: %s \n", strReference);
               } else { //as soon as potentialReferenceOutputs > 1 we need to go fishing
-                  strReference = ""; // avoid leaving strReference populated for sanity
+                  strReference.clear(); // avoid leaving strReference populated for sanity
                   referenceFound = false;
                   if (msc_debug_parser_data) PrintToLog("More than one potential reference candidate, blanking strReference, need to go fishing\n");
               }
@@ -994,7 +992,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
       }
       if (!referenceFound) { // do we have a reference now? or do we need to dig deeper
           if (msc_debug_parser_data) PrintToLog("Reference has not been found yet, going fishing\n");
-          BOOST_FOREACH(const string &addr, address_data) {
+          BOOST_FOREACH(const std::string& addr, address_data) {
               if (addr != exodus_address) { // removed strSender restriction, not to spec
                   if ((addr == strSender) && (!changeRemoved)) {
                       changeRemoved = true; // per spec ignore first output to sender as change if multiple possible ref addresses
@@ -1008,70 +1006,66 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
       }
       if (msc_debug_parser_data) PrintToLog("Ending reference identification\nFinal decision on reference identification is: %s\n", strReference);
       if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+
       // ### CLASS B SPECIFC PARSING ###
       if (omniClass == OMNI_CLASS_B) {
+          std::vector<std::string> multisig_script_data;
 
           // ### POPULATE MULTISIG SCRIPT DATA ###
-          for (unsigned int i = 0; i < wtx.vout.size(); i++) {
-              CTxDestination address;
-              if (ExtractDestination(wtx.vout[i].scriptPubKey, address)) {} else { // if true it's a plain pay-to-pubkeyhash output
-                  txnouttype type;
-                  std::vector<CTxDestination> vDest;
-                  int nRequired;
-                  if (msc_debug_script) PrintToLog("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
-                  if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired)) {
-                      if (msc_debug_script) PrintToLog(" >> multisig: ");
-                      BOOST_FOREACH(const CTxDestination &dest, vDest) {
-                          CBitcoinAddress address = CBitcoinAddress(dest);
-                          CKeyID keyID;
-                          if (!address.GetKeyID(keyID)) { } // TODO: add an error handler
-                          if (msc_debug_script) PrintToLog("%s ; ", address.ToString());
-                      }
-                      if (msc_debug_script) PrintToLog("\n");
-                      // ignore first public key, as it should belong to the sender
-                      // and it be used to avoid the creation of unspendable dust
-                      GetScriptPushes(wtx.vout[i].scriptPubKey, multisig_script_data, true);
-                  }
-              }
+          for (unsigned int i = 0; i < wtx.vout.size(); ++i) {
+            txnouttype whichType;
+            std::vector<CTxDestination> vDest;
+            int nRequired;
+            if (msc_debug_script) PrintToLog("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
+            if (!ExtractDestinations(wtx.vout[i].scriptPubKey, whichType, vDest, nRequired)) { continue; }
+            if (whichType == TX_MULTISIG) {
+                if (msc_debug_script) PrintToLog(" >> multisig: ");
+                BOOST_FOREACH(const CTxDestination& dest, vDest) {
+                    CBitcoinAddress address = CBitcoinAddress(dest);
+                    if (msc_debug_script) PrintToLog("%s ; ", address.ToString());
+                }
+                if (msc_debug_script) PrintToLog("\n");
+                // ignore first public key, as it should belong to the sender
+                // and it be used to avoid the creation of unspendable dust
+                GetScriptPushes(wtx.vout[i].scriptPubKey, multisig_script_data, true);
+            }
           }
 
           // ### PREPARE A FEW VARS ###
           std::string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
           PrepareObfuscatedHashes(strSender, strObfuscatedHashes);
           unsigned char packets[MAX_PACKETS][32];
-          int mdata_count = 0;  // multisig data count
+          unsigned int mdata_count = 0;  // multisig data count
 
           // ### DEOBFUSCATE MULTISIG PACKETS ###
-          for (unsigned int k = 0; k<multisig_script_data.size();k++) {
+          for (unsigned int k = 0; k < multisig_script_data.size(); ++k) {
               if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-              CPubKey key(ParseHex(multisig_script_data[k]));
-              CKeyID keyID = key.GetID();
-              string strAddress = CBitcoinAddress(keyID).ToString();
-              char *c_addr_type = (char *)"";
-              string strPacket;
-              if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
-              vector<unsigned char>hash = ParseHex(strObfuscatedHashes[mdata_count+1]);
-              vector<unsigned char>packet = ParseHex(multisig_script_data[k].substr(2*1,2*PACKET_SIZE));
-              for (unsigned int i=0;i<packet.size();i++) { // this is a data packet, must deobfuscate now
+
+              std::vector<unsigned char> hash = ParseHex(strObfuscatedHashes[mdata_count+1]);
+              std::vector<unsigned char> packet = ParseHex(multisig_script_data[k].substr(2*1,2*PACKET_SIZE));
+              for (unsigned int i = 0; i < packet.size(); i++) { // this is a data packet, must deobfuscate now
                   packet[i] ^= hash[i];
               }
-              memcpy(&packets[mdata_count], &packet[0], PACKET_SIZE);
-              strPacket = HexStr(packet.begin(),packet.end(), false);
-              ++mdata_count;
-              if (MAX_PACKETS <= mdata_count) {
+              if (MAX_PACKETS <= mdata_count+1) {
                   PrintToLog("increase MAX_PACKETS ! mdata_count= %d\n", mdata_count);
                   return -222;
               }
-              if (msc_debug_parser_data) PrintToLog("multisig_data[%d]:%s: %s%s\n", k, multisig_script_data[k], strAddress, c_addr_type);
+              memcpy(&packets[mdata_count], &packet[0], PACKET_SIZE);
+              ++mdata_count;
+              CPubKey key(ParseHex(multisig_script_data[k]));
+              CKeyID keyID = key.GetID();
+              std::string strAddress = CBitcoinAddress(keyID).ToString();
+              std::string strPacket = HexStr(packet.begin(), packet.end());
+              if (msc_debug_parser_data) PrintToLog("multisig_data[%d]:%s: %s\n", k, multisig_script_data[k], strAddress);
               if (!strPacket.empty()) { if (msc_debug_parser) PrintToLog("packet #%d: %s\n", mdata_count, strPacket); }
               if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
           }
           packet_size = mdata_count * (PACKET_SIZE - 1);
-          if (sizeof(single_pkt)<packet_size) return -111;
+          if (sizeof(single_pkt) < packet_size) { return -111; }
           if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
 
           // ### FINALIZE CLASS B ###
-          for (int m=0;m<mdata_count;m++) { // now decode mastercoin packets
+          for (unsigned int m = 0; m < mdata_count; ++m) { // now decode mastercoin packets
               if (msc_debug_parser) PrintToLog("m=%d: %s\n", m, HexStr(packets[m], PACKET_SIZE + packets[m], false));
               // check to ensure the sequence numbers are sequential and begin with 01 !
               if (1+m != packets[m][0]) {
@@ -1083,39 +1077,36 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
 
       // ### CLASS C SPECIFIC PARSING ###
       if (omniClass == OMNI_CLASS_C) {
+          std::vector<std::string> op_return_script_data;
 
           // ### POPULATE OP RETURN SCRIPT DATA ###
-          for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+          for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
               txnouttype whichType;
-              bool validType = false;
-              if (!GetOutputType(wtx.vout[i].scriptPubKey, whichType)) validType=false;
-              if (isAllowedOutputType(whichType, nBlock)) validType=true;
-              if ((whichType == TX_NULL_DATA) && (validType)) {
-                  GetScriptPushes(wtx.vout[i].scriptPubKey, op_return_script_data); // only one OP_RETURN output permitted per tx
-                  string debug_op_string;
-                  if (op_return_script_data.size() > 0) debug_op_string=op_return_script_data[0];
-                  if (msc_debug_parser_data) PrintToLog("Class C transaction detected: %s parsed to %s at vout %d\n", wtx.GetHash().GetHex(), debug_op_string, i);
+              if (!GetOutputType(wtx.vout[n].scriptPubKey, whichType)) { continue; }
+              if (!isAllowedOutputType(whichType, nBlock)) { continue; }
+              if (whichType == TX_NULL_DATA) {
+                  GetScriptPushes(wtx.vout[n].scriptPubKey, op_return_script_data);
+                  std::string debug_op_string;
+                  if (op_return_script_data.size() > 0) debug_op_string = op_return_script_data[0];
+                  if (msc_debug_parser_data) PrintToLog("Class C transaction detected: %s parsed to %s at vout %d\n", wtx.GetHash().GetHex(), debug_op_string, n);
               }
           }
 
           // ### EXTRACT PAYLOAD FOR CLASS C ###
-          if (op_return_script_data.size() > 0) {
+          for (unsigned int n = 0; n < op_return_script_data.size(); ++n) {
               if (op_return_script_data[0].size() > 4) {
-                  std::string payload = op_return_script_data[0].substr(4,op_return_script_data[0].size()-4); // strip out marker
-                  packet_size=(payload.size())/2; // get packet byte size - hex so always a multiple of 2
-                  if(packet_size < MIN_PAYLOAD_SIZE) return -111;
-                  memcpy(single_pkt, &ParseHex(payload)[0], packet_size); // load the packet ready to set mp tx info
+                  std::string payload = op_return_script_data[n].substr(4); // strip out marker
+                  unsigned int size = payload.size() / 2; // get packet byte size - hex so always a multiple of 2
+                  memcpy(single_pkt+packet_size, &ParseHex(payload)[0], size); // load the packet ready to set mp tx info
+                  packet_size += size;
               }
           }
+          if (packet_size < MIN_PAYLOAD_SIZE) { return -111; }
       }
   }
 
-
-
-
-
   // ### SET MP TX INFO ###
-  if (msc_debug_verbose) PrintToLog("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt, false));
+  if (msc_debug_verbose) PrintToLog("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt));
   mp_tx.Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, omniClass-1, (inAll-outAll));
 
   return 0;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1196,7 +1196,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
 
             // ### EXTRACT PAYLOAD FOR CLASS C ###
             for (unsigned int n = 0; n < op_return_script_data.size(); ++n) {
-                if (op_return_script_data[0].size() > 4) {
+                if (op_return_script_data[n].size() > 4) {
                     std::string payload = op_return_script_data[n].substr(4); // strip out marker
                     unsigned int size = payload.size() / 2; // get packet byte size - hex so always a multiple of 2
                     memcpy(single_pkt+packet_size, &ParseHex(payload)[0], size); // load the packet ready to set mp tx info

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -724,7 +724,15 @@ bool mastercore::IsAllowedOutputType(int whichType, int nBlock)
     return false;
 }
 
-static int getEncodingClass(const CTransaction& tx, int nBlock)
+/**
+ * Returns the encoding class, used to embed a payload.
+ *
+ *   0 None
+ *   1 Class A (p2pkh)
+ *   2 Class B (multisig)
+ *   3 Class C (op-return)
+ */
+int mastercore::GetEncodingClass(const CTransaction& tx, int nBlock)
 {
     bool hasExodus = false;
     bool hasMultisig = false;
@@ -797,7 +805,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
     mp_tx.Set(wtx.GetHash(), nBlock, idx, nTime);
 
     // ### CLASS IDENTIFICATION AND MARKER CHECK ###
-    int omniClass = getEncodingClass(wtx, nBlock);
+    int omniClass = GetEncodingClass(wtx, nBlock);
 
     if (omniClass == NO_MARKER) {
         return -1; // No Exodus/Omni marker, thus not a valid Omni transaction

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -937,9 +937,6 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         unsigned char seq = 0xFF;
         int64_t dataAddressValue = 0;
         for (unsigned k = 0; k < script_data.size(); ++k) { // Step 1, locate the data packet
-            txnouttype whichType;
-            if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-            if (!IsAllowedOutputType(whichType, nBlock)) break;
             std::string strSub = script_data[k].substr(2,16); // retrieve bytes 1-9 of packet for peek & decode comparison
             seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
             if (("0000000000000001" == strSub) || ("0000000000000002" == strSub)) { // peek & decode comparison
@@ -959,9 +956,6 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         if (!strDataAddress.empty()) { // Step 2, try to locate address with seqnum = DataAddressSeq+1 (also verify Step 1, we should now have a valid data packet)
             unsigned char expectedRefAddressSeq = dataAddressSeq + 1;
             for (unsigned k = 0; k < script_data.size(); ++k) { // loop through outputs
-                txnouttype whichType;
-                if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-                if (!IsAllowedOutputType(whichType, nBlock)) break;
                 seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
                 if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (expectedRefAddressSeq == seq)) { // found reference address with matching sequence number
                     if (strRefAddress.empty()) { // confirm we have not already located a reference address
@@ -985,9 +979,6 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             }
             if (strRefAddress.empty()) { // Step 3, if we still don't have a reference address, see if we can locate an address with matching output amounts
                 for (unsigned k = 0; k < script_data.size(); ++k) { // loop through outputs
-                    txnouttype whichType;
-                    if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-                    if (!IsAllowedOutputType(whichType, nBlock)) break;
                     if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (dataAddressValue == value_data[k])) { // this output matches data output, check if matches exodus output
                         for (unsigned int exodus_idx = 0; exodus_idx < ExodusValues.size(); exodus_idx++) {
                             if (value_data[k] == ExodusValues[exodus_idx]) { //this output matches data address value and exodus address value, choose as ref

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -215,9 +215,9 @@ std::string mastercore::strMPProperty(uint32_t propertyId)
     return str;
 }
 
-inline bool isNonMainNet()
+inline bool MainNet()
 {
-    return Params().NetworkIDString() != "main";
+    return Params().NetworkIDString() == "main";
 }
 
 inline bool TestNet()
@@ -233,6 +233,11 @@ inline bool RegTest()
 inline bool UnitTest()
 {
     return Params().NetworkIDString() == "unittest";
+}
+
+inline bool isNonMainNet()
+{
+    return !MainNet() && !UnitTest();
 }
 
 std::string FormatDivisibleShortMP(int64_t n)
@@ -2023,7 +2028,7 @@ int mastercore_init()
     InitDebugLogLevels();
     ShrinkDebugLog();
 
-    if (isNonMainNet() && !UnitTest()) {
+    if (isNonMainNet()) {
         exodus_address = exodus_testnet;
     }
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -777,8 +777,11 @@ int mastercore::GetEncodingClass(const CTransaction& tx, int nBlock)
             }
             if (!scriptPushes.empty()) {
                 std::vector<unsigned char> vchMarker = GetOmMarker();
-                std::vector<unsigned char> vchPushes = ParseHex(scriptPushes[0]);
-                if (std::equal(vchMarker.begin(), vchMarker.end(), vchPushes.begin())) {
+                std::vector<unsigned char> vchPushed = ParseHex(scriptPushes[0]);
+                if (vchPushed.size() < vchMarker.size()) {
+                    continue;
+                }
+                if (std::equal(vchMarker.begin(), vchMarker.end(), vchPushed.begin())) {
                     hasOpReturn = true;
                 }
             }
@@ -1770,6 +1773,9 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                     if (!vstrPushes.empty()) {
                         std::vector<unsigned char> vchMarker = GetOmMarker();
                         std::vector<unsigned char> vchPushed = ParseHex(vstrPushes[0]);
+                        if (vchPushed.size() < vchMarker.size()) {
+                            continue;
+                        }
                         if (std::equal(vchMarker.begin(), vchMarker.end(), vchPushed.begin())) {
                             size_t sizeHex = vchMarker.size() * 2;
                             // strip out the marker at the very beginning

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -98,6 +98,8 @@ using namespace mastercore;
 CCriticalSection cs_tally;
 
 static string exodus_address = "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P";
+
+static const string exodus_mainnet = "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P";
 static const string exodus_testnet = "mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv";
 static const string getmoney_testnet = "moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP";
 
@@ -3474,9 +3476,13 @@ int mastercore_handler_disc_end(int nBlockNow, CBlockIndex const * pBlockIndex)
  */
 const CBitcoinAddress ExodusAddress()
 {
-    static CBitcoinAddress address(exodus_address);
-
-    return address;
+    if (isNonMainNet()) {
+        static CBitcoinAddress testAddress(exodus_testnet);
+        return testAddress;
+    } else {
+        static CBitcoinAddress mainAddress(exodus_mainnet);
+        return mainAddress;
+    }
 }
 
 /**
@@ -3493,17 +3499,16 @@ const CBitcoinAddress ExodusAddress()
  */
 const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock)
 {
-    static CBitcoinAddress moneysAddress(getmoney_testnet);
-    static CBitcoinAddress exodusAddress = ExodusAddress();
-
     if (MONEYMAN_TESTNET_BLOCK <= nBlock && isNonMainNet()) {
-        return moneysAddress;
+        static CBitcoinAddress moneyAddress(getmoney_testnet);
+        return moneyAddress;
     }
     else if (MONEYMAN_REGTEST_BLOCK <= nBlock && RegTest()) {
-        return moneysAddress;
+        static CBitcoinAddress moneyAddress(getmoney_testnet);
+        return moneyAddress;
     }
 
-    return exodusAddress;
+    return ExodusAddress();
 }
 
  // the 31-byte packet & the packet #

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -511,10 +511,16 @@ static void calculateFundraiser(int64_t amtTransfer, uint8_t bonusPerc,
     tokens = std::make_pair(createdTokens_int.convert_to<int64_t>(), issuerTokens_int.convert_to<int64_t>());
 }
 
-// certain transaction types are not live on the network until some specific block height
-// certain transactions will be unknown to the client, i.e. "black holes" based on their version
-// the Restrictions array is as such: type, block-allowed-in, top-version-allowed
-bool mastercore::isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty)
+/**
+ * Checks, if the transaction type and version is supported and enabled.
+ *
+ * Certain transaction types are not live/enabled until some specific block height.
+ * Certain transactions will be unknown to the client, i.e. "black holes" based on their version.
+ *
+ * The restrictions array is as such:
+ *   type, block-allowed-in, top-version-allowed
+ */
+bool mastercore::IsTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty)
 {
 bool bAllowed = false;
 bool bBlackHole = false;
@@ -673,7 +679,10 @@ int TXExodusFundraiser(const CTransaction &wtx, const string &sender, int64_t Ex
   return -1;
 }
 
-static bool isAllowedInputType(int whichType, int nBlock)
+/**
+ * Checks, if the script type is allowed as input.
+ */
+bool mastercore::IsAllowedInputType(int whichType, int nBlock)
 {
     switch (whichType)
     {
@@ -687,7 +696,10 @@ static bool isAllowedInputType(int whichType, int nBlock)
     return false;
 }
 
-static bool isAllowedOutputType(int whichType, int nBlock)
+/**
+ * Checks, if the script type qualifies as output.
+ */
+bool mastercore::IsAllowedOutputType(int whichType, int nBlock)
 {
     switch (whichType)
     {
@@ -721,7 +733,7 @@ static int getEncodingClass(const CTransaction& tx, int nBlock)
         if (!GetOutputType(output.scriptPubKey, outType)) {
             continue;
         }
-        if (!isAllowedOutputType(outType, nBlock)) {
+        if (!IsAllowedOutputType(outType, nBlock)) {
             continue;
         }
 
@@ -811,7 +823,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             inAll += txPrev.vout[n].nValue;
             if (ExtractDestination(txPrev.vout[n].scriptPubKey, source)) { // extract the destination of the previous transaction's vout[n] and check it's allowed type
                 if (!GetOutputType(txPrev.vout[n].scriptPubKey, whichType)) { ++inputs_errors; break; }
-                if (!isAllowedInputType(whichType, nBlock)) { ++inputs_errors; break; }
+                if (!IsAllowedInputType(whichType, nBlock)) { ++inputs_errors; break; }
                 CBitcoinAddress addressSource(source);
                 inputs_sum_of_values[addressSource.ToString()] += txPrev.vout[n].nValue;
             }
@@ -846,7 +858,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             txnouttype whichType;
             inAll += txPrev.vout[n].nValue;
             if (!GetOutputType(txPrev.vout[n].scriptPubKey, whichType)) { return -101; }
-            if (!isAllowedInputType(whichType, nBlock)) { return -101; }
+            if (!IsAllowedInputType(whichType, nBlock)) { return -101; }
             if (ExtractDestination(txPrev.vout[n].scriptPubKey, source)) {
                 strSender = CBitcoinAddress(source).ToString();
             }
@@ -901,7 +913,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
     for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
         txnouttype whichType;
         if (!GetOutputType(wtx.vout[n].scriptPubKey, whichType)) { continue; }
-        if (!isAllowedOutputType(whichType, nBlock)) { continue; }
+        if (!IsAllowedOutputType(whichType, nBlock)) { continue; }
         CTxDestination dest;
         if (ExtractDestination(wtx.vout[n].scriptPubKey, dest)) {
             CBitcoinAddress address(dest);
@@ -927,7 +939,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         for (unsigned k = 0; k < script_data.size(); ++k) { // Step 1, locate the data packet
             txnouttype whichType;
             if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-            if (!isAllowedOutputType(whichType, nBlock)) break;
+            if (!IsAllowedOutputType(whichType, nBlock)) break;
             std::string strSub = script_data[k].substr(2,16); // retrieve bytes 1-9 of packet for peek & decode comparison
             seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
             if (("0000000000000001" == strSub) || ("0000000000000002" == strSub)) { // peek & decode comparison
@@ -949,7 +961,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             for (unsigned k = 0; k < script_data.size(); ++k) { // loop through outputs
                 txnouttype whichType;
                 if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-                if (!isAllowedOutputType(whichType, nBlock)) break;
+                if (!IsAllowedOutputType(whichType, nBlock)) break;
                 seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
                 if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (expectedRefAddressSeq == seq)) { // found reference address with matching sequence number
                     if (strRefAddress.empty()) { // confirm we have not already located a reference address
@@ -975,7 +987,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                 for (unsigned k = 0; k < script_data.size(); ++k) { // loop through outputs
                     txnouttype whichType;
                     if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
-                    if (!isAllowedOutputType(whichType, nBlock)) break;
+                    if (!IsAllowedOutputType(whichType, nBlock)) break;
                     if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (dataAddressValue == value_data[k])) { // this output matches data output, check if matches exodus output
                         for (unsigned int exodus_idx = 0; exodus_idx < ExodusValues.size(); exodus_idx++) {
                             if (value_data[k] == ExodusValues[exodus_idx]) { //this output matches data address value and exodus address value, choose as ref
@@ -1136,7 +1148,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
                 txnouttype whichType;
                 if (!GetOutputType(wtx.vout[n].scriptPubKey, whichType)) { continue; }
-                if (!isAllowedOutputType(whichType, nBlock)) { continue; }
+                if (!IsAllowedOutputType(whichType, nBlock)) { continue; }
                 if (whichType == TX_NULL_DATA) {
                     GetScriptPushes(wtx.vout[n].scriptPubKey, op_return_script_data);
                     std::string debug_op_string;
@@ -2250,7 +2262,7 @@ static int64_t selectCoins(const string &FromAddress, CCoinControl &coinControl,
           if (!GetOutputType(pcoin->vout[i].scriptPubKey, whichType))
             continue;
 
-          if (!isAllowedInputType(whichType, nHeight))
+          if (!IsAllowedInputType(whichType, nHeight))
             continue;
 
           CTxDestination dest;
@@ -2299,7 +2311,7 @@ static bool UseEncodingClassC(size_t nDataSize)
     size_t nTotalSize = nDataSize + 2; // Marker "om"
     bool fDataEnabled = GetBoolArg("-datacarrier", true);
     int nBlockNow = GetHeight();
-    if (!isAllowedOutputType(TX_NULL_DATA, nBlockNow)) {
+    if (!IsAllowedOutputType(TX_NULL_DATA, nBlockNow)) {
         fDataEnabled = false;
     }
     return nTotalSize <= nMaxDatacarrierBytes && fDataEnabled;
@@ -3585,7 +3597,7 @@ int CMPTransaction::interpretPacket(CMPOffer* obj_o, CMPMetaDEx* mdex_o)
 
 int CMPTransaction::logicMath_SimpleSend()
 {
-    if (!isTransactionTypeAllowed(block, property, type, version)) {
+    if (!IsTransactionTypeAllowed(block, property, type, version)) {
         return (PKT_ERROR_SEND -22);
     }
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -504,7 +504,12 @@ int64_t getTotalTokens(uint32_t propertyId, int64_t* n_owners_total = NULL);
 
 char *c_strMasterProtocolTXType(int i);
 
-bool isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty = false);
+/** Checks, if the script type is allowed as input. */
+bool IsAllowedInputType(int whichType, int nBlock);
+/** Checks, if the script type qualifies as output. */
+bool IsAllowedOutputType(int whichType, int nBlock);
+/** Checks, if the transaction type and version is supported and enabled. */
+bool IsTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty = false);
 
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -156,8 +156,8 @@ bool feeCheck(const std::string& address, size_t nDataSize);
 /** Returns the Exodus address. */
 const CBitcoinAddress ExodusAddress();
 
-/** Returns the Exodus fundraiser address. */
-const CBitcoinAddress MoneyAddress(int nBlock = 0);
+/** Returns the Exodus crowdsale address. */
+const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock = 0);
 
 //! Used to indicate, whether to automatically commit created transactions
 extern bool autoCommit;

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -161,6 +161,9 @@ const CBitcoinAddress ExodusAddress();
 /** Returns the Exodus crowdsale address. */
 const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock = 0);
 
+/** Returns the marker for class C transactions. */
+const std::vector<unsigned char> GetOmMarker();
+
 //! Used to indicate, whether to automatically commit created transactions
 extern bool autoCommit;
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -53,20 +53,14 @@ int const MAX_STATE_HISTORY = 50;
 #define OMNI_CLASS_B 2
 #define OMNI_CLASS_C 3
 
-// Maximum number of keys supported in Class B
-#define CLASS_B_MAX_SENDABLE_PACKETS 2
-
-// Master Protocol Transaction (Packet) Version
+// Omni Layer Transaction (Packet) Version
 #define MP_TX_PKT_V0  0
 #define MP_TX_PKT_V1  1
-
-// Maximum outputs per BTC Transaction
-#define MAX_BTC_OUTPUTS 16
 
 #define MIN_PAYLOAD_SIZE     5
 #define PACKET_SIZE_CLASS_A 19
 #define PACKET_SIZE         31
-#define MAX_PACKETS         64
+#define MAX_PACKETS        255
 
 // Transaction types, from the spec
 enum TransactionType {

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -8,6 +8,8 @@
 
 class CBitcoinAddress;
 class CBlockIndex;
+class CCoinsView;
+class CCoinsViewCache;
 class CTransaction;
 
 #include "omnicore/log.h"
@@ -480,6 +482,10 @@ extern std::map<std::string, CMPTally> mp_tally_map;
 extern CMPTxList *p_txlistdb;
 extern CMPTradeList *t_tradelistdb;
 extern CMPSTOList *s_stolistdb;
+
+// TODO: move, rename
+extern CCoinsView viewDummy;
+extern CCoinsViewCache view;
 
 std::string strMPProperty(uint32_t propertyId);
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -48,6 +48,7 @@ int const MAX_STATE_HISTORY = 50;
 #define SP_STRING_FIELD_LEN 256
 
 // Omni Layer Transaction Class
+#define NO_MARKER    0
 #define OMNI_CLASS_A 1
 #define OMNI_CLASS_B 2
 #define OMNI_CLASS_C 3

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -162,6 +162,9 @@ bool feeCheck(const std::string& address, size_t nDataSize);
 /** Returns the Exodus address. */
 const CBitcoinAddress ExodusAddress();
 
+/** Returns the Exodus fundraiser address. */
+const CBitcoinAddress MoneyAddress(int nBlock = 0);
+
 //! Used to indicate, whether to automatically commit created transactions
 extern bool autoCommit;
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -489,6 +489,8 @@ extern CMPSTOList *s_stolistdb;
 // TODO: move, rename
 extern CCoinsView viewDummy;
 extern CCoinsViewCache view;
+//! Guards coins view cache
+extern CCriticalSection cs_tx_cache;
 
 std::string strMPProperty(uint32_t propertyId);
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -510,6 +510,8 @@ bool IsAllowedInputType(int whichType, int nBlock);
 bool IsAllowedOutputType(int whichType, int nBlock);
 /** Checks, if the transaction type and version is supported and enabled. */
 bool IsTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty = false);
+/** Returns the encoding class, used to embed a payload. */
+int GetEncodingClass(const CTransaction& tx, int nBlock);
 
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 

--- a/src/omnicore/test/encoding_c_tests.cpp
+++ b/src/omnicore/test/encoding_c_tests.cpp
@@ -27,6 +27,8 @@ BOOST_AUTO_TEST_CASE(class_c_marker)
     std::vector<unsigned char> vchMarker;
     vchMarker.push_back(0x6f); // "o"
     vchMarker.push_back(0x6d); // "m"
+    vchMarker.push_back(0x6e); // "n"
+    vchMarker.push_back(0x69); // "i"
 
     std::vector<unsigned char> vchPayload = ParseHex(
         "00000000000000010000000006dac2c0");
@@ -85,7 +87,7 @@ BOOST_AUTO_TEST_CASE(class_c_with_empty_payload)
     BOOST_CHECK_EQUAL(vecOutputs.size(), 0);
 
     // Exactly the size of the marker
-    nMaxDatacarrierBytes = 2; // byte
+    nMaxDatacarrierBytes = 4; // byte
 
     BOOST_CHECK(OmniCore_Encode_ClassC(vchEmptyPayload, vecOutputs));
     BOOST_CHECK_EQUAL(vecOutputs.size(), 1);

--- a/src/omnicore/test/exodus_tests.cpp
+++ b/src/omnicore/test/exodus_tests.cpp
@@ -1,0 +1,115 @@
+#include "omnicore/omnicore.h"
+
+#include "base58.h"
+#include "chainparams.h"
+
+#include <limits>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_exodus_tests)
+
+BOOST_AUTO_TEST_CASE(exodus_address_mainnet)
+{
+    SelectParams(CBaseChainParams::MAIN);
+
+    BOOST_CHECK(CBitcoinAddress("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P") ==
+                ExodusAddress());
+    BOOST_CHECK(!(CBitcoinAddress("1rDQWR9yZLJY7ciyghAaF7XKD9tGzQuP6") ==
+                ExodusAddress()));
+
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+BOOST_AUTO_TEST_CASE(exodus_crowdsale_address_mainnet)
+{
+    SelectParams(CBaseChainParams::MAIN);
+
+    BOOST_CHECK(CBitcoinAddress("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P") ==
+                ExodusCrowdsaleAddress(0));
+    BOOST_CHECK(CBitcoinAddress("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P") ==
+                ExodusCrowdsaleAddress(std::numeric_limits<int>().max()));
+    BOOST_CHECK(!(CBitcoinAddress("1rDQWR9yZLJY7ciyghAaF7XKD9tGzQuP6") ==
+                ExodusCrowdsaleAddress(0)));
+    BOOST_CHECK(!(CBitcoinAddress("1rDQWR9yZLJY7ciyghAaF7XKD9tGzQuP6") ==
+                ExodusCrowdsaleAddress(std::numeric_limits<int>().max())));
+
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+BOOST_AUTO_TEST_CASE(exodus_address_testnet)
+{
+    SelectParams(CBaseChainParams::TESTNET);
+
+    BOOST_CHECK(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusAddress());
+    BOOST_CHECK(!(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusAddress()));
+
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+BOOST_AUTO_TEST_CASE(exodus_address_regtest)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+
+    BOOST_CHECK(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusAddress());
+    BOOST_CHECK(!(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusAddress()));
+
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+BOOST_AUTO_TEST_CASE(exodus_crowdsale_address_testnet)
+{
+    SelectParams(CBaseChainParams::TESTNET);
+
+    BOOST_CHECK(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(0));
+    BOOST_CHECK(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(MONEYMAN_TESTNET_BLOCK-1));
+    BOOST_CHECK(!(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(0)));
+    BOOST_CHECK(!(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(MONEYMAN_TESTNET_BLOCK-1)));
+    BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(MONEYMAN_TESTNET_BLOCK));
+    BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(std::numeric_limits<int>().max()));
+    BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(MONEYMAN_TESTNET_BLOCK)));
+    BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(std::numeric_limits<int>().max())));
+
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+BOOST_AUTO_TEST_CASE(exodus_crowdsale_address_regtest)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+
+    BOOST_CHECK(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(0));
+    BOOST_CHECK(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(MONEYMAN_REGTEST_BLOCK-1));
+    BOOST_CHECK(!(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(0)));
+    BOOST_CHECK(!(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(MONEYMAN_REGTEST_BLOCK-1)));
+    BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(MONEYMAN_REGTEST_BLOCK));
+    BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
+                ExodusCrowdsaleAddress(std::numeric_limits<int>().max()));
+    BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(MONEYMAN_REGTEST_BLOCK)));
+    BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
+                ExodusCrowdsaleAddress(std::numeric_limits<int>().max())));
+
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/marker_tests.cpp
+++ b/src/omnicore/test/marker_tests.cpp
@@ -1,34 +1,15 @@
+#include "omnicore/test/utils_tx.h"
+
 #include "omnicore/omnicore.h"
 #include "omnicore/script.h"
 
-#include "base58.h"
 #include "primitives/transaction.h"
-#include "script/script.h"
-#include "script/standard.h"
-#include "utilstrencodings.h"
 
-#include <stdint.h>
 #include <limits>
 
 #include <boost/test/unit_test.hpp>
 
 using namespace mastercore;
-
-// Forward declarations
-static CTxOut PayToPubKeyHash_Exodus();
-static CTxOut PayToPubKeyHash_ExodusCrowdsale(int nHeight);
-static CTxOut PayToPubKeyHash_Unrelated();
-static CTxOut PayToScriptHash_Unrelated();
-static CTxOut PayToPubKey_Unrelated();
-static CTxOut PayToBareMultisig_1of3();
-static CTxOut PayToBareMultisig_3of5();
-static CTxOut OpReturn_Empty();
-static CTxOut OpReturn_UnrelatedShort();
-static CTxOut OpReturn_Unrelated();
-static CTxOut OpReturn_Tagged_A();
-static CTxOut OpReturn_Tagged_B();
-static CTxOut OpReturn_Tagged_C();
-static CTxOut NonStandardOutput();
 
 BOOST_AUTO_TEST_SUITE(omnicore_marker_tests)
 
@@ -330,179 +311,5 @@ BOOST_AUTO_TEST_CASE(class_class_c)
     }
 }
 
+
 BOOST_AUTO_TEST_SUITE_END()
-
-static CTxOut PayToPubKeyHash_Exodus()
-{
-    CBitcoinAddress address = ExodusAddress();
-    CScript scriptPubKey = GetScriptForDestination(address.Get());
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToPubKeyHash_ExodusCrowdsale(int nHeight)
-{
-    CBitcoinAddress address = ExodusCrowdsaleAddress(nHeight);
-    CScript scriptPubKey = GetScriptForDestination(address.Get());
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToPubKeyHash_Unrelated()
-{
-    CBitcoinAddress address("1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX");
-    CScript scriptPubKey = GetScriptForDestination(address.Get());
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToScriptHash_Unrelated()
-{
-    CBitcoinAddress address("3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL");
-    CScript scriptPubKey = GetScriptForDestination(address.Get());
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToPubKey_Unrelated()
-{
-    std::vector<unsigned char> vchPubKey = ParseHex(
-        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
-        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
-
-    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
-
-    CScript scriptPubKey;
-    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    txnouttype outType;
-    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
-    BOOST_CHECK(outType == TX_PUBKEY);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToBareMultisig_1of3()
-{
-    std::vector<unsigned char> vchPayload1 = ParseHex(
-        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
-        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
-    std::vector<unsigned char> vchPayload2 = ParseHex(
-        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
-    std::vector<unsigned char> vchPayload3 = ParseHex(
-        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
-
-    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
-    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
-    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
-
-    // 1-of-3 bare multisig script
-    CScript scriptPubKey;
-    scriptPubKey << CScript::EncodeOP_N(1);
-    scriptPubKey << ToByteVector(pubKey1);
-    scriptPubKey << ToByteVector(pubKey2);
-    scriptPubKey << ToByteVector(pubKey3);
-    scriptPubKey << CScript::EncodeOP_N(3);
-    scriptPubKey << OP_CHECKMULTISIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToBareMultisig_3of5()
-{
-    std::vector<unsigned char> vchPayload1 = ParseHex(
-        "02619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf");
-    std::vector<unsigned char> vchPayload2 = ParseHex(
-        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
-    std::vector<unsigned char> vchPayload3 = ParseHex(
-        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
-    std::vector<unsigned char> vchPayload4 = ParseHex(
-        "0261a017029ec4688ec9bf33c44ad2e595f83aaf3ed4f3032d1955715f5ffaf6b8");
-    std::vector<unsigned char> vchPayload5 = ParseHex(
-        "02dc1a0afc933d703557d9f5e86423a5cec9fee4bfa850b3d02ceae72117178802");
-
-    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
-    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
-    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
-    CPubKey pubKey4(vchPayload4.begin(), vchPayload4.end());
-    CPubKey pubKey5(vchPayload5.begin(), vchPayload5.end());
-
-    // 3-of-5 bare multisig script
-    CScript scriptPubKey;
-    scriptPubKey << CScript::EncodeOP_N(3);
-    scriptPubKey << ToByteVector(pubKey1);
-    scriptPubKey << ToByteVector(pubKey2) << ToByteVector(pubKey3);
-    scriptPubKey << ToByteVector(pubKey4) << ToByteVector(pubKey5);
-    scriptPubKey << CScript::EncodeOP_N(5);
-    scriptPubKey << OP_CHECKMULTISIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut OpReturn_Empty()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN;
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut OpReturn_UnrelatedShort()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("b9");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut OpReturn_Unrelated()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("7468697320697320646578782028323031352d30362d313129");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut OpReturn_Tagged_A()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6d0000408");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut OpReturn_Tagged_B()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6d00011516");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut OpReturn_Tagged_C()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6dffff2342");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut NonStandardOutput()
-{
-    CScript scriptPubKey;
-    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-

--- a/src/omnicore/test/marker_tests.cpp
+++ b/src/omnicore/test/marker_tests.cpp
@@ -29,14 +29,12 @@ BOOST_AUTO_TEST_CASE(class_no_marker)
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(OpReturn_Unrelated());
         mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_C());
         mutableTx.vout.push_back(NonStandardOutput());
-        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(OpReturn_SimpleSend());
         mutableTx.vout.push_back(OpReturn_UnrelatedShort());
         mutableTx.vout.push_back(OpReturn_Empty());
         mutableTx.vout.push_back(PayToPubKey_Unrelated());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_A());
 
         CTransaction tx(mutableTx);
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
@@ -47,14 +45,13 @@ BOOST_AUTO_TEST_CASE(class_no_marker)
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(OpReturn_Unrelated());
         mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
         mutableTx.vout.push_back(NonStandardOutput());
-        mutableTx.vout.push_back(OpReturn_Tagged_B());
         mutableTx.vout.push_back(OpReturn_UnrelatedShort());
         mutableTx.vout.push_back(OpReturn_Empty());
         mutableTx.vout.push_back(PayToPubKey_Unrelated());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(OpReturn_MultiSimpleSend());
 
         CTransaction tx(mutableTx);
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
@@ -124,12 +121,11 @@ BOOST_AUTO_TEST_CASE(class_class_a)
         mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
         mutableTx.vout.push_back(OpReturn_Empty());
         mutableTx.vout.push_back(PayToPubKey_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
         mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
         mutableTx.vout.push_back(NonStandardOutput());
-        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_A());
         mutableTx.vout.push_back(OpReturn_Unrelated());
 
         CTransaction tx(mutableTx);
@@ -187,13 +183,12 @@ BOOST_AUTO_TEST_CASE(class_class_b)
         mutableTx.vout.push_back(PayToPubKey_Unrelated());
         mutableTx.vout.push_back(PayToBareMultisig_1of3());
         mutableTx.vout.push_back(OpReturn_UnrelatedShort());
-        mutableTx.vout.push_back(OpReturn_Tagged_A());
-        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
         mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
         mutableTx.vout.push_back(PayToBareMultisig_3of5());
         mutableTx.vout.push_back(OpReturn_Unrelated());
         mutableTx.vout.push_back(NonStandardOutput());
-        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(OpReturn_SimpleSend());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
         mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
 
@@ -226,7 +221,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         int nBlock = OP_RETURN_BLOCK;
 
         CMutableTransaction mutableTx;
-        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
 
         CTransaction tx(mutableTx);
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
@@ -235,7 +230,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         int nBlock = std::numeric_limits<int>().max();
 
         CMutableTransaction mutableTx;
-        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(OpReturn_SimpleSend());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
 
@@ -248,7 +243,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(NonStandardOutput());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
         mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
         mutableTx.vout.push_back(OpReturn_Empty());
         mutableTx.vout.push_back(OpReturn_Unrelated());
@@ -270,7 +265,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         mutableTx.vout.push_back(PayToBareMultisig_1of3());
         mutableTx.vout.push_back(NonStandardOutput());
         mutableTx.vout.push_back(PayToPubKey_Unrelated());
-        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(OpReturn_MultiSimpleSend());
         mutableTx.vout.push_back(PayToBareMultisig_3of5());
 
         CTransaction tx(mutableTx);
@@ -288,7 +283,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
         mutableTx.vout.push_back(NonStandardOutput());
         mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
-        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
 
         CTransaction tx(mutableTx);
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
@@ -298,11 +293,14 @@ BOOST_AUTO_TEST_CASE(class_class_c)
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(OpReturn_MultiSimpleSend());
         mutableTx.vout.push_back(PayToBareMultisig_1of3());
+        mutableTx.vout.push_back(PayToBareMultisig_1of3());
+        mutableTx.vout.push_back(OpReturn_SimpleSend());
         mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
         mutableTx.vout.push_back(PayToScriptHash_Unrelated());
         mutableTx.vout.push_back(NonStandardOutput());
-        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(OpReturn_PlainMarker());
         mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
         mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
 

--- a/src/omnicore/test/marker_tests.cpp
+++ b/src/omnicore/test/marker_tests.cpp
@@ -1,0 +1,508 @@
+#include "omnicore/omnicore.h"
+#include "omnicore/script.h"
+
+#include "base58.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+#include <limits>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+// Forward declarations
+static CTxOut PayToPubKeyHash_Exodus();
+static CTxOut PayToPubKeyHash_ExodusCrowdsale(int nHeight);
+static CTxOut PayToPubKeyHash_Unrelated();
+static CTxOut PayToScriptHash_Unrelated();
+static CTxOut PayToPubKey_Unrelated();
+static CTxOut PayToBareMultisig_1of3();
+static CTxOut PayToBareMultisig_3of5();
+static CTxOut OpReturn_Empty();
+static CTxOut OpReturn_UnrelatedShort();
+static CTxOut OpReturn_Unrelated();
+static CTxOut OpReturn_Tagged_A();
+static CTxOut OpReturn_Tagged_B();
+static CTxOut OpReturn_Tagged_C();
+static CTxOut NonStandardOutput();
+
+BOOST_AUTO_TEST_SUITE(omnicore_marker_tests)
+
+BOOST_AUTO_TEST_CASE(class_no_marker)
+{
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        CTransaction tx(mutableTx);
+
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
+    }
+    {
+        int nBlock = 0;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_A());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
+    }
+    {
+        int nBlock = 0;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_A());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(NonStandardOutput());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToBareMultisig_3of5());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToBareMultisig_1of3());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(class_class_a)
+{
+    {
+        int nBlock = 0;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_A);
+    }
+    {
+        int nBlock = P2SH_BLOCK;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_A);
+    }
+    {
+        int nBlock = 0;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_A);
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_A);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(class_class_b)
+{
+    {
+        int nBlock = 0;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+        mutableTx.vout.push_back(PayToBareMultisig_1of3());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_B);
+    }
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToBareMultisig_3of5());
+        mutableTx.vout.push_back(PayToBareMultisig_3of5());
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_B);
+    }
+    {
+        int nBlock = 0;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToBareMultisig_1of3());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(OpReturn_Tagged_C());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(PayToBareMultisig_3of5());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_B);
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(PayToBareMultisig_1of3());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_B);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(class_class_c)
+{
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(OpReturn_Tagged_A());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
+    }
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(PayToBareMultisig_1of3());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Tagged_B());
+        mutableTx.vout.push_back(PayToBareMultisig_3of5());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(OpReturn_UnrelatedShort());
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Unrelated());
+        mutableTx.vout.push_back(OpReturn_Empty());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
+        mutableTx.vout.push_back(OpReturn_Tagged_C());
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
+    }
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        CMutableTransaction mutableTx;
+        mutableTx.vout.push_back(PayToPubKey_Unrelated());
+        mutableTx.vout.push_back(PayToBareMultisig_1of3());
+        mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+        mutableTx.vout.push_back(PayToScriptHash_Unrelated());
+        mutableTx.vout.push_back(NonStandardOutput());
+        mutableTx.vout.push_back(OpReturn_Tagged_A());
+        mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+        mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
+
+        CTransaction tx(mutableTx);
+        BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+static CTxOut PayToPubKeyHash_Exodus()
+{
+    CBitcoinAddress address = ExodusAddress();
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToPubKeyHash_ExodusCrowdsale(int nHeight)
+{
+    CBitcoinAddress address = ExodusCrowdsaleAddress(nHeight);
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToPubKeyHash_Unrelated()
+{
+    CBitcoinAddress address("1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX");
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToScriptHash_Unrelated()
+{
+    CBitcoinAddress address("3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL");
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToPubKey_Unrelated()
+{
+    std::vector<unsigned char> vchPubKey = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+
+    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
+
+    CScript scriptPubKey;
+    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    txnouttype outType;
+    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
+    BOOST_CHECK(outType == TX_PUBKEY);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToBareMultisig_1of3()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+
+    // 1-of-3 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(1);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2);
+    scriptPubKey << ToByteVector(pubKey3);
+    scriptPubKey << CScript::EncodeOP_N(3);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToBareMultisig_3of5()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "02619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+    std::vector<unsigned char> vchPayload4 = ParseHex(
+        "0261a017029ec4688ec9bf33c44ad2e595f83aaf3ed4f3032d1955715f5ffaf6b8");
+    std::vector<unsigned char> vchPayload5 = ParseHex(
+        "02dc1a0afc933d703557d9f5e86423a5cec9fee4bfa850b3d02ceae72117178802");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+    CPubKey pubKey4(vchPayload4.begin(), vchPayload4.end());
+    CPubKey pubKey5(vchPayload5.begin(), vchPayload5.end());
+
+    // 3-of-5 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(3);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2) << ToByteVector(pubKey3);
+    scriptPubKey << ToByteVector(pubKey4) << ToByteVector(pubKey5);
+    scriptPubKey << CScript::EncodeOP_N(5);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut OpReturn_Empty()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN;
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut OpReturn_UnrelatedShort()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("b9");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut OpReturn_Unrelated()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("7468697320697320646578782028323031352d30362d313129");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut OpReturn_Tagged_A()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6d0000408");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut OpReturn_Tagged_B()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6d00011516");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut OpReturn_Tagged_C()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6dffff2342");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut NonStandardOutput()
+{
+    CScript scriptPubKey;
+    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+

--- a/src/omnicore/test/output_restriction_tests.cpp
+++ b/src/omnicore/test/output_restriction_tests.cpp
@@ -1,0 +1,118 @@
+#include "omnicore/omnicore.h"
+
+#include "chainparams.h"
+#include "script/standard.h"
+
+#include <stdint.h>
+#include <limits>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_output_restriction_tests)
+
+BOOST_AUTO_TEST_CASE(input_nonstandard)
+{
+    BOOST_CHECK(!IsAllowedInputType(TX_NONSTANDARD, 0));
+    BOOST_CHECK(!IsAllowedInputType(TX_NONSTANDARD, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(input_pubkey)
+{
+    BOOST_CHECK(!IsAllowedInputType(TX_PUBKEY, 0));
+    BOOST_CHECK(!IsAllowedInputType(TX_PUBKEY, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(input_pubkeyhash)
+{
+    BOOST_CHECK(IsAllowedInputType(TX_PUBKEYHASH, 0));
+    BOOST_CHECK(IsAllowedInputType(TX_PUBKEYHASH, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(input_scripthash)
+{
+    BOOST_CHECK(!IsAllowedInputType(TX_SCRIPTHASH, 0));
+    BOOST_CHECK(!IsAllowedInputType(TX_SCRIPTHASH, P2SH_BLOCK-1));
+    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, P2SH_BLOCK));
+    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(input_scripthash_testnet)
+{
+    SelectParams(CBaseChainParams::TESTNET);
+    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, 0));
+    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+BOOST_AUTO_TEST_CASE(input_multisig)
+{
+    BOOST_CHECK(!IsAllowedInputType(TX_MULTISIG, 0));
+    BOOST_CHECK(!IsAllowedInputType(TX_MULTISIG, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(input_nulldata)
+{
+    BOOST_CHECK(!IsAllowedInputType(TX_NULL_DATA, 0));
+    BOOST_CHECK(!IsAllowedInputType(TX_NULL_DATA, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(output_nonstandard)
+{
+    BOOST_CHECK(!IsAllowedOutputType(TX_NONSTANDARD, 0));
+    BOOST_CHECK(!IsAllowedOutputType(TX_NONSTANDARD, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(output_pubkey)
+{
+    BOOST_CHECK(!IsAllowedOutputType(TX_PUBKEY, 0));
+    BOOST_CHECK(!IsAllowedOutputType(TX_PUBKEY, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(output_pubkeyhash)
+{
+    BOOST_CHECK(IsAllowedOutputType(TX_PUBKEYHASH, 0));
+    BOOST_CHECK(IsAllowedOutputType(TX_PUBKEYHASH, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(output_scripthash)
+{
+    BOOST_CHECK(!IsAllowedOutputType(TX_SCRIPTHASH, 0));
+    BOOST_CHECK(!IsAllowedOutputType(TX_SCRIPTHASH, P2SH_BLOCK-1));
+    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, P2SH_BLOCK));
+    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(output_scripthash_testnet)
+{
+    SelectParams(CBaseChainParams::TESTNET);
+    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, 0));
+    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+BOOST_AUTO_TEST_CASE(output_multisig)
+{
+    BOOST_CHECK(IsAllowedOutputType(TX_MULTISIG, 0));
+    BOOST_CHECK(IsAllowedOutputType(TX_MULTISIG, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(output_nulldata)
+{
+    BOOST_CHECK(!IsAllowedOutputType(TX_NULL_DATA, 0));
+    BOOST_CHECK(!IsAllowedOutputType(TX_NULL_DATA, OP_RETURN_BLOCK-1));
+    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, OP_RETURN_BLOCK));
+    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, std::numeric_limits<int>().max()));
+}
+
+BOOST_AUTO_TEST_CASE(output_nulldata_testnet)
+{
+    SelectParams(CBaseChainParams::TESTNET);
+    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, 0));
+    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, std::numeric_limits<int>().max()));
+    SelectParams(CBaseChainParams::UNITTEST);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/parsing_a_tests.cpp
+++ b/src/omnicore/test/parsing_a_tests.cpp
@@ -1,0 +1,332 @@
+#include "omnicore/createpayload.h"
+#include "omnicore/encoding.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/script.h"
+#include "omnicore/tx.h"
+
+#include "base58.h"
+#include "coins.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+#include <limits>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_parsing_a_tests)
+
+static CTxOut PayToPubKey_Unrelated();
+static CTxOut NonStandardOutput();
+static CTxOut OpReturn_Unrelated();
+
+/** Creates a dummy transaction with the given inputs and outputs. */
+static CTransaction TxClassA(const std::vector<CTxOut>& txInputs, const std::vector<CTxOut>& txOuts)
+{
+    CMutableTransaction mutableTx;
+
+    // Inputs:
+    for (std::vector<CTxOut>::const_iterator it = txInputs.begin(); it != txInputs.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+
+        // Create transaction for input:
+        CMutableTransaction inputTx;
+        unsigned int nOut = 0;
+        inputTx.vout.push_back(txOut);
+        CTransaction tx(inputTx);
+
+        // Populate transaction cache:
+        CCoinsModifier coins = view.ModifyCoins(tx.GetHash());
+
+        if (nOut >= coins->vout.size()) {
+            coins->vout.resize(nOut+1);
+        }
+        coins->vout[nOut].scriptPubKey = txOut.scriptPubKey;
+        coins->vout[nOut].nValue = txOut.nValue;
+
+        // Add input:
+        CTxIn txIn(tx.GetHash(), nOut);
+        mutableTx.vin.push_back(txIn);
+    }
+
+    for (std::vector<CTxOut>::const_iterator it = txOuts.begin(); it != txOuts.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+
+        mutableTx.vout.push_back(txOut);
+    }
+
+    return CTransaction(mutableTx);
+}
+
+/** Helper to create a CTxOut object. */
+static CTxOut createTxOut(int64_t amount, const std::string& dest)
+{
+    return CTxOut(amount, GetScriptForDestination(CBitcoinAddress(dest).Get()));
+}
+
+BOOST_AUTO_TEST_CASE(valid_class_a)
+{
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6000, "1CVE9Au1XEm3MkYxeAhUDVqWvaHrP98iUt"));
+        txOutputs.push_back(createTxOut(6000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+        
+        txOutputs.push_back(createTxOut(6000, "1CVE9Au1XEm3MsiMuLcMKryYWXHeMv9tBn"));
+        txOutputs.push_back(createTxOut(6000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000200000002540be400000000");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(PayToPubKey_Unrelated());
+        txOutputs.push_back(PayToPubKey_Unrelated());
+        txOutputs.push_back(PayToPubKey_Unrelated());
+        txOutputs.push_back(createTxOut(6000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(OpReturn_Unrelated());
+        txOutputs.push_back(OpReturn_Unrelated());
+        txOutputs.push_back(createTxOut(6000, "1CVE9Au1XEm3MkYxeAhUDVqWvaHrP98iUt"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6000, "1HKTxLaqcbH5GcqpAbStfFwH2zvho6q8ZD"));
+        txOutputs.push_back(createTxOut(6000, "1HEBH9TXCR3NkKaNd5ZLugxzmc3Feqkbns"));
+        txOutputs.push_back(createTxOut(1747000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6000, "1HKTxLaqcbH5GcqpAbStfFwH2zvho6q8ZD"));
+        txOutputs.push_back(createTxOut(6000, "1HQkdXiA2mWmoQkrknyxrHTfeBoKhthq23"));
+        txOutputs.push_back(createTxOut(6001, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1HQkdXiA2mWmoQkrknyxrHTfeBoKhthq23");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(70000, "1e1jLtDvEetgwJ6jB3DuCf27sXcjA8qQ2"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(9001, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(9001, "1e1jLtDvEetgwJ6jB3DuCf27sXcjA8qQ2"));
+        txOutputs.push_back(createTxOut(9001, "1e1jLtDvEethgGWJCWWZPVBdZWNM3zVYP"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1e1jLtDvEetgwJ6jB3DuCf27sXcjA8qQ2");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1e1jLtDvEethgGWJCWWZPVBdZWNM3zVYP");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000010000000777777700000000");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "3Kpeeo8MVoYnx7PeNb5FUus8bkJsZFPbw7"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6001, "344VVXmhPVTYnaNYNj3xgkcy3wasEEZtur"));
+        txOutputs.push_back(createTxOut(6002, "34CxDzguRHnxA6fwccVBfC3wCZfvwmHAxV"));
+        txOutputs.push_back(createTxOut(6003, "3J7F31dxvHXWqTse4rjzS7XayWJnr5fZqW"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "3Kpeeo8MVoYnx7PeNb5FUus8bkJsZFPbw7");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "34CxDzguRHnxA6fwccVBfC3wCZfvwmHAxV");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000200000002540be400000000");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(invalid_class_a)
+{
+    // More than one data packet
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(6000, "1CVE9Au1XEm3MkYxeAhUDVqWvaHrP98iUt"));
+        txOutputs.push_back(createTxOut(6000, "1CVE9Au1XEm3MkYxeAhUDVqWvaHrP98iUt"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) != 0);
+    }
+    // Not MSC or TMSC
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6000, "1CVE9Au1XEm3NVXNDCAksgfgSGGc1xs4Wi"));
+        txOutputs.push_back(createTxOut(6000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) != 0);
+    }
+    // Seq collision
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
+        txOutputs.push_back(createTxOut(6000, "1HKTxLaqcbH5GcqpAbStfFwH2zvho6q8ZD"));
+        txOutputs.push_back(createTxOut(6000, "1HQkdXiA2mWmoQkrknyxrHTfeBoKhthq23"));
+        txOutputs.push_back(createTxOut(6000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+
+        CTransaction dummyTx = TxClassA(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) != 0);
+    }
+}
+
+static CTxOut PayToPubKey_Unrelated()
+{
+    std::vector<unsigned char> vchPubKey = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+
+    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
+
+    CScript scriptPubKey;
+    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    txnouttype outType;
+    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
+    BOOST_CHECK(outType == TX_PUBKEY);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut OpReturn_Unrelated()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("7468697320697320646578782028323031352d30362d313129");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut NonStandardOutput()
+{
+    CScript scriptPubKey;
+    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/omnicore/test/parsing_a_tests.cpp
+++ b/src/omnicore/test/parsing_a_tests.cpp
@@ -1,3 +1,5 @@
+#include "omnicore/test/utils_tx.h"
+
 #include "omnicore/createpayload.h"
 #include "omnicore/encoding.h"
 #include "omnicore/omnicore.h"
@@ -9,7 +11,6 @@
 #include "primitives/transaction.h"
 #include "script/script.h"
 #include "script/standard.h"
-#include "utilstrencodings.h"
 
 #include <stdint.h>
 #include <limits>
@@ -20,10 +21,6 @@
 using namespace mastercore;
 
 BOOST_AUTO_TEST_SUITE(omnicore_parsing_a_tests)
-
-static CTxOut PayToPubKey_Unrelated();
-static CTxOut NonStandardOutput();
-static CTxOut OpReturn_Unrelated();
 
 /** Creates a dummy transaction with the given inputs and outputs. */
 static CTransaction TxClassA(const std::vector<CTxOut>& txInputs, const std::vector<CTxOut>& txOuts)
@@ -58,7 +55,6 @@ static CTransaction TxClassA(const std::vector<CTxOut>& txInputs, const std::vec
     for (std::vector<CTxOut>::const_iterator it = txOuts.begin(); it != txOuts.end(); ++it)
     {
         const CTxOut& txOut = *it;
-
         mutableTx.vout.push_back(txOut);
     }
 
@@ -77,7 +73,8 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         int nBlock = std::numeric_limits<int>().max();
 
         std::vector<CTxOut> txInputs;
-        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txInputs.push_back(createTxOut(1765000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txInputs.push_back(createTxOut(50000, "1JcWjikLW5CFV5XVTNSvqssJctYTwEf7Pc"));
 
         std::vector<CTxOut> txOutputs;
         txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
@@ -89,6 +86,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
 
         CMPTransaction metaTx;
         BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getFeePaid(), 50000);
         BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
         BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq");
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
@@ -97,10 +95,10 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         int nBlock = std::numeric_limits<int>().max();
 
         std::vector<CTxOut> txInputs;
-        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txInputs.push_back(createTxOut(907500, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txInputs.push_back(createTxOut(907500, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
 
         std::vector<CTxOut> txOutputs;
-        
         txOutputs.push_back(createTxOut(6000, "1CVE9Au1XEm3MsiMuLcMKryYWXHeMv9tBn"));
         txOutputs.push_back(createTxOut(6000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
         txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
@@ -110,6 +108,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
 
         CMPTransaction metaTx;
         BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getFeePaid(), 50000);
         BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
         BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq");
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000200000002540be400000000");
@@ -121,7 +120,6 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
 
         std::vector<CTxOut> txOutputs;
-
         txOutputs.push_back(NonStandardOutput());
         txOutputs.push_back(NonStandardOutput());
         txOutputs.push_back(NonStandardOutput());
@@ -151,19 +149,20 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         int nBlock = std::numeric_limits<int>().max();
 
         std::vector<CTxOut> txInputs;
-        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txInputs.push_back(createTxOut(87000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
 
         std::vector<CTxOut> txOutputs;
         txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
         txOutputs.push_back(createTxOut(6000, "1HKTxLaqcbH5GcqpAbStfFwH2zvho6q8ZD"));
         txOutputs.push_back(createTxOut(6000, "1HEBH9TXCR3NkKaNd5ZLugxzmc3Feqkbns"));
-        txOutputs.push_back(createTxOut(1747000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
-        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txOutputs.push_back(createTxOut(7000, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
+        txOutputs.push_back(createTxOut(7000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
 
         CTransaction dummyTx = TxClassA(txInputs, txOutputs);
 
         CMPTransaction metaTx;
         BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getFeePaid(), 55000);
         BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
         BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
@@ -172,19 +171,24 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         int nBlock = std::numeric_limits<int>().max();
 
         std::vector<CTxOut> txInputs;
-        txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txInputs.push_back(createTxOut(100000, "34xhWktMFEGRTRmWf1hdNn1SyDDWiXa18H"));
+        txInputs.push_back(createTxOut(100000, "34xhWktMFEGRTRmWf1hdNn1SyDDWiXa18H"));
+        txInputs.push_back(createTxOut(200000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txInputs.push_back(createTxOut(100000, "34xhWktMFEGRTRmWf1hdNn1SyDDWiXa18H"));
+        txInputs.push_back(createTxOut(200000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
 
         std::vector<CTxOut> txOutputs;
         txOutputs.push_back(createTxOut(6000, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P"));
         txOutputs.push_back(createTxOut(6000, "1HKTxLaqcbH5GcqpAbStfFwH2zvho6q8ZD"));
         txOutputs.push_back(createTxOut(6000, "1HQkdXiA2mWmoQkrknyxrHTfeBoKhthq23"));
         txOutputs.push_back(createTxOut(6001, "1CcJFxoEW5PUwesMVxGrq6kAPJ1TJsSVqq"));
-        txOutputs.push_back(createTxOut(1747000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
+        txOutputs.push_back(createTxOut(665999, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
 
         CTransaction dummyTx = TxClassA(txInputs, txOutputs);
 
         CMPTransaction metaTx;
         BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getFeePaid(), 10000);
         BOOST_CHECK_EQUAL(metaTx.getSender(), "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk");
         BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1HQkdXiA2mWmoQkrknyxrHTfeBoKhthq23");
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
@@ -290,43 +294,5 @@ BOOST_AUTO_TEST_CASE(invalid_class_a)
     }
 }
 
-static CTxOut PayToPubKey_Unrelated()
-{
-    std::vector<unsigned char> vchPubKey = ParseHex(
-        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
-        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
-
-    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
-
-    CScript scriptPubKey;
-    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    txnouttype outType;
-    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
-    BOOST_CHECK(outType == TX_PUBKEY);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut OpReturn_Unrelated()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("7468697320697320646578782028323031352d30362d313129");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut NonStandardOutput()
-{
-    CScript scriptPubKey;
-    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/src/omnicore/test/parsing_a_tests.cpp
+++ b/src/omnicore/test/parsing_a_tests.cpp
@@ -70,7 +70,7 @@ static CTxOut createTxOut(int64_t amount, const std::string& dest)
 BOOST_AUTO_TEST_CASE(valid_class_a)
 {
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = 0;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(1765000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = 0;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(907500, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = 0;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(87000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = P2SH_BLOCK;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(100000, "34xhWktMFEGRTRmWf1hdNn1SyDDWiXa18H"));
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000100000002540be400000000");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = 0;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(70000, "1e1jLtDvEetgwJ6jB3DuCf27sXcjA8qQ2"));
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000010000000777777700000000");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = P2SH_BLOCK;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(1815000, "3Kpeeo8MVoYnx7PeNb5FUus8bkJsZFPbw7"));
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(invalid_class_a)
 {
     // More than one data packet
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = 0;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(invalid_class_a)
     }
     // Not MSC or TMSC
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = 0;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(invalid_class_a)
     }
     // Seq collision
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = 0;
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));

--- a/src/omnicore/test/parsing_b_tests.cpp
+++ b/src/omnicore/test/parsing_b_tests.cpp
@@ -1,0 +1,136 @@
+#include "omnicore/test/utils_tx.h"
+
+#include "omnicore/createpayload.h"
+#include "omnicore/encoding.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/script.h"
+#include "omnicore/tx.h"
+
+#include "base58.h"
+#include "coins.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "script/standard.h"
+
+#include <stdint.h>
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_parsing_b_tests)
+
+/** Creates a dummy transaction with the given inputs and outputs. */
+static CTransaction TxClassB(const std::vector<CTxOut>& txInputs, const std::vector<CTxOut>& txOuts)
+{
+    CMutableTransaction mutableTx;
+
+    // Inputs:
+    for (std::vector<CTxOut>::const_iterator it = txInputs.begin(); it != txInputs.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+
+        // Create transaction for input:
+        CMutableTransaction inputTx;
+        unsigned int nOut = 0;
+        inputTx.vout.push_back(txOut);
+        CTransaction tx(inputTx);
+
+        // Populate transaction cache:
+        CCoinsModifier coins = view.ModifyCoins(tx.GetHash());
+
+        if (nOut >= coins->vout.size()) {
+            coins->vout.resize(nOut+1);
+        }
+        coins->vout[nOut].scriptPubKey = txOut.scriptPubKey;
+        coins->vout[nOut].nValue = txOut.nValue;
+
+        // Add input:
+        CTxIn txIn(tx.GetHash(), nOut);
+        mutableTx.vin.push_back(txIn);
+    }
+
+    for (std::vector<CTxOut>::const_iterator it = txOuts.begin(); it != txOuts.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+        mutableTx.vout.push_back(txOut);
+    }
+
+    return CTransaction(mutableTx);
+}
+
+/** Helper to create a CTxOut object. */
+static CTxOut createTxOut(int64_t amount, const std::string& dest)
+{
+    return CTxOut(amount, GetScriptForDestination(CBitcoinAddress(dest).Get()));
+}
+
+/** Helper to determine hex-encoded payload size. */
+static size_t getPayloadSize(unsigned int nPackets)
+{
+    // multiply by 2 for hex conversion
+    // subtract 1 byte for sequence number
+    return 2 * (PACKET_SIZE - 1) * nPackets;
+}
+
+BOOST_AUTO_TEST_CASE(valid_common_class_b)
+{
+    int nBlock = 0;
+
+    std::vector<CTxOut> txInputs;
+    txInputs.push_back(createTxOut(1000000, "1BxtgEa8UcrMzVZaW32zVyJh4Sg4KGFzxA"));
+    txInputs.push_back(createTxOut(1000000, "1HG3s4Ext3sTqBTHrgftyUzG3cvx5ZbPCj"));
+    txInputs.push_back(createTxOut(2000001, "1Pa6zyqnhL6LDJtrkCMi9XmEDNHJ23ffEr"));
+
+    std::vector<CTxOut> txOutputs;
+    txOutputs.push_back(PayToPubKeyHash_Exodus());
+    txOutputs.push_back(PayToBareMultisig_1of3());
+    txOutputs.push_back(PayToBareMultisig_3of5());
+    txOutputs.push_back(PayToBareMultisig_3of5());
+    txOutputs.push_back(PayToPubKeyHash_Unrelated());
+
+    CTransaction dummyTx = TxClassB(txInputs, txOutputs);
+
+    CMPTransaction metaTx;
+    BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+    BOOST_CHECK_EQUAL(metaTx.getSender(), "1Pa6zyqnhL6LDJtrkCMi9XmEDNHJ23ffEr");
+    BOOST_CHECK_EQUAL(metaTx.getPayload().size(), getPayloadSize(10));
+}
+
+BOOST_AUTO_TEST_CASE(valid_arbitrary_output_number_class_b)
+{
+    int nBlock = std::numeric_limits<int>::max();
+
+    int nOutputs = 3000 * 8; // due to the junk
+
+    std::vector<CTxOut> txInputs;
+    txInputs.push_back(createTxOut(5550000, "3QHw8qKf1vQkMnSVXarq7N4PYzz1G3mAK4"));
+
+    std::vector<CTxOut> txOutputs;
+    for (int i = 0; i < nOutputs / 8; ++i) {
+        txOutputs.push_back(PayToBareMultisig_1of2());
+        txOutputs.push_back(PayToBareMultisig_1of3());
+        txOutputs.push_back(PayToBareMultisig_3of5());
+        txOutputs.push_back(OpReturn_Unrelated());
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(PayToPubKey_Unrelated());
+        txOutputs.push_back(PayToScriptHash_Unrelated());
+        txOutputs.push_back(PayToPubKeyHash_Exodus());
+    }
+
+    std::random_shuffle(txOutputs.begin(), txOutputs.end());
+
+    CTransaction dummyTx = TxClassB(txInputs, txOutputs);
+    BOOST_CHECK_EQUAL(dummyTx.vout.size(), nOutputs);
+
+    CMPTransaction metaTx;
+    BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+    BOOST_CHECK_EQUAL(metaTx.getSender(), "3QHw8qKf1vQkMnSVXarq7N4PYzz1G3mAK4");
+    BOOST_CHECK_EQUAL(metaTx.getPayload().size(), getPayloadSize(MAX_PACKETS));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(multiple_op_return)
             txOutputs.push_back(txOut);
         }
         {
-            CScript scriptPubKey; // has no marker!
+            CScript scriptPubKey; // has no marker and will be ignored!
             scriptPubKey << OP_RETURN << ParseHex("4d756c686f6c6c616e64204472697665");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
@@ -310,10 +310,38 @@ BOOST_AUTO_TEST_CASE(multiple_op_return)
         BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
         BOOST_CHECK_EQUAL(metaTx.getSender(), "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2");
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "12222222222222222222222222234555555"
-                "5555555555555555555567888888888896c686f6c6c616e64204472697665ffff1"
+                "555555555555555555556788888888889ffff11111111111111111111111111111"
                 "111111111111111111111111111111111111111111111111111111111111111111"
                 "111111111111111111111111111111111111111111111111111111111111111111"
-                "11111111111111111111111111111111111111111111111111111111117");
+                "1111111111111111111111111111117");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(multiple_op_return_pushes)
+{
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(100000, "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2"));
+
+        std::vector<CTxOut> txOutputs;
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN;
+            scriptPubKey << ParseHex("6f6d00000000000000010000000006dac2c0");
+            scriptPubKey << ParseHex("00000000000000030000000000000d48");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(),
+                "00000000000000010000000006dac2c000000000000000030000000000000d48");
     }
 }
 

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -1,3 +1,5 @@
+#include "omnicore/test/utils_tx.h"
+
 #include "omnicore/createpayload.h"
 #include "omnicore/encoding.h"
 #include "omnicore/omnicore.h"
@@ -20,13 +22,6 @@
 using namespace mastercore;
 
 BOOST_AUTO_TEST_SUITE(omnicore_parsing_c_tests)
-
-static CTxOut PayToPubKeyHash_Exodus();
-static CTxOut PayToPubKey_Unrelated();
-static CTxOut NonStandardOutput();
-static CTxOut PayToBareMultisig_1of3();
-static CTxOut OpReturn_SimpleSend();
-static CTxOut OpReturn_Unrelated();
 
 /** Creates a dummy transaction with the given inputs and outputs. */
 static CTransaction TxClassC(const std::vector<CTxOut>& txInputs, const std::vector<CTxOut>& txOuts)
@@ -322,89 +317,5 @@ BOOST_AUTO_TEST_CASE(multiple_op_return)
     }
 }
 
-static CTxOut PayToPubKeyHash_Exodus()
-{
-    CBitcoinAddress address = ExodusAddress();
-    CScript scriptPubKey = GetScriptForDestination(address.Get());
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToPubKey_Unrelated()
-{
-    std::vector<unsigned char> vchPubKey = ParseHex(
-        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
-        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
-
-    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
-
-    CScript scriptPubKey;
-    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    txnouttype outType;
-    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
-    BOOST_CHECK(outType == TX_PUBKEY);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToBareMultisig_1of3()
-{
-    std::vector<unsigned char> vchPayload1 = ParseHex(
-        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
-        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
-    std::vector<unsigned char> vchPayload2 = ParseHex(
-        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
-    std::vector<unsigned char> vchPayload3 = ParseHex(
-        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
-
-    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
-    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
-    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
-
-    // 1-of-3 bare multisig script
-    CScript scriptPubKey;
-    scriptPubKey << CScript::EncodeOP_N(1);
-    scriptPubKey << ToByteVector(pubKey1);
-    scriptPubKey << ToByteVector(pubKey2);
-    scriptPubKey << ToByteVector(pubKey3);
-    scriptPubKey << CScript::EncodeOP_N(3);
-    scriptPubKey << OP_CHECKMULTISIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut OpReturn_SimpleSend()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6d00000000000000070000000006dac2c0");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut OpReturn_Unrelated()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("7468697320697320646578782028323031352d30362d313229");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-static CTxOut NonStandardOutput()
-{
-    CScript scriptPubKey;
-    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
 
 BOOST_AUTO_TEST_SUITE_END()
-
-

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -1,0 +1,410 @@
+#include "omnicore/createpayload.h"
+#include "omnicore/encoding.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/script.h"
+#include "omnicore/tx.h"
+
+#include "base58.h"
+#include "coins.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+#include <limits>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_parsing_c_tests)
+
+static CTxOut PayToPubKeyHash_Exodus();
+static CTxOut PayToPubKey_Unrelated();
+static CTxOut NonStandardOutput();
+static CTxOut PayToBareMultisig_1of3();
+static CTxOut OpReturn_SimpleSend();
+static CTxOut OpReturn_Unrelated();
+
+/** Creates a dummy transaction with the given inputs and outputs. */
+static CTransaction TxClassC(const std::vector<CTxOut>& txInputs, const std::vector<CTxOut>& txOuts)
+{
+    CMutableTransaction mutableTx;
+
+    // Inputs:
+    for (std::vector<CTxOut>::const_iterator it = txInputs.begin(); it != txInputs.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+
+        // Create transaction for input:
+        CMutableTransaction inputTx;
+        unsigned int nOut = 0;
+        inputTx.vout.push_back(txOut);
+        CTransaction tx(inputTx);
+
+        // Populate transaction cache:
+        CCoinsModifier coins = view.ModifyCoins(tx.GetHash());
+
+        if (nOut >= coins->vout.size()) {
+            coins->vout.resize(nOut+1);
+        }
+        coins->vout[nOut].scriptPubKey = txOut.scriptPubKey;
+        coins->vout[nOut].nValue = txOut.nValue;
+
+        // Add input:
+        CTxIn txIn(tx.GetHash(), nOut);
+        mutableTx.vin.push_back(txIn);
+    }
+
+    for (std::vector<CTxOut>::const_iterator it = txOuts.begin(); it != txOuts.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+        mutableTx.vout.push_back(txOut);
+    }
+
+    return CTransaction(mutableTx);
+}
+
+/** Helper to create a CTxOut object. */
+static CTxOut createTxOut(int64_t amount, const std::string& dest)
+{
+    return CTxOut(amount, GetScriptForDestination(CBitcoinAddress(dest).Get()));
+}
+
+BOOST_AUTO_TEST_CASE(reference_identification)
+{
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(5000000, "1NNQKWM8mC35pBNPxV1noWFZEw7A5X6zXz"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(OpReturn_SimpleSend());
+        txOutputs.push_back(createTxOut(2700000, ExodusAddress().ToString()));
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK(metaTx.getReceiver().empty());
+        BOOST_CHECK_EQUAL(metaTx.getFeePaid(), 2300000);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1NNQKWM8mC35pBNPxV1noWFZEw7A5X6zXz");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000070000000006dac2c0");
+    }
+    {
+        int nBlock = OP_RETURN_BLOCK + 1000;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(6000, "3NfRfUekDSzgSyohRro9jXD1AqDALN321P"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(OpReturn_SimpleSend());
+        txOutputs.push_back(createTxOut(6000, "3QHw8qKf1vQkMnSVXarq7N4PYzz1G3mAK4"));
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getFeePaid(), 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "3NfRfUekDSzgSyohRro9jXD1AqDALN321P");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "3QHw8qKf1vQkMnSVXarq7N4PYzz1G3mAK4");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000070000000006dac2c0");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(80000, "1M773vkrQDtBpkorfHTdctRo6kHxb4fXuT"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(OpReturn_SimpleSend());
+        txOutputs.push_back(createTxOut(6000, "1M773vkrQDtBpkorfHTdctRo6kHxb4fXuT"));
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getFeePaid(), 74000);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1M773vkrQDtBpkorfHTdctRo6kHxb4fXuT");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "1M773vkrQDtBpkorfHTdctRo6kHxb4fXuT");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000070000000006dac2c0");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(80000, "19NNUnwsKZK5dCnDCZ7pqeruL2syA8hSVh"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(OpReturn_SimpleSend());
+        txOutputs.push_back(createTxOut(6000, "3NjfEthPHg6GEH9j7o4j4BGGZafBX2yw8j"));
+        txOutputs.push_back(PayToPubKey_Unrelated());
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(createTxOut(6000, "37pwWHk1oFaWxVsnYKfGs7Lyt5yJEVomTH"));
+        txOutputs.push_back(PayToBareMultisig_1of3());
+        txOutputs.push_back(createTxOut(6000, "19NNUnwsKZK5dCnDCZ7pqeruL2syA8hSVh"));
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "19NNUnwsKZK5dCnDCZ7pqeruL2syA8hSVh");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "37pwWHk1oFaWxVsnYKfGs7Lyt5yJEVomTH");
+    }
+    {
+        int nBlock = std::numeric_limits<int>().max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(55550, "35iqJySouevicrYzMhjKSsqokSGwGovGov"));
+
+        std::vector<CTxOut> txOutputs;
+        txOutputs.push_back(createTxOut(6000, "3NjfEthPHg6GEH9j7o4j4BGGZafBX2yw8j"));
+        txOutputs.push_back(PayToPubKey_Unrelated());
+        txOutputs.push_back(NonStandardOutput());
+        txOutputs.push_back(createTxOut(6000, "35iqJySouevicrYzMhjKSsqokSGwGovGov"));
+        txOutputs.push_back(createTxOut(6000, "35iqJySouevicrYzMhjKSsqokSGwGovGov"));
+        txOutputs.push_back(PayToPubKeyHash_Exodus());
+        txOutputs.push_back(OpReturn_SimpleSend());
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "35iqJySouevicrYzMhjKSsqokSGwGovGov");
+        BOOST_CHECK_EQUAL(metaTx.getReceiver(), "35iqJySouevicrYzMhjKSsqokSGwGovGov");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(op_return_payload_too_small)
+{
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(100000, "1MV8MySYueghUDMsjNV67CfeRXmQZAxjSW"));
+
+        std::vector<CTxOut> txOutputs;
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6d00000304");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) != 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(op_return_payload_min_size)
+{
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(100000, "1KsXJ5XuoXHHkevNm3bLpqWPP4PtGEjfuE"));
+
+        std::vector<CTxOut> txOutputs;
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6dffffffff05");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "1KsXJ5XuoXHHkevNm3bLpqWPP4PtGEjfuE");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "ffffffff05");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(multiple_op_return_short)
+{
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(100000, "13ZXjcDDUY3cRTPFXVfwmFR9Mz2WpnF5PP"));
+
+        std::vector<CTxOut> txOutputs;
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6d0000111122223333");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN;
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6d0001000200030004");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6d");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "13ZXjcDDUY3cRTPFXVfwmFR9Mz2WpnF5PP");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "00001111222233330001000200030004");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(multiple_op_return)
+{
+    {
+        int nBlock = OP_RETURN_BLOCK;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(100000, "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2"));
+
+        std::vector<CTxOut> txOutputs;
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6d1222222222222222222222222223");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6d4555555555555555555555555556");
+            CTxOut txOut = CTxOut(5, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6d788888888889");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        {
+            CScript scriptPubKey; // has no marker!
+            scriptPubKey << OP_RETURN << ParseHex("4d756c686f6c6c616e64204472697665");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN << ParseHex("6f6dffff111111111111111111111111"
+                    "11111111111111111111111111111111111111111111111111111111111111"
+                    "11111111111111111111111111111111111111111111111111111111111111"
+                    "11111111111111111111111111111111111111111117");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getSender(), "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2");
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "12222222222222222222222222234555555"
+                "5555555555555555555567888888888896c686f6c6c616e64204472697665ffff1"
+                "111111111111111111111111111111111111111111111111111111111111111111"
+                "111111111111111111111111111111111111111111111111111111111111111111"
+                "11111111111111111111111111111111111111111111111111111111117");
+    }
+}
+
+static CTxOut PayToPubKeyHash_Exodus()
+{
+    CBitcoinAddress address = ExodusAddress();
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToPubKey_Unrelated()
+{
+    std::vector<unsigned char> vchPubKey = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+
+    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
+
+    CScript scriptPubKey;
+    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    txnouttype outType;
+    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
+    BOOST_CHECK(outType == TX_PUBKEY);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToBareMultisig_1of3()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+
+    // 1-of-3 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(1);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2);
+    scriptPubKey << ToByteVector(pubKey3);
+    scriptPubKey << CScript::EncodeOP_N(3);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut OpReturn_SimpleSend()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6d00000000000000070000000006dac2c0");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut OpReturn_Unrelated()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("7468697320697320646578782028323031352d30362d313229");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+static CTxOut NonStandardOutput()
+{
+    CScript scriptPubKey;
+    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -173,52 +173,6 @@ BOOST_AUTO_TEST_CASE(reference_identification)
     }
 }
 
-BOOST_AUTO_TEST_CASE(op_return_payload_too_small)
-{
-    {
-        int nBlock = OP_RETURN_BLOCK;
-
-        std::vector<CTxOut> txInputs;
-        txInputs.push_back(createTxOut(100000, "1MV8MySYueghUDMsjNV67CfeRXmQZAxjSW"));
-
-        std::vector<CTxOut> txOutputs;
-        {
-            CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6d00000304");
-            CTxOut txOut = CTxOut(0, scriptPubKey);
-            txOutputs.push_back(txOut);
-        }
-        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
-
-        CMPTransaction metaTx;
-        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) != 0);
-    }
-}
-
-BOOST_AUTO_TEST_CASE(op_return_payload_min_size)
-{
-    {
-        int nBlock = OP_RETURN_BLOCK;
-
-        std::vector<CTxOut> txInputs;
-        txInputs.push_back(createTxOut(100000, "1KsXJ5XuoXHHkevNm3bLpqWPP4PtGEjfuE"));
-
-        std::vector<CTxOut> txOutputs;
-        {
-            CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6dffffffff05");
-            CTxOut txOut = CTxOut(0, scriptPubKey);
-            txOutputs.push_back(txOut);
-        }
-        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
-
-        CMPTransaction metaTx;
-        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
-        BOOST_CHECK_EQUAL(metaTx.getSender(), "1KsXJ5XuoXHHkevNm3bLpqWPP4PtGEjfuE");
-        BOOST_CHECK_EQUAL(metaTx.getPayload(), "ffffffff05");
-    }
-}
-
 BOOST_AUTO_TEST_CASE(multiple_op_return_short)
 {
     {

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(multiple_op_return_short)
         std::vector<CTxOut> txOutputs;
         {
             CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6d0000111122223333");
+            scriptPubKey << OP_RETURN << ParseHex("6f6d6e690000111122223333");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
         }
@@ -219,13 +219,13 @@ BOOST_AUTO_TEST_CASE(multiple_op_return_short)
         }
         {
             CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6d0001000200030004");
+            scriptPubKey << OP_RETURN << ParseHex("6f6d6e690001000200030004");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
         }
         {
             CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6d");
+            scriptPubKey << OP_RETURN << ParseHex("6f6d6e69");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
         }
@@ -249,19 +249,19 @@ BOOST_AUTO_TEST_CASE(multiple_op_return)
         std::vector<CTxOut> txOutputs;
         {
             CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6d1222222222222222222222222223");
+            scriptPubKey << OP_RETURN << ParseHex("6f6d6e691222222222222222222222222223");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
         }
         {
             CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6d4555555555555555555555555556");
+            scriptPubKey << OP_RETURN << ParseHex("6f6d6e694555555555555555555555555556");
             CTxOut txOut = CTxOut(5, scriptPubKey);
             txOutputs.push_back(txOut);
         }
         {
             CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6d788888888889");
+            scriptPubKey << OP_RETURN << ParseHex("6f6d6e69788888888889");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
         }
@@ -273,10 +273,10 @@ BOOST_AUTO_TEST_CASE(multiple_op_return)
         }
         {
             CScript scriptPubKey;
-            scriptPubKey << OP_RETURN << ParseHex("6f6dffff111111111111111111111111"
+            scriptPubKey << OP_RETURN << ParseHex("6f6d6e69ffff11111111111111111111"
                     "11111111111111111111111111111111111111111111111111111111111111"
                     "11111111111111111111111111111111111111111111111111111111111111"
-                    "11111111111111111111111111111111111111111117");
+                    "111111111111111111111111111111111111111111111117");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
         }
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(multiple_op_return_pushes)
         {
             CScript scriptPubKey;
             scriptPubKey << OP_RETURN;
-            scriptPubKey << ParseHex("6f6d00000000000000010000000006dac2c0");
+            scriptPubKey << ParseHex("6f6d6e6900000000000000010000000006dac2c0");
             scriptPubKey << ParseHex("00000000000000030000000000000d48");
             CTxOut txOut = CTxOut(0, scriptPubKey);
             txOutputs.push_back(txOut);
@@ -345,6 +345,33 @@ BOOST_AUTO_TEST_CASE(multiple_op_return_pushes)
         BOOST_CHECK_EQUAL(metaTx.getSender(), "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2");
         BOOST_CHECK_EQUAL(metaTx.getPayload(),
                 "00000000000000010000000006dac2c000000000000000030000000000000d48");
+    }
+
+    {
+        /**
+         * The following transaction is invalid, because the first pushed data
+         * doesn't contain the class C marker.
+         */
+        int nBlock = OP_RETURN_BLOCK;
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(100000, "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2"));
+
+        std::vector<CTxOut> txOutputs;
+        {
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN;
+            scriptPubKey << ParseHex("6f6d");
+            scriptPubKey << ParseHex("6e69");
+            scriptPubKey << ParseHex("00000000000000010000000006dac2c0");
+            CTxOut txOut = CTxOut(0, scriptPubKey);
+            txOutputs.push_back(txOut);
+        }
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) != 0);
     }
 }
 

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -383,6 +383,28 @@ BOOST_AUTO_TEST_CASE(multiple_op_return_pushes)
                 "00000000000000010000000006dac2c000000000000000030000000000000d48");
     }
     {
+        int nBlock = std::numeric_limits<int>::max();
+
+        std::vector<CTxOut> txInputs;
+        txInputs.push_back(createTxOut(100000, "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2"));
+
+        std::vector<CTxOut> txOutputs;
+        {
+          CScript scriptPubKey;
+          scriptPubKey << OP_RETURN;
+          scriptPubKey << ParseHex("6f6d6e69");
+          scriptPubKey << ParseHex("00000000000000010000000006dac2c0");
+          CTxOut txOut = CTxOut(0, scriptPubKey);
+          txOutputs.push_back(txOut);
+        }
+
+        CTransaction dummyTx = TxClassC(txInputs, txOutputs);
+
+        CMPTransaction metaTx;
+        BOOST_CHECK(ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0);
+        BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000010000000006dac2c0");
+    }
+    {
         /**
          * The following transaction is invalid, because the first pushed data
          * doesn't contain the class C marker.

--- a/src/omnicore/test/script_extraction_tests.cpp
+++ b/src/omnicore/test/script_extraction_tests.cpp
@@ -163,6 +163,41 @@ BOOST_AUTO_TEST_CASE(extract_scripthash_test)
     BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(ToByteVector(innerId)));
 }
 
+BOOST_AUTO_TEST_CASE(extract_no_nulldata_test)
+{
+    // Null data script
+    CScript script;
+    script << OP_RETURN;
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_NULL_DATA);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(extract_empty_nulldata_test)
+{
+    // Null data script
+    CScript script;
+    script << OP_RETURN << ParseHex("");
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_NULL_DATA);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 1);
+    BOOST_CHECK_EQUAL(vstrSolutions[0].size(), 0);
+}
+
 BOOST_AUTO_TEST_CASE(extract_nulldata_test)
 {
     std::vector<unsigned char> vchPayload = ParseHex(
@@ -182,6 +217,41 @@ BOOST_AUTO_TEST_CASE(extract_nulldata_test)
     BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
     BOOST_CHECK_EQUAL(vstrSolutions.size(), 1);
     BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(vchPayload));
+}
+
+BOOST_AUTO_TEST_CASE(extract_nulldata_multipush_test)
+{
+    std::vector<std::string> vstrPayloads;
+    vstrPayloads.push_back("6f6d");
+    vstrPayloads.push_back("00000000000000010000000006dac2c0");
+    vstrPayloads.push_back("01d84bcec5b65aa1a03d6abfd975824c75856a2961");
+    vstrPayloads.push_back("00000000000000030000000000000d48");
+    vstrPayloads.push_back("05627138bb55251bfb289a1ec390eafd3755b1a698");
+    vstrPayloads.push_back("00000032010001000000005465737473004f6d6e6920436f726500546573"
+            "7420546f6b656e7300687474703a2f2f6275696c6465722e62697477617463682e636f2f005"
+            "573656420746f2074657374207468652065787472616374696f6e206f66206d756c7469706c"
+            "652070757368657320696e20616e204f505f52455455524e207363726970742e00000000000"
+            "00f4240");
+
+    // Null data script
+    CScript script;
+    script << OP_RETURN;
+    for (unsigned n = 0; n < vstrPayloads.size(); ++n) {
+        script << ParseHex(vstrPayloads[n]);
+    }
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_NULL_DATA);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), vstrPayloads.size());
+    for (unsigned n = 0; n < vstrSolutions.size(); ++n) {
+        BOOST_CHECK_EQUAL(vstrSolutions[n], vstrPayloads[n]);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(extract_anypush_test)

--- a/src/omnicore/test/sender_bycontribution_tests.cpp
+++ b/src/omnicore/test/sender_bycontribution_tests.cpp
@@ -1,0 +1,443 @@
+#include "omnicore/omnicore.h"
+#include "omnicore/script.h"
+#include "omnicore/tx.h"
+
+#include "base58.h"
+#include "coins.h"
+#include "primitives/transaction.h"
+#include "random.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_sender_bycontribution_tests)
+
+// Forward declarations
+static CTxOut PayToPubKeyHash_Exodus();
+static CTxOut PayToBareMultisig_1of3();
+static CTxOut PayToPubKeyHash_Unrelated();
+
+/** Creates a dummy class B transaction with the given inputs. */
+static CTransaction TxClassB(const std::vector<CTxOut>& txInputs)
+{
+    CMutableTransaction mutableTx;
+
+    // Inputs:
+    for (std::vector<CTxOut>::const_iterator it = txInputs.begin(); it != txInputs.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+
+        // Create transaction for input:
+        CMutableTransaction inputTx;
+        unsigned int nOut = 0;
+        inputTx.vout.push_back(txOut);
+        CTransaction tx(inputTx);
+
+        // Populate transaction cache:
+        CCoinsModifier coins = view.ModifyCoins(tx.GetHash());
+
+        if (nOut >= coins->vout.size()) {
+            coins->vout.resize(nOut+1);
+        }
+        coins->vout[nOut].scriptPubKey = txOut.scriptPubKey;
+        coins->vout[nOut].nValue = txOut.nValue;
+
+        // Add input:
+        CTxIn txIn(tx.GetHash(), nOut);
+        mutableTx.vin.push_back(txIn);
+    }
+
+    // Outputs:
+    mutableTx.vout.push_back(PayToPubKeyHash_Exodus());
+    mutableTx.vout.push_back(PayToBareMultisig_1of3());
+    mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
+
+    return CTransaction(mutableTx);
+}
+
+/** Extracts the sender "by contribution". */
+static bool GetSenderByContribution(const std::vector<CTxOut>& vouts, std::string& strSender)
+{
+    int nBlock = std::numeric_limits<int>().max();
+
+    CMPTransaction metaTx;
+    CTransaction dummyTx = TxClassB(vouts);
+
+    if (ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0) {
+        strSender = metaTx.getSender();
+        return true;
+    }
+
+    return false;
+}
+
+static const unsigned nOutputs = 256;
+static const unsigned nAllRounds = 2;
+static const unsigned nShuffleRounds = 16;
+
+/** Helper to create a CTxOut object. */
+static CTxOut createTxOut(int64_t amount, const std::string& dest)
+{
+    return CTxOut(amount, GetScriptForDestination(CBitcoinAddress(dest).Get()));
+}
+
+/** Helper to create a CKeyID object with random value.*/
+static CKeyID createRandomKeyId()
+{
+    std::vector<unsigned char> vch;
+    vch.reserve(20);
+    for (int i = 0; i < 20; ++i) {
+        vch.push_back(static_cast<unsigned char>(std::rand() % 256));
+    }
+    return CKeyID(uint160(vch));
+}
+
+/** Helper to create a CScriptID object with random value.*/
+static CScriptID createRandomScriptId()
+{
+    std::vector<unsigned char> vch;
+    vch.reserve(20);
+    for (int i = 0; i < 20; ++i) {
+        vch.push_back(static_cast<unsigned char>(std::rand() % 256));
+    }
+    return CScriptID(uint160(vch));
+}
+
+/**
+ * Identifies the sender of a transaction, based on the list of provided transaction
+ * outputs, and then shuffles the list n times, while checking, if this produces the
+ * same result. The "contribution by sum" sender selection doesn't require specific
+ * positions or order of outputs, and should work in all cases.
+ */
+void shuffleAndCheck(std::vector<CTxOut>& vouts, unsigned nRounds)
+{
+    std::string strSenderFirst;
+    BOOST_CHECK(GetSenderByContribution(vouts, strSenderFirst));
+
+    for (unsigned j = 0; j < nRounds; ++j) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strSenderFirst, strSender);
+    }
+}
+
+/**
+ * Tests sender selection "by sum" with pay-to-pubkey-hash outputs, where a single
+ * candidate has the highest output value.
+ */
+BOOST_AUTO_TEST_CASE(p2pkh_contribution_by_sum_test)
+{
+    std::vector<CTxOut> vouts;
+    vouts.push_back(createTxOut(100, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(100, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(100, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(100, "168F7az8ACWxntNqL1FathoKTbgK17GVft"));
+    vouts.push_back(createTxOut(100, "168F7az8ACWxntNqL1FathoKTbgK17GVft"));
+    vouts.push_back(createTxOut(999, "16X6UDz6dMkVAAkWdY6HKe85o6EVAbzDtn")); // Winner
+    vouts.push_back(createTxOut(100, "1BYk8d1fWy1JLcNqHyNTEg2Jxu9EDb1BmY"));
+    vouts.push_back(createTxOut(100, "1BYk8d1fWy1JLcNqHyNTEg2Jxu9EDb1BmY"));
+    vouts.push_back(createTxOut(100, "1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB"));
+
+    std::string strExpected("16X6UDz6dMkVAAkWdY6HKe85o6EVAbzDtn");
+
+    for (int i = 0; i < 10; ++i) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strExpected, strSender);
+    }
+}
+
+/**
+ * Tests sender selection "by sum" with pay-to-pubkey-hash outputs, where a candidate
+ * with the highest output value by sum, with more than one output, is chosen.
+ */
+BOOST_AUTO_TEST_CASE(p2pkh_contribution_by_total_sum_test)
+{
+    std::vector<CTxOut> vouts;
+    vouts.push_back(createTxOut(499, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(501, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(295, "1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB")); // Winner
+    vouts.push_back(createTxOut(310, "1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB")); // Winner
+    vouts.push_back(createTxOut(400, "1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB")); // Winner
+    vouts.push_back(createTxOut(500, "1Pr75FNvtoWHeocNfc4zTQCfK5kMVakWcn"));
+    vouts.push_back(createTxOut(500, "1Pr75FNvtoWHeocNfc4zTQCfK5kMVakWcn"));
+
+    std::string strExpected("1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB");
+
+    for (int i = 0; i < 10; ++i) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strExpected, strSender);
+    }
+}
+
+/**
+ * Tests sender selection "by sum" with pay-to-pubkey-hash outputs, where all outputs
+ * have equal values, and a candidate is chosen based on the lexicographical order of
+ * the base58 string representation (!) of the candidate.
+ *
+ * Note: it reflects the behavior of Omni Core, but this edge case is not specified.
+ */
+BOOST_AUTO_TEST_CASE(p2pkh_contribution_by_sum_order_test)
+{
+    std::vector<CTxOut> vouts;
+    vouts.push_back(createTxOut(1000, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe")); // Winner
+    vouts.push_back(createTxOut(1000, "168F7az8ACWxntNqL1FathoKTbgK17GVft"));
+    vouts.push_back(createTxOut(1000, "16X6UDz6dMkVAAkWdY6HKe85o6EVAbzDtn"));
+    vouts.push_back(createTxOut(1000, "1BYk8d1fWy1JLcNqHyNTEg2Jxu9EDb1BmY"));
+    vouts.push_back(createTxOut(1000, "1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB"));    
+    vouts.push_back(createTxOut(1000, "1HG3s4Ext3sTqBTHrgftyUzG3cvx5ZbPCj"));
+    vouts.push_back(createTxOut(1000, "1K6JtSvrHtyFmxdtGZyZEF7ydytTGqasNc"));    
+    vouts.push_back(createTxOut(1000, "1Pa6zyqnhL6LDJtrkCMi9XmEDNHJ23ffEr"));
+    vouts.push_back(createTxOut(1000, "1Pr75FNvtoWHeocNfc4zTQCfK5kMVakWcn"));
+
+    std::string strExpected("1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe");
+
+    for (int i = 0; i < 10; ++i) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strExpected, strSender);
+    }
+}
+
+/**
+ * Tests sender selection "by sum" with pay-to-script-hash outputs, where a single
+ * candidate has the highest output value.
+ */
+BOOST_AUTO_TEST_CASE(p2sh_contribution_by_sum_test)
+{
+    std::vector<CTxOut> vouts;
+    vouts.push_back(createTxOut(100, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(150, "32LUY4obZmFGFVtJTs4o1qk4dxo1bYq9s8"));
+    vouts.push_back(createTxOut(400, "34To5z7h35gQ54212gFRJSkwJUxGREr3SZ"));
+    vouts.push_back(createTxOut(100, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(400, "3HsMqdiWqaziUe9VExna46NbWBAFaioMrK"));
+    vouts.push_back(createTxOut(100, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(777, "3KYen723gbjhJU69j8jRhZU6fDw8iVVWKy")); // Winner
+    vouts.push_back(createTxOut(100, "3KuUrmqdM7BWfHTsyyLyYnJ57HgnKurvkK"));
+
+    std::string strExpected("3KYen723gbjhJU69j8jRhZU6fDw8iVVWKy");
+
+    for (int i = 0; i < 10; ++i) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strExpected, strSender);
+    }
+}
+
+/**
+ * Tests sender selection "by sum" with pay-to-pubkey-hash and pay-to-script-hash 
+ * outputs mixed, where a candidate with the highest output value by sum, with more 
+ * than one output, is chosen.
+ */
+BOOST_AUTO_TEST_CASE(p2sh_contribution_by_total_sum_test)
+{
+    std::vector<CTxOut> vouts;
+
+    vouts.push_back(createTxOut(100, "34To5z7h35gQ54212gFRJSkwJUxGREr3SZ"));
+    vouts.push_back(createTxOut(500, "34To5z7h35gQ54212gFRJSkwJUxGREr3SZ"));
+    vouts.push_back(createTxOut(600, "3CD1QW6fjgTwKq3Pj97nty28WZAVkziNom")); // Winner
+    vouts.push_back(createTxOut(500, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(100, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+    vouts.push_back(createTxOut(350, "3CD1QW6fjgTwKq3Pj97nty28WZAVkziNom")); // Winner
+    vouts.push_back(createTxOut(110, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+
+    std::string strExpected("3CD1QW6fjgTwKq3Pj97nty28WZAVkziNom");
+
+    for (int i = 0; i < 10; ++i) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strExpected, strSender);
+    }
+}
+
+/**
+ * Tests sender selection "by sum" with pay-to-script-hash outputs, where all outputs
+ * have equal values, and a candidate is chosen based on the lexicographical order of
+ * the base58 string representation (!) of the candidate.
+ *
+ * Note: it reflects the behavior of Omni Core, but this edge case is not specified.
+ */
+BOOST_AUTO_TEST_CASE(p2sh_contribution_by_sum_order_test)
+{
+    std::vector<CTxOut> vouts;
+    vouts.push_back(createTxOut(1000, "32LUY4obZmFGFVtJTs4o1qk4dxo1bYq9s8")); // Winner
+    vouts.push_back(createTxOut(1000, "34To5z7h35gQ54212gFRJSkwJUxGREr3SZ"));
+    vouts.push_back(createTxOut(1000, "3CD1QW6fjgTwKq3Pj97nty28WZAVkziNom"));
+    vouts.push_back(createTxOut(1000, "3GLZeQfjqFpULBzS12TjraZziNewnCE7bd"));
+    vouts.push_back(createTxOut(1000, "3HsMqdiWqaziUe9VExna46NbWBAFaioMrK"));    
+    vouts.push_back(createTxOut(1000, "3KYen723gbjhJU69j8jRhZU6fDw8iVVWKy"));
+    vouts.push_back(createTxOut(1000, "3KuUrmqdM7BWfHTsyyLyYnJ57HgnKurvkK"));    
+    vouts.push_back(createTxOut(1000, "3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8"));
+    vouts.push_back(createTxOut(1000, "3PeDornjuSraASTqyN7WDMexTogz29QnXu"));    
+    
+    std::string strExpected("32LUY4obZmFGFVtJTs4o1qk4dxo1bYq9s8");
+
+    for (int i = 0; i < 10; ++i) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strExpected, strSender);
+    }
+}
+
+/**
+ * Tests sender selection "by sum", where the lexicographical order of the base58 
+ * representation as string (instead of uint160) determines the chosen candidate.
+ *
+ * In practise this implies selecting the sender "by sum" via a comparison of 
+ * CBitcoinAddress objects would yield faulty results.
+ *
+ * Note: it reflects the behavior of Omni Core, but this edge case is not specified.
+ */
+BOOST_AUTO_TEST_CASE(sender_selection_string_based_test)
+{
+    std::vector<CTxOut> vouts;
+    // Hash 160: 539a7a290034e0107f27cb36cb2d1095b1768d10
+    vouts.push_back(createTxOut(1000, "18d49BjkbBCoK659fuktKjB3HugxK9NbpW")); // Winner
+    // Hash 160: 70161ebf72f894fbee554e88cf7889035899827f
+    vouts.push_back(createTxOut(1000, "1BDfBRCA3WBuHYHcaAdy4vojgmWZQncc16"));
+    // Hash 160: b94b91c9e0423f6e5279de68989dda9032d67e87
+    vouts.push_back(createTxOut(1000, "1HtkY9cvSBEQugk1R3XT5wjJZuyvSyzT8W"));
+    // Hash 160: 06569c8f59f428db748c94bf1d5d9f5f9d0db116
+    vouts.push_back(createTxOut(1000, "1aWp2ceCw95EVBwAv8HwX4Gofx9ksthjv"));  // Not!
+
+    std::string strExpected("18d49BjkbBCoK659fuktKjB3HugxK9NbpW");
+
+    for (int i = 0; i < 24; ++i) {
+        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+
+        std::string strSender;
+        BOOST_CHECK(GetSenderByContribution(vouts, strSender));
+        BOOST_CHECK_EQUAL(strExpected, strSender);
+    }
+}
+
+/**
+ * Tests order independence of the sender selection "by sum" for pay-to-pubkey-hash
+ * outputs, where all output values are equal.
+ */
+BOOST_AUTO_TEST_CASE(sender_selection_same_amount_test)
+{
+    for (unsigned i = 0; i < nAllRounds; ++i) {
+        std::vector<CTxOut> vouts;
+        for (unsigned n = 0; n < nOutputs; ++n) {
+            CTxOut output(static_cast<int64_t>(1000),
+                    GetScriptForDestination(createRandomKeyId()));
+            vouts.push_back(output);
+        }
+        shuffleAndCheck(vouts, nShuffleRounds);
+    }
+}
+
+/**
+ * Tests order independence of the sender selection "by sum" for pay-to-pubkey-hash
+ * outputs, where output values are different for each output.
+ */
+BOOST_AUTO_TEST_CASE(sender_selection_increasing_amount_test)
+{
+    for (unsigned i = 0; i < nAllRounds; ++i) {
+        std::vector<CTxOut> vouts;
+        for (unsigned n = 0; n < nOutputs; ++n) {
+            CTxOut output(static_cast<int64_t>(1000 + n),
+                    GetScriptForDestination(createRandomKeyId()));
+            vouts.push_back(output);
+        }
+        shuffleAndCheck(vouts, nShuffleRounds);
+    }
+}
+
+/**
+ * Tests order independence of the sender selection "by sum" for pay-to-pubkey-hash
+ * and pay-to-script-hash outputs mixed together, where output values are equal for 
+ * every second output.
+ */
+BOOST_AUTO_TEST_CASE(sender_selection_mixed_test)
+{
+    for (unsigned i = 0; i < nAllRounds; ++i) {
+        std::vector<CTxOut> vouts;
+        for (unsigned n = 0; n < nOutputs; ++n) {
+            CScript scriptPubKey;
+            if (std::rand() % 2 == 0) {
+                scriptPubKey = GetScriptForDestination(createRandomKeyId());
+            } else {
+                scriptPubKey = GetScriptForDestination(createRandomScriptId());
+            };
+            int64_t nAmount = static_cast<int64_t>(1000 - n * (n % 2 == 0));
+            vouts.push_back(CTxOut(nAmount, scriptPubKey));
+        }
+        shuffleAndCheck(vouts, nShuffleRounds);
+    }
+}
+
+// TODO: move into shared header, since it's also used for the marker tests
+static CTxOut PayToPubKeyHash_Exodus()
+{
+    CBitcoinAddress address = ExodusAddress();
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToBareMultisig_1of3()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+
+    // 1-of-3 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(1);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2);
+    scriptPubKey << ToByteVector(pubKey3);
+    scriptPubKey << CScript::EncodeOP_N(3);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToPubKeyHash_Unrelated()
+{
+    CBitcoinAddress address("1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX");
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/sender_firstin_tests.cpp
+++ b/src/omnicore/test/sender_firstin_tests.cpp
@@ -1,3 +1,5 @@
+#include "omnicore/test/utils_tx.h"
+
 #include "omnicore/omnicore.h"
 #include "omnicore/script.h"
 #include "omnicore/tx.h"
@@ -7,13 +9,10 @@
 #include "base58.h"
 #include "coins.h"
 #include "primitives/transaction.h"
-#include "random.h"
 #include "script/script.h"
 #include "script/standard.h"
-#include "utilstrencodings.h"
 
 #include <stdint.h>
-#include <algorithm>
 #include <limits>
 #include <vector>
 
@@ -22,10 +21,6 @@
 using namespace mastercore;
 
 BOOST_AUTO_TEST_SUITE(omnicore_sender_firstin_tests)
-
-static CTxOut PayToPubKey_Unrelated();
-static CTxOut PayToBareMultisig_1of3();
-static CTxOut NonStandardOutput();
 
 /** Creates a dummy class C transaction with the given inputs. */
 static CTransaction TxClassC(const std::vector<CTxOut>& txInputs)
@@ -142,63 +137,6 @@ BOOST_AUTO_TEST_CASE(invalid_inputs)
         std::string strSender;
         BOOST_CHECK(!GetFirstSender(vouts, strSender));
     }
-}
-
-static CTxOut PayToPubKey_Unrelated()
-{
-    std::vector<unsigned char> vchPubKey = ParseHex(
-        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
-        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
-
-    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
-
-    CScript scriptPubKey;
-    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    txnouttype outType;
-    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
-    BOOST_CHECK(outType == TX_PUBKEY);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut PayToBareMultisig_1of3()
-{
-    std::vector<unsigned char> vchPayload1 = ParseHex(
-        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
-        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
-    std::vector<unsigned char> vchPayload2 = ParseHex(
-        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
-    std::vector<unsigned char> vchPayload3 = ParseHex(
-        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
-
-    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
-    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
-    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
-
-    // 1-of-3 bare multisig script
-    CScript scriptPubKey;
-    scriptPubKey << CScript::EncodeOP_N(1);
-    scriptPubKey << ToByteVector(pubKey1);
-    scriptPubKey << ToByteVector(pubKey2);
-    scriptPubKey << ToByteVector(pubKey3);
-    scriptPubKey << CScript::EncodeOP_N(3);
-    scriptPubKey << OP_CHECKMULTISIG;
-
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
-}
-
-static CTxOut NonStandardOutput()
-{
-    CScript scriptPubKey;
-    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
-    int64_t amount = GetDustThreshold(scriptPubKey);
-
-    return CTxOut(amount, scriptPubKey);
 }
 
 

--- a/src/omnicore/test/sender_firstin_tests.cpp
+++ b/src/omnicore/test/sender_firstin_tests.cpp
@@ -1,0 +1,205 @@
+#include "omnicore/omnicore.h"
+#include "omnicore/script.h"
+#include "omnicore/tx.h"
+#include "omnicore/encoding.h"
+#include "omnicore/createpayload.h"
+
+#include "base58.h"
+#include "coins.h"
+#include "primitives/transaction.h"
+#include "random.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_sender_firstin_tests)
+
+static CTxOut PayToPubKey_Unrelated();
+static CTxOut PayToBareMultisig_1of3();
+static CTxOut NonStandardOutput();
+
+/** Creates a dummy class C transaction with the given inputs. */
+static CTransaction TxClassC(const std::vector<CTxOut>& txInputs)
+{
+    CMutableTransaction mutableTx;
+
+    // Inputs:
+    for (std::vector<CTxOut>::const_iterator it = txInputs.begin(); it != txInputs.end(); ++it)
+    {
+        const CTxOut& txOut = *it;
+
+        // Create transaction for input:
+        CMutableTransaction inputTx;
+        unsigned int nOut = 0;
+        inputTx.vout.push_back(txOut);
+        CTransaction tx(inputTx);
+
+        // Populate transaction cache:
+        CCoinsModifier coins = view.ModifyCoins(tx.GetHash());
+
+        if (nOut >= coins->vout.size()) {
+            coins->vout.resize(nOut+1);
+        }
+        coins->vout[nOut].scriptPubKey = txOut.scriptPubKey;
+        coins->vout[nOut].nValue = txOut.nValue;
+
+        // Add input:
+        CTxIn txIn(tx.GetHash(), nOut);
+        mutableTx.vin.push_back(txIn);
+    }
+
+    // Outputs:
+    std::vector<std::pair<CScript, int64_t> > txOutputs;
+    std::vector<unsigned char> vchPayload = CreatePayload_SimpleSend(1, 1000);
+    BOOST_CHECK(OmniCore_Encode_ClassC(vchPayload, txOutputs));
+
+    for (std::vector<std::pair<CScript, int64_t> >::const_iterator it = txOutputs.begin(); it != txOutputs.end(); ++it)
+    {
+        CTxOut txOut(it->second, it->first);
+        mutableTx.vout.push_back(txOut);
+    }
+
+    return CTransaction(mutableTx);
+}
+
+/** Helper to create a CTxOut object. */
+static CTxOut createTxOut(int64_t amount, const std::string& dest)
+{
+    return CTxOut(amount, GetScriptForDestination(CBitcoinAddress(dest).Get()));
+}
+
+/** Extracts the "first" sender. */
+static bool GetFirstSender(const std::vector<CTxOut>& txInputs, std::string& strSender)
+{
+    int nBlock = std::numeric_limits<int>().max();
+
+    CMPTransaction metaTx;
+    CTransaction dummyTx = TxClassC(txInputs);
+
+    if (ParseTransaction(dummyTx, nBlock, 1, metaTx) == 0) {
+        strSender = metaTx.getSender();
+        return true;
+    }
+
+    return false;
+}
+
+BOOST_AUTO_TEST_CASE(first_vin_is_sender)
+{
+    std::vector<CTxOut> vouts;
+    vouts.push_back(createTxOut(100, "1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB")); // Winner
+    vouts.push_back(createTxOut(999, "3KYen723gbjhJU69j8jRhZU6fDw8iVVWKy"));
+    vouts.push_back(createTxOut(200, "1471EHpnJ62MDxLw96dKcNT8sWPEbHrAUe"));
+
+    std::string strExpected("1CE8bBr1dYZRMnpmyYsFEoexa1YoPz2mfB");
+
+    std::string strSender;
+    BOOST_CHECK(GetFirstSender(vouts, strSender));
+    BOOST_CHECK_EQUAL(strExpected, strSender);
+}
+
+BOOST_AUTO_TEST_CASE(less_input_restrictions)
+{
+    std::vector<CTxOut> vouts;
+    vouts.push_back(createTxOut(555, "3CD1QW6fjgTwKq3Pj97nty28WZAVkziNom")); // Winner
+    vouts.push_back(PayToPubKey_Unrelated());
+    vouts.push_back(PayToBareMultisig_1of3());
+    vouts.push_back(NonStandardOutput());
+
+    std::string strExpected("3CD1QW6fjgTwKq3Pj97nty28WZAVkziNom");
+
+    std::string strSender;
+    BOOST_CHECK(GetFirstSender(vouts, strSender));
+    BOOST_CHECK_EQUAL(strExpected, strSender);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_inputs)
+{
+    {
+        std::vector<CTxOut> vouts;
+        vouts.push_back(PayToPubKey_Unrelated());
+        std::string strSender;
+        BOOST_CHECK(!GetFirstSender(vouts, strSender));
+    }
+    {
+        std::vector<CTxOut> vouts;
+        vouts.push_back(PayToBareMultisig_1of3());
+        std::string strSender;
+        BOOST_CHECK(!GetFirstSender(vouts, strSender));
+    }
+    {
+        std::vector<CTxOut> vouts;
+        vouts.push_back(NonStandardOutput());
+        std::string strSender;
+        BOOST_CHECK(!GetFirstSender(vouts, strSender));
+    }
+}
+
+static CTxOut PayToPubKey_Unrelated()
+{
+    std::vector<unsigned char> vchPubKey = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+
+    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
+
+    CScript scriptPubKey;
+    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    txnouttype outType;
+    BOOST_CHECK(GetOutputType(scriptPubKey, outType));
+    BOOST_CHECK(outType == TX_PUBKEY);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut PayToBareMultisig_1of3()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+
+    // 1-of-3 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(1);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2);
+    scriptPubKey << ToByteVector(pubKey3);
+    scriptPubKey << CScript::EncodeOP_N(3);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+static CTxOut NonStandardOutput()
+{
+    CScript scriptPubKey;
+    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/utils_tx.cpp
+++ b/src/omnicore/test/utils_tx.cpp
@@ -1,0 +1,192 @@
+#include "omnicore/test/utils_tx.h"
+
+#include "omnicore/omnicore.h"
+#include "omnicore/script.h"
+
+#include "base58.h"
+#include "primitives/transaction.h"
+#include "pubkey.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+
+CTxOut PayToPubKeyHash_Exodus()
+{
+    CBitcoinAddress address = ExodusAddress();
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+CTxOut PayToPubKeyHash_ExodusCrowdsale(int nHeight)
+{
+    CBitcoinAddress address = ExodusCrowdsaleAddress(nHeight);
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+CTxOut PayToPubKeyHash_Unrelated()
+{
+    CBitcoinAddress address("1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX");
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+CTxOut PayToScriptHash_Unrelated()
+{
+    CBitcoinAddress address("3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL");
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+CTxOut PayToPubKey_Unrelated()
+{
+    std::vector<unsigned char> vchPubKey = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+
+    CPubKey pubKey(vchPubKey.begin(), vchPubKey.end());
+
+    CScript scriptPubKey;
+    scriptPubKey << ToByteVector(pubKey) << OP_CHECKSIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+CTxOut PayToBareMultisig_1of3()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+
+    // 1-of-3 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(1);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2);
+    scriptPubKey << ToByteVector(pubKey3);
+    scriptPubKey << CScript::EncodeOP_N(3);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+CTxOut PayToBareMultisig_3of5()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "02619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+    std::vector<unsigned char> vchPayload4 = ParseHex(
+        "0261a017029ec4688ec9bf33c44ad2e595f83aaf3ed4f3032d1955715f5ffaf6b8");
+    std::vector<unsigned char> vchPayload5 = ParseHex(
+        "02dc1a0afc933d703557d9f5e86423a5cec9fee4bfa850b3d02ceae72117178802");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+    CPubKey pubKey4(vchPayload4.begin(), vchPayload4.end());
+    CPubKey pubKey5(vchPayload5.begin(), vchPayload5.end());
+
+    // 3-of-5 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(3);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2) << ToByteVector(pubKey3);
+    scriptPubKey << ToByteVector(pubKey4) << ToByteVector(pubKey5);
+    scriptPubKey << CScript::EncodeOP_N(5);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
+CTxOut OpReturn_Empty()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN;
+
+    return CTxOut(0, scriptPubKey);
+}
+
+CTxOut OpReturn_UnrelatedShort()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("b9");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+CTxOut OpReturn_Unrelated()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("7468697320697320646578782028323031352d30362d313129");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+CTxOut OpReturn_Tagged_A()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6d0000408");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+CTxOut OpReturn_Tagged_B()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6d00011516");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+CTxOut OpReturn_Tagged_C()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6dffff2342");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+CTxOut OpReturn_SimpleSend()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << ParseHex("6f6d00000000000000070000000006dac2c0");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+CTxOut NonStandardOutput()
+{
+    CScript scriptPubKey;
+    scriptPubKey << ParseHex("decafbad") << OP_DROP << OP_TRUE;
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+

--- a/src/omnicore/test/utils_tx.cpp
+++ b/src/omnicore/test/utils_tx.cpp
@@ -149,26 +149,10 @@ CTxOut OpReturn_Unrelated()
     return CTxOut(0, scriptPubKey);
 }
 
-CTxOut OpReturn_Tagged_A()
+CTxOut OpReturn_PlainMarker()
 {
     CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6d0000408");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-CTxOut OpReturn_Tagged_B()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6d00011516");
-
-    return CTxOut(0, scriptPubKey);
-}
-
-CTxOut OpReturn_Tagged_C()
-{
-    CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6dffff2342");
+    scriptPubKey << OP_RETURN << ParseHex("6f6d");
 
     return CTxOut(0, scriptPubKey);
 }
@@ -177,6 +161,20 @@ CTxOut OpReturn_SimpleSend()
 {
     CScript scriptPubKey;
     scriptPubKey << OP_RETURN << ParseHex("6f6d00000000000000070000000006dac2c0");
+
+    return CTxOut(0, scriptPubKey);
+}
+
+
+CTxOut OpReturn_MultiSimpleSend()
+{
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN;
+    scriptPubKey << ParseHex("6f6d");
+    scriptPubKey << ParseHex("00000000000000070000000000002329");
+    scriptPubKey << ParseHex("0062e907b15cbf27d5425399ebf6f0fb50ebb88f18");
+    scriptPubKey << ParseHex("000000000000001f0000000001406f40");
+    scriptPubKey << ParseHex("05da59767e81f4b019fe9f5984dbaa4f61bf197967");
 
     return CTxOut(0, scriptPubKey);
 }

--- a/src/omnicore/test/utils_tx.cpp
+++ b/src/omnicore/test/utils_tx.cpp
@@ -152,7 +152,7 @@ CTxOut OpReturn_Unrelated()
 CTxOut OpReturn_PlainMarker()
 {
     CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6d");
+    scriptPubKey << OP_RETURN << ParseHex("6f6d6e69");
 
     return CTxOut(0, scriptPubKey);
 }
@@ -160,7 +160,7 @@ CTxOut OpReturn_PlainMarker()
 CTxOut OpReturn_SimpleSend()
 {
     CScript scriptPubKey;
-    scriptPubKey << OP_RETURN << ParseHex("6f6d00000000000000070000000006dac2c0");
+    scriptPubKey << OP_RETURN << ParseHex("6f6d6e6900000000000000070000000006dac2c0");
 
     return CTxOut(0, scriptPubKey);
 }
@@ -170,7 +170,7 @@ CTxOut OpReturn_MultiSimpleSend()
 {
     CScript scriptPubKey;
     scriptPubKey << OP_RETURN;
-    scriptPubKey << ParseHex("6f6d");
+    scriptPubKey << ParseHex("6f6d6e69");
     scriptPubKey << ParseHex("00000000000000070000000000002329");
     scriptPubKey << ParseHex("0062e907b15cbf27d5425399ebf6f0fb50ebb88f18");
     scriptPubKey << ParseHex("000000000000001f0000000001406f40");

--- a/src/omnicore/test/utils_tx.cpp
+++ b/src/omnicore/test/utils_tx.cpp
@@ -64,6 +64,30 @@ CTxOut PayToPubKey_Unrelated()
     return CTxOut(amount, scriptPubKey);
 }
 
+CTxOut PayToBareMultisig_1of2()
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "04ad90e5b6bc86b3ec7fac2c5fbda7423fc8ef0d58df594c773fa05e2c281b2bfe"
+        "877677c668bd13603944e34f4818ee03cadd81a88542b8b4d5431264180e2c28");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+
+    // 1-of-2 bare multisig script
+    CScript scriptPubKey;
+    scriptPubKey << CScript::EncodeOP_N(1);
+    scriptPubKey << ToByteVector(pubKey1);
+    scriptPubKey << ToByteVector(pubKey2);
+    scriptPubKey << CScript::EncodeOP_N(2);
+    scriptPubKey << OP_CHECKMULTISIG;
+
+    int64_t amount = GetDustThreshold(scriptPubKey);
+
+    return CTxOut(amount, scriptPubKey);
+}
+
 CTxOut PayToBareMultisig_1of3()
 {
     std::vector<unsigned char> vchPayload1 = ParseHex(

--- a/src/omnicore/test/utils_tx.h
+++ b/src/omnicore/test/utils_tx.h
@@ -13,10 +13,9 @@ CTxOut PayToBareMultisig_3of5();
 CTxOut OpReturn_Empty();
 CTxOut OpReturn_UnrelatedShort();
 CTxOut OpReturn_Unrelated();
-CTxOut OpReturn_Tagged_A();
-CTxOut OpReturn_Tagged_B();
-CTxOut OpReturn_Tagged_C();
+CTxOut OpReturn_PlainMarker();
 CTxOut OpReturn_SimpleSend();
+CTxOut OpReturn_MultiSimpleSend();
 CTxOut NonStandardOutput();
 
 

--- a/src/omnicore/test/utils_tx.h
+++ b/src/omnicore/test/utils_tx.h
@@ -1,0 +1,23 @@
+#ifndef OMNICORE_TEST_UTILS_TX_H
+#define OMNICORE_TEST_UTILS_TX_H
+
+class CTxOut;
+
+CTxOut PayToPubKeyHash_Exodus();
+CTxOut PayToPubKeyHash_ExodusCrowdsale(int nHeight);
+CTxOut PayToPubKeyHash_Unrelated();
+CTxOut PayToScriptHash_Unrelated();
+CTxOut PayToPubKey_Unrelated();
+CTxOut PayToBareMultisig_1of3();
+CTxOut PayToBareMultisig_3of5();
+CTxOut OpReturn_Empty();
+CTxOut OpReturn_UnrelatedShort();
+CTxOut OpReturn_Unrelated();
+CTxOut OpReturn_Tagged_A();
+CTxOut OpReturn_Tagged_B();
+CTxOut OpReturn_Tagged_C();
+CTxOut OpReturn_SimpleSend();
+CTxOut NonStandardOutput();
+
+
+#endif // OMNICORE_TEST_UTILS_TX_H

--- a/src/omnicore/test/utils_tx.h
+++ b/src/omnicore/test/utils_tx.h
@@ -8,6 +8,7 @@ CTxOut PayToPubKeyHash_ExodusCrowdsale(int nHeight);
 CTxOut PayToPubKeyHash_Unrelated();
 CTxOut PayToScriptHash_Unrelated();
 CTxOut PayToPubKey_Unrelated();
+CTxOut PayToBareMultisig_1of2();
 CTxOut PayToBareMultisig_1of3();
 CTxOut PayToBareMultisig_3of5();
 CTxOut OpReturn_Empty();

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -231,7 +231,7 @@ unsigned int prop_id;
   PrintToLog("\t             URL: %s\n", url);
   PrintToLog("\t            Data: %s\n", data);
 
-  if (!isTransactionTypeAllowed(block, prop_id, type, version))
+  if (!IsTransactionTypeAllowed(block, prop_id, type, version))
   {
     error_code = (PKT_ERROR_SP -503);
     return NULL;
@@ -881,7 +881,7 @@ void CMPTransaction::printInfo(FILE *fp)
 
 int CMPTransaction::logicMath_SendToOwners()
 {
-    if (!isTransactionTypeAllowed(block, property, type, version)) {
+    if (!IsTransactionTypeAllowed(block, property, type, version)) {
         return (PKT_ERROR_STO -22);
     }
 
@@ -975,7 +975,7 @@ int rc = PKT_ERROR_TRADEOFFER;
       }
 
       // block height checks, for instance DEX is only available on MSC starting with block 290630
-      if (!isTransactionTypeAllowed(block, property, type, version)) return -88888;
+      if (!IsTransactionTypeAllowed(block, property, type, version)) return -88888;
 
       if (obj_o)
       {
@@ -1102,7 +1102,7 @@ int CMPTransaction::logicMath_MetaDExTrade()
 
     int rc = PKT_ERROR_METADEX - 100;
 
-    if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -889);
+    if (!IsTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -889);
 
     // ensure we are not trading same property for itself
     if (property == desired_property) return (PKT_ERROR_METADEX -5);
@@ -1138,7 +1138,7 @@ int CMPTransaction::logicMath_MetaDExCancelPrice()
 
     int rc = PKT_ERROR_METADEX -100;
 
-    if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -890);
+    if (!IsTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -890);
 
     // ensure we are not trading same property for itself
     if (property == desired_property) return (PKT_ERROR_METADEX -5);
@@ -1162,7 +1162,7 @@ int CMPTransaction::logicMath_MetaDExCancelPair()
 {
     int rc = PKT_ERROR_METADEX -100;
 
-    if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -891);
+    if (!IsTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -891);
 
     // ensure we are not trading same property for itself
     if (property == desired_property) return (PKT_ERROR_METADEX - 5);
@@ -1182,7 +1182,7 @@ int CMPTransaction::logicMath_MetaDExCancelEcosystem()
 {
     int rc = PKT_ERROR_METADEX -101;
 
-    if (!isTransactionTypeAllowed(block, ecosystem, type, version, true)) return (PKT_ERROR_METADEX -892);
+    if (!IsTransactionTypeAllowed(block, ecosystem, type, version, true)) return (PKT_ERROR_METADEX -892);
 
     rc = MetaDEx_CANCEL_EVERYTHING(txid, block, sender, ecosystem);
 
@@ -1198,7 +1198,7 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
         return (PKT_ERROR_SP -502);
     }
     uint32_t prop_id = _my_sps->peekNextSPID(ecosystem);
-    if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
+    if (!IsTransactionTypeAllowed(block, prop_id, type, version)) {
         return (PKT_ERROR_SP -503);
     }
     if ('\0' == name[0]) {
@@ -1244,7 +1244,7 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
         return (PKT_ERROR_SP -502);
     }
     uint32_t prop_id = _my_sps->peekNextSPID(ecosystem);
-    if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
+    if (!IsTransactionTypeAllowed(block, prop_id, type, version)) {
         return (PKT_ERROR_SP -503);
     }
     if ('\0' == name[0]) {
@@ -1354,7 +1354,7 @@ int CMPTransaction::logicMath_CreatePropertyMananged()
         return (PKT_ERROR_SP -502);
     }
     uint32_t prop_id = _my_sps->peekNextSPID(ecosystem);
-    if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
+    if (!IsTransactionTypeAllowed(block, prop_id, type, version)) {
         return (PKT_ERROR_SP -503);
     }
     if ('\0' == name[0]) {
@@ -1392,7 +1392,7 @@ int CMPTransaction::logicMath_GrantTokens()
 
     int rc = PKT_ERROR_TOKENS - 1000;
 
-    if (!isTransactionTypeAllowed(block, property, type, version)) {
+    if (!IsTransactionTypeAllowed(block, property, type, version)) {
       PrintToLog("\tRejecting Grant: Transaction type not yet allowed\n");
       return (PKT_ERROR_TOKENS - 22);
     }
@@ -1461,7 +1461,7 @@ int CMPTransaction::logicMath_RevokeTokens()
 
     int rc = PKT_ERROR_TOKENS - 1000;
 
-    if (!isTransactionTypeAllowed(block, property, type, version)) {
+    if (!IsTransactionTypeAllowed(block, property, type, version)) {
       PrintToLog("\tRejecting Revoke: Transaction type not yet allowed\n");
       return (PKT_ERROR_TOKENS - 22);
     }
@@ -1507,7 +1507,7 @@ int CMPTransaction::logicMath_ChangeIssuer()
 {
   int rc = PKT_ERROR_TOKENS - 1000;
 
-  if (!isTransactionTypeAllowed(block, property, type, version)) {
+  if (!IsTransactionTypeAllowed(block, property, type, version)) {
     PrintToLog("\tRejecting Change of Issuer: Transaction type not yet allowed\n");
     return (PKT_ERROR_TOKENS - 22);
   }

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -120,6 +120,8 @@ public:
     std::string getSender() const { return sender; }
     std::string getReceiver() const { return receiver; }
 
+    std::string getPayload() const { return HexStr(pkt, pkt + pkt_size); }
+
     uint64_t getAmount() const { return nValue; }
     uint64_t getNewAmount() const { return nNewValue; }
 


### PR DESCRIPTION
Primarily this PR intends to improve the structure of `parseTransaction()` by grouping code, and executing only those parts, which are necessary for each encoding class.

While probably not 100 % accurate, the time spent in `parseTransaction()`, when running the regtests via OmniJ, was on average 0.001415 s per call, with 2870 calls in total, and it was reduced to 0.000885 s per call by this PR.

The new structure may allow to split `parseTransaction()` into smaller logic parts at some point in the future, for example to handle the input selection outside of that function, or maybe even to handle the different encoding classes class A, B and C transactions seperately.

It partially resolves #73.