### PR TITLE
Show script verification errors in signrawtransaction result

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -27,6 +27,7 @@ if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
   ${BUILDDIR}/qa/rpc-tests/httpbasics.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/mempool_coinbase_spends.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/mempool_clear_test.py --srcdir "${BUILDDIR}/src"
+  ${BUILDDIR}/qa/rpc-tests/signrawtransactions.py --srcdir "${BUILDDIR}/src"
   #${BUILDDIR}/qa/rpc-tests/forknotify.py --srcdir "${BUILDDIR}/src"
 else
   echo "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"

--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework import BitcoinTestFramework
+from util import *
+
+
+class SignRawTransactionsTest(BitcoinTestFramework):
+    """Tests transaction signing via RPC command "signrawtransaction"."""
+
+    def setup_chain(self):
+        print('Initializing test directory ' + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 1)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(1, self.options.tmpdir)
+        self.is_network_split = False
+
+    def successful_signing_test(self):
+        """Creates and signs a valid raw transaction with one input.
+
+        Expected results:
+
+        1) The transaction has a complete set of signatures
+        2) No script verification error occurred"""
+        privKeys = ['cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N']
+
+        inputs = [
+            # Valid pay-to-pubkey script
+            {'txid': '9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71', 'vout': 0,
+             'scriptPubKey': '76a91460baa0f494b38ce3c940dea67f3804dc52d1fb9488ac'}
+        ]
+
+        outputs = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
+
+        rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
+        rawTxSigned = self.nodes[0].signrawtransaction(rawTx, inputs, privKeys)
+
+        # 1) The transaction has a complete set of signatures
+        assert 'complete' in rawTxSigned
+        assert_equal(rawTxSigned['complete'], True)
+
+        # 2) No script verification error occurred
+        assert 'errors' not in rawTxSigned
+
+    def script_verification_error_test(self):
+        """Creates and signs a raw transaction with valid (vin 0), invalid (vin 1) and one missing (vin 2) input script.
+
+        Expected results:
+
+        3) The transaction has no complete set of signatures
+        4) Two script verification errors occurred
+        5) Script verification errors have certain properties ("txid", "vout", "scriptSig", "sequence", "error")
+        6) The verification errors refer to the invalid (vin 1) and missing input (vin 2)"""
+        privKeys = ['cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N']
+
+        inputs = [
+            # Valid pay-to-pubkey script
+            {'txid': '9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71', 'vout': 0},
+            # Invalid script
+            {'txid': '5b8673686910442c644b1f4993d8f7753c7c8fcb5c87ee40d56eaeef25204547', 'vout': 7},
+            # Missing scriptPubKey
+            {'txid': '9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71', 'vout': 1},
+        ]
+
+        scripts = [
+            # Valid pay-to-pubkey script
+            {'txid': '9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71', 'vout': 0,
+             'scriptPubKey': '76a91460baa0f494b38ce3c940dea67f3804dc52d1fb9488ac'},
+            # Invalid script
+            {'txid': '5b8673686910442c644b1f4993d8f7753c7c8fcb5c87ee40d56eaeef25204547', 'vout': 7,
+             'scriptPubKey': 'badbadbadbad'}
+        ]
+
+        outputs = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
+
+        rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
+        rawTxSigned = self.nodes[0].signrawtransaction(rawTx, scripts, privKeys)
+
+        # 3) The transaction has no complete set of signatures
+        assert 'complete' in rawTxSigned
+        assert_equal(rawTxSigned['complete'], False)
+
+        # 4) Two script verification errors occurred
+        assert 'errors' in rawTxSigned
+        assert_equal(len(rawTxSigned['errors']), 2)
+
+        # 5) Script verification errors have certain properties
+        assert 'txid' in rawTxSigned['errors'][0]
+        assert 'vout' in rawTxSigned['errors'][0]
+        assert 'scriptSig' in rawTxSigned['errors'][0]
+        assert 'sequence' in rawTxSigned['errors'][0]
+        assert 'error' in rawTxSigned['errors'][0]
+
+        # 6) The verification errors refer to the invalid (vin 1) and missing input (vin 2)
+        assert_equal(rawTxSigned['errors'][0]['txid'], inputs[1]['txid'])
+        assert_equal(rawTxSigned['errors'][0]['vout'], inputs[1]['vout'])
+        assert_equal(rawTxSigned['errors'][1]['txid'], inputs[2]['txid'])
+        assert_equal(rawTxSigned['errors'][1]['vout'], inputs[2]['vout'])
+
+    def run_test(self):
+        self.successful_signing_test()
+        self.script_verification_error_test()
+
+
+if __name__ == '__main__':
+    SignRawTransactionsTest().main()

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2009-2015 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,6 +12,7 @@
 #include "net.h"
 #include "rpcserver.h"
 #include "script/script.h"
+#include "script/script_error.h"
 #include "script/sign.h"
 #include "script/standard.h"
 #include "uint256.h"
@@ -484,6 +485,18 @@ Value decodescript(const Array& params, bool fHelp)
     return r;
 }
 
+/** Pushes a JSON object for script verification or signing errors to vErrorsRet. */
+static void TxInErrorToJSON(const CTxIn& txin, Array& vErrorsRet, const std::string& strMessage)
+{
+    Object entry;
+    entry.push_back(Pair("txid", txin.prevout.hash.ToString()));
+    entry.push_back(Pair("vout", (uint64_t)txin.prevout.n));
+    entry.push_back(Pair("scriptSig", HexStr(txin.scriptSig.begin(), txin.scriptSig.end())));
+    entry.push_back(Pair("sequence", (uint64_t)txin.nSequence));
+    entry.push_back(Pair("error", strMessage));
+    vErrorsRet.push_back(entry);
+}
+
 Value signrawtransaction(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 4)
@@ -525,8 +538,18 @@ Value signrawtransaction(const Array& params, bool fHelp)
 
             "\nResult:\n"
             "{\n"
-            "  \"hex\": \"value\",   (string) The raw transaction with signature(s) (hex-encoded string)\n"
-            "  \"complete\": n       (numeric) if transaction has a complete set of signature (0 if not)\n"
+            "  \"hex\" : \"value\",           (string) The hex-encoded raw transaction with signature(s)\n"
+            "  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n"
+            "  \"errors\" : [                 (json array of objects) Script verification errors (if there are any)\n"
+            "    {\n"
+            "      \"txid\" : \"hash\",           (string) The hash of the referenced, previous transaction\n"
+            "      \"vout\" : n,                (numeric) The index of the output to spent and used as input\n"
+            "      \"scriptSig\" : \"hex\",       (string) The hex-encoded signature script\n"
+            "      \"sequence\" : n,            (numeric) Script sequence number\n"
+            "      \"error\" : \"text\"           (string) Verification or signing error related to the input\n"
+            "    }\n"
+            "    ,...\n"
+            "  ]\n"
             "}\n"
 
             "\nExamples:\n"
@@ -556,7 +579,6 @@ Value signrawtransaction(const Array& params, bool fHelp)
     // mergedTx will end up with all the signatures; it
     // starts as a clone of the rawtx:
     CMutableTransaction mergedTx(txVariants[0]);
-    bool fComplete = true;
 
     // Fetch previous transactions (inputs):
     CCoinsView viewDummy;
@@ -671,12 +693,15 @@ Value signrawtransaction(const Array& params, bool fHelp)
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
 
+    // Script verification errors
+    Array vErrors;
+
     // Sign what we can:
     for (unsigned int i = 0; i < mergedTx.vin.size(); i++) {
         CTxIn& txin = mergedTx.vin[i];
         const CCoins* coins = view.AccessCoins(txin.prevout.hash);
         if (coins == NULL || !coins->IsAvailable(txin.prevout.n)) {
-            fComplete = false;
+            TxInErrorToJSON(txin, vErrors, "Input not found or already spent");
             continue;
         }
         const CScript& prevPubKey = coins->vout[txin.prevout.n].scriptPubKey;
@@ -690,13 +715,19 @@ Value signrawtransaction(const Array& params, bool fHelp)
         BOOST_FOREACH(const CMutableTransaction& txv, txVariants) {
             txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.vin[i].scriptSig);
         }
-        if (!VerifyScript(txin.scriptSig, prevPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&mergedTx, i)))
-            fComplete = false;
+        ScriptError serror = SCRIPT_ERR_OK;
+        if (!VerifyScript(txin.scriptSig, prevPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&mergedTx, i), &serror)) {
+            TxInErrorToJSON(txin, vErrors, ScriptErrorString(serror));
+        }
     }
+    bool fComplete = vErrors.empty();
 
     Object result;
     result.push_back(Pair("hex", EncodeHexTx(mergedTx)));
     result.push_back(Pair("complete", fComplete));
+    if (!vErrors.empty()) {
+        result.push_back(Pair("errors", vErrors));
+    }
 
     return result;
 }


### PR DESCRIPTION
This is a backport of PR https://github.com/bitcoin/bitcoin/pull/5937, which became part of 0.11.

In my opinion it's handy for raw transaction handling, and to some degree also in the context of shared/P2SH transactions.

---

If there are any script verification errors, when using `"signrawtransaction"`, they are shown in the RPC result.

Example:
```bash
./bitcoin-cli "signrawtransaction" "0100000002d8fde545ff10eec10a6bef0c293c892b556aaa8c9e2f5f4c8545ca5c88e41c930100000000ffffffff62a717b7379c9fd900bf8cd42d6cbe1992f51aac2edff637dd291ec0b710acf23800000000ffffffff01a0410000000000001976a9142d0242ee11731e1fb95f3917b61a11aa400f6d5388ac00000000" "[{\"txid\":\"931ce4885cca45854c5f2f9e8caa6a552b893c290cef6b0ac1ee10ff45e5fdd8\",\"vout\":1,\"scriptPubKey\":\"512102a6bce06d76dfa05974f50e71660936966be40fceee99fed481a526016b3b240e21160000000100000001d865ecba07d000000000000000000000000000000000000052ae\"},{\"txid\":\"f2ac10b7c01e29dd37f6df2eac1af59219be6c2dd48cbf00d99f9c37b717a762\",\"vout\":56,\"scriptPubKey\":\"01\"}]" "[\"xxxxxx\"]"
```
```json
{
  "hex" : "0100000002d8fde545ff10eec10a6bef0c293c892b556aaa8c9e2f5f4c8545ca5c88e41c93010000004a00483045022100f5e5d54c229c241c8525a9e01c9774d0cf974f2262a7045636c2308dbae43af90220151439bb3913379327fcf10ee51b779f9b349c58870962a605276419122a2fb601ffffffff62a717b7379c9fd900bf8cd42d6cbe1992f51aac2edff637dd291ec0b710acf23800000000ffffffff01a0410000000000001976a9142d0242ee11731e1fb95f3917b61a11aa400f6d5388ac00000000",
  "complete" : false,
  "errors" : [
    {
      "txid" : "931ce4885cca45854c5f2f9e8caa6a552b893c290cef6b0ac1ee10ff45e5fdd8",
      "vout" : 1,
      "scriptSig" : "00483045022100f5e5d54c229c241c8525a9e01c9774d0cf974f2262a7045636c2308dbae43af90220151439bb3913379327fcf10ee51b779f9b349c58870962a605276419122a2fb601",
      "sequence" : 4294967295,
      "error" : "Public key is neither compressed or uncompressed"
    },
    {
      "txid" : "f2ac10b7c01e29dd37f6df2eac1af59219be6c2dd48cbf00d99f9c37b717a762",
      "vout" : 56,
      "scriptSig" : "",
      "sequence" : 4294967295,
      "error" : "Opcode missing or not understood"
    }
  ]
}
```

The field `"errors"` is currently omitted, if no script verification error occured.

Unfortunally not all error descriptions are intuitive, for example, when partially signing a script-hash transaction results in the message `"Operation not valid with the current stack size"`, but addressing this seemed out of scope of this PR.