### PR TITLE
Increase efficiency of OmniJ RPC tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,11 @@ matrix:
     - compiler: ": 64-bit"
       env: HOST=x86_64-unknown-linux-gnu RUN_OMNIJ_TESTS=true RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
     - compiler: ": Win64"
-      env: HOST=x86_64-w64-mingw32 GOAL="install" BITCOIN_CONFIG="--enable-gui" MAKEJOBS="-j2"
+      env: HOST=x86_64-w64-mingw32 GOAL="deploy" BITCOIN_CONFIG="--enable-gui" MAKEJOBS="-j2"
       addons:
         apt:
           packages:
+            - nsis
             - gcc-mingw-w64-x86-64
             - g++-mingw-w64-x86-64
             - binutils-mingw-w64-x86-64

--- a/qa/pull-tester/omnicore-rpc-tests.sh
+++ b/qa/pull-tester/omnicore-rpc-tests.sh
@@ -16,7 +16,7 @@ touch "$DATADIR/regtest/omnicore.log"
 cd $TESTDIR
 echo "Omni Core RPC test dir: "$TESTDIR
 echo "Last OmniJ commit: "$(git log -n 1 --format="%H Author: %cn <%ce>")
-$REAL_BITCOIND -regtest -txindex -server -daemon -rpcuser=bitcoinrpc -rpcpassword=pass -discover=0 -listen=0 -datadir="$DATADIR"
+$REAL_BITCOIND -regtest -txindex -server -daemon -rpcuser=bitcoinrpc -rpcpassword=pass -debug=1 -omnidebug=all -omnialertallowsender=any -discover=0 -listen=0 -datadir="$DATADIR"
 $REAL_BITCOINCLI -regtest -rpcuser=bitcoinrpc -rpcpassword=pass -rpcwait getinfo
 $REAL_BITCOINCLI -regtest -rpcuser=bitcoinrpc -rpcpassword=pass -rpcwait getinfo_MP
 ./gradlew --console plain :omnij-rpc:regTest

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -189,6 +189,7 @@ Value setgenerate(const Array& params, bool fHelp)
             ++nHeight;
             blockHashes.push_back(pblock->GetHash().GetHex());
         }
+        reservekey.KeepKey();
         return blockHashes;
     }
     else // Not -regtest: start generate thread, return immediately


### PR DESCRIPTION
Somewhere in Bitcoin Core 0.9 the mining code was changed, and the key used for newly generated blocks was no longer removed from the keypool. This has performance implications, because until then a new key was generated, when mining regtest blocks. However, this has a significant downside: when mining blocks in regtest mode, and then getting a new key via `"getnewaddress"`, the new key may not be unused, but already received coins.

This is very undesired, and directly messes with some RPC tests, depending on the order of how they are exectued. The change is safe, and simply restores earlier behavior of Bitcoin Core.

I've benchmarked it's impact, and in practise it's performance impliciations are acceptable in my opinion, and the delay is within the range of a few seconds (from 2:00 to 2:10 min on my machine).

This resolves https://github.com/OmniLayer/OmniJ/issues/85.

---

Wrong use of log format specifiers can result in compiler warnings, or worse, in segfaults.

Running tests with all enabled debug information therefore seems reasonable.

---

Accepting any address as alert source, when running the RPC tests, allows testing of the alert system.

---

The package `nsis` was not available for the container based infrastructure of Travis CI until some time ago, but since it is now, it can be used to test the generation of install packages on Windows x64 during the automated testing.

Thanks to @theuni by the way, for creating the whitelist request .. :)