### PR TITLE
Enable P2SH in send dialog

### DIFF
--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -179,7 +179,6 @@ void SendMPDialog::updateProperty()
         }
         if (!includeAddress) continue; //ignore this address, has never transacted in this propertyId
         if (!IsMyAddress(address)) continue; //ignore this address, it's not ours
-        if ((address.substr(0,1)=="2") || (address.substr(0,3)=="3")) continue; //quick hack to not show P2SH addresses in from selector (can't be sent from UI)
         ui->sendFromComboBox->addItem(QString::fromStdString(address + " \t" + FormatMP(propertyId, getUserAvailableMPbalance(address, propertyId)) + getTokenLabel(propertyId)));
     }
 


### PR DESCRIPTION
Omni Core is able to handle P2SH, and it doesn't require any special treatment.

Sending via the UI, and in particular the "send dialog" is supported and works fine. (tested)

This is basically the missing piece, because the overview, balance view, and the transaction history already show/include P2SH related items.