### PR TITLE
Format, document and add aggregation methods to CMPTally

### DIFF
--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -13,7 +13,8 @@ OMNICORE_TEST_CPP = \
   omnicore/test/script_extraction_tests.cpp \
   omnicore/test/script_solver_tests.cpp \
   omnicore/test/strtoint64_tests.cpp \
-  omnicore/test/swapbyteorder_tests.cpp
+  omnicore/test/swapbyteorder_tests.cpp \
+  omnicore/test/tally_tests.cpp
 
 BITCOIN_TESTS += \
   $(OMNICORE_TEST_CPP) \

--- a/src/omnicore/encoding.cpp
+++ b/src/omnicore/encoding.cpp
@@ -25,8 +25,8 @@
 bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& redeemingPubKey,
         const std::vector<unsigned char>& vchPayload, std::vector<std::pair<CScript, int64_t> >& vecOutputs)
 {
-    int nRemainingBytes = vchPayload.size();
-    int nNextByte = 0;
+    unsigned int nRemainingBytes = vchPayload.size();
+    unsigned int nNextByte = 0;
     unsigned char chSeqNum = 1;
     std::string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
     PrepareObfuscatedHashes(senderAddress, strObfuscatedHashes);
@@ -37,7 +37,7 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
         vKeys.push_back(redeemingPubKey); // Always include the redeeming pubkey
         for (int i = 0; i < nKeys; i++) {
             // Add up to 30 bytes of data
-            int nCurrentBytes = nRemainingBytes < (PACKET_SIZE - 1) ? nRemainingBytes: (PACKET_SIZE - 1);
+            unsigned int nCurrentBytes = nRemainingBytes < (PACKET_SIZE - 1) ? nRemainingBytes: (PACKET_SIZE - 1);
             std::vector<unsigned char> vchFakeKey;
             vchFakeKey.insert(vchFakeKey.end(), chSeqNum); // Add sequence number
             vchFakeKey.insert(vchFakeKey.end(), vchPayload.begin() + nNextByte,
@@ -46,7 +46,7 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
             nNextByte += nCurrentBytes;
             nRemainingBytes -= nCurrentBytes;
             std::vector<unsigned char> vchHash = ParseHex(strObfuscatedHashes[chSeqNum]);
-            for (int j = 0; j < PACKET_SIZE; j++) { // Xor in the obfuscation
+            for (size_t j = 0; j < PACKET_SIZE; j++) { // Xor in the obfuscation
                 vchFakeKey[j] = vchFakeKey[j] ^ vchHash[j];
             }
             vchFakeKey.insert(vchFakeKey.begin(), 0x02); // Prepend a public key prefix

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -356,7 +356,7 @@ rational_t CMPMetaDEx::inversePrice() const
     return inversePrice;
 }
 
-uint64_t CMPMetaDEx::getBlockTime() const
+int64_t CMPMetaDEx::getBlockTime() const
 {
     CBlockIndex* pblockindex = chainActive[block];
     return pblockindex->GetBlockTime();

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -64,7 +64,7 @@ public:
     int getBlock() const { return block; }
     unsigned int getIdx() const { return idx; }
 
-    uint64_t getBlockTime() const;
+    int64_t getBlockTime() const;
 
     // needed only by the RPC functions
     // needed only by the RPC functions

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -221,7 +221,7 @@ public:
     /** Updates the number of tokens for the given tally type. */
     bool updateMoney(uint32_t propertyId, int64_t amount, TallyType ttype)
     {
-        if (TALLY_TYPE_COUNT <= ttype) {
+        if (TALLY_TYPE_COUNT <= ttype || amount == 0) {
             return false;
         }
         bool bRet = false;

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -164,132 +164,218 @@ int64_t feeCheck(const string &address);
 /** Returns the Exodus address. */
 const CBitcoinAddress ExodusAddress();
 
-/** Used to indicate, whether to automatically commit created transactions. */
+//! Used to indicate, whether to automatically commit created transactions
 extern bool autoCommit;
 
+//! Global lock for state objects
 extern CCriticalSection cs_tally;
 
+//! Balance record types
 enum TallyType { BALANCE = 0, SELLOFFER_RESERVE = 1, ACCEPT_RESERVE = 2, PENDING = 3, METADEX_RESERVE = 4, TALLY_TYPE_COUNT };
 
+/** Balance records of a single entity.
+ */
 class CMPTally
 {
 private:
-typedef struct
-{
-  int64_t balance[TALLY_TYPE_COUNT];
-} BalanceRecord;
+    typedef struct {
+        int64_t balance[TALLY_TYPE_COUNT];
+    } BalanceRecord;
 
-  typedef std::map<unsigned int, BalanceRecord> TokenMap;
-  TokenMap mp_token;
-  TokenMap::iterator my_it;
+    //! Map of balance records
+    typedef std::map<uint32_t, BalanceRecord> TokenMap;
+    //! Balance records for different tokens
+    TokenMap mp_token;
+    //! Internal iterator pointing to a balance record
+    TokenMap::iterator my_it;
 
-  bool propertyExists(unsigned int which_property) const
-  {
-  const TokenMap::const_iterator it = mp_token.find(which_property);
-
-    return (it != mp_token.end());
-  }
+    // TODO: lock outside of CMPTally
+    //
+    // There are usually many tally operations, and the
+    // global tally map must be locked anyway, so locking
+    // here is redundant and might be costly.
 
 public:
-
-  unsigned int init()
-  {
-  unsigned int ret = 0;
-
-    my_it = mp_token.begin();
-    if (my_it != mp_token.end()) ret = my_it->first;
-
-    return ret;
-  }
-
-  unsigned int next()
-  {
-  unsigned int ret;
-
-    if (my_it == mp_token.end()) return 0;
-
-    ret = my_it->first;
-
-    ++my_it;
-
-    return ret;
-  }
-
-  bool updateMoney(unsigned int which_property, int64_t amount, TallyType ttype)
-  {
-  bool bRet = false;
-  int64_t now64;
-
-    if (TALLY_TYPE_COUNT <= ttype) return false;
-
-    LOCK(cs_tally);
-
-    now64 = mp_token[which_property].balance[ttype];
-
-    if ((PENDING != ttype) && (0>(now64 + amount)))
+    /** Resets the internal iterator. */
+    uint32_t init()
     {
+        uint32_t ret = 0;
+        my_it = mp_token.begin();
+        if (my_it != mp_token.end()) {
+            ret = my_it->first;
+        }
+        return ret;
     }
-    else
+
+    /** Advances the internal iterator. */
+    uint32_t next()
     {
-      now64 += amount;
-      mp_token[which_property].balance[ttype] = now64;
-
-      bRet = true;
+        uint32_t ret = 0;
+        if (my_it != mp_token.end()) {
+            ret = my_it->first;
+            ++my_it;
+        }
+        return ret;
     }
 
-    return bRet;
-  }
-
-  // the constructor -- create an empty tally for an address
-  CMPTally()
-  {
-    my_it = mp_token.begin();
-  }
-
-  int64_t print(int which_property = OMNI_PROPERTY_MSC, bool bDivisible = true)
-  {
-  int64_t money = 0;
-  int64_t so_r = 0;
-  int64_t a_r = 0;
-  int64_t pending = 0;
-
-    if (propertyExists(which_property))
+    /** Updates the number of tokens for the given tally type. */
+    bool updateMoney(uint32_t propertyId, int64_t amount, TallyType ttype)
     {
-      money = mp_token[which_property].balance[BALANCE];
-      so_r = mp_token[which_property].balance[SELLOFFER_RESERVE];
-      a_r = mp_token[which_property].balance[ACCEPT_RESERVE];
-      pending = mp_token[which_property].balance[PENDING];
+        if (TALLY_TYPE_COUNT <= ttype) {
+            return false;
+        }
+        bool bRet = false;
+        int64_t now64 = 0;
+
+        LOCK(cs_tally);
+
+        now64 = mp_token[propertyId].balance[ttype];
+
+        if (PENDING != ttype && (now64 + amount) < 0) {
+            // NOTE:
+            // This check also serves as overflow protection!
+        } else {
+            now64 += amount;
+            mp_token[propertyId].balance[ttype] = now64;
+
+            bRet = true;
+        }
+
+        return bRet;
     }
 
-    if (bDivisible)
+    /** Creates an empty tally. */
+    CMPTally()
     {
-      PrintToConsole("%22s [SO_RESERVE= %22s , ACCEPT_RESERVE= %22s ] %22s\n",
-       FormatDivisibleMP(money, true), FormatDivisibleMP(so_r, true), FormatDivisibleMP(a_r, true), FormatDivisibleMP(pending, true));
+        my_it = mp_token.begin();
     }
-    else
+
+    /** Returns the number of tokens for the given tally type. */
+    int64_t getMoney(uint32_t propertyId, TallyType ttype) const
     {
-      PrintToConsole("%14lu [SO_RESERVE= %14lu , ACCEPT_RESERVE= %14lu ] %14ld\n", money, so_r, a_r, pending);
+        if (TALLY_TYPE_COUNT <= ttype) {
+            return 0;
+        }
+        int64_t money = 0;
+
+        LOCK(cs_tally);
+        TokenMap::const_iterator it = mp_token.find(propertyId);
+
+        if (it != mp_token.end()) {
+            const BalanceRecord& record = it->second;
+            money = record.balance[ttype];
+        }
+
+        return money;
     }
 
-    return (money + so_r + a_r);
-  }
+    /** Returns the number of available tokens. */
+    int64_t getMoneyAvailable(uint32_t propertyId) const
+    {
+        LOCK(cs_tally);
+        TokenMap::const_iterator it = mp_token.find(propertyId);
 
-  int64_t getMoney(unsigned int which_property, TallyType ttype) const
-  {
-    if (TALLY_TYPE_COUNT <= ttype) return 0;
+        if (it != mp_token.end()) {
+            const BalanceRecord& record = it->second;
+            if (record.balance[PENDING] < 0) {
+                return record.balance[BALANCE] + record.balance[PENDING];
+            } else {
+                return record.balance[BALANCE];
+            }
+        }
 
-    int64_t money = 0;
-
-    LOCK(cs_tally);
-    TokenMap::const_iterator it = mp_token.find(which_property);
-
-    if (it != mp_token.end()) {
-        const BalanceRecord& record = it->second;
-        money = record.balance[ttype];
+        return 0;
     }
 
-    return money;
-  }
+    /** Returns the number of reserved tokens. */
+    int64_t getMoneyReserved(uint32_t propertyId) const
+    {
+        int64_t money = 0;
+
+        LOCK(cs_tally);
+        TokenMap::const_iterator it = mp_token.find(propertyId);
+
+        if (it != mp_token.end()) {
+            const BalanceRecord& record = it->second;
+            money += record.balance[SELLOFFER_RESERVE];
+            money += record.balance[ACCEPT_RESERVE];
+            money += record.balance[METADEX_RESERVE];
+        }
+
+        return money;
+    }
+
+    /** Compares the tally with another tally and returns true, if they are equal. */
+    bool operator==(const CMPTally& rhs) const
+    {
+        LOCK(cs_tally);
+
+        if (mp_token.size() != rhs.mp_token.size()) {
+            return false;
+        }
+        TokenMap::const_iterator pc1 = mp_token.begin();
+        TokenMap::const_iterator pc2 = rhs.mp_token.begin();
+
+        for (unsigned int i = 0; i < mp_token.size(); ++i) {
+            if (pc1->first != pc2->first) {
+                return false;
+            }
+            const BalanceRecord& record1 = pc1->second;
+            const BalanceRecord& record2 = pc2->second;
+
+            for (int ttype = 0; ttype < TALLY_TYPE_COUNT; ++ttype) {
+                if (record1.balance[ttype] != record2.balance[ttype]) {
+                    return false;
+                }
+            }
+            ++pc1;
+            ++pc2;
+        }
+
+        assert(pc1 == mp_token.end());
+        assert(pc2 == rhs.mp_token.end());
+
+        return true;
+    }
+
+    /** Compares the tally with another tally and returns true, if they are not equal. */
+    bool operator!=(const CMPTally& rhs) const
+    {
+        return !operator==(rhs);
+    }
+
+    /** Prints a balance record to the console. */
+    int64_t print(uint32_t propertyId = OMNI_PROPERTY_MSC, bool bDivisible = true) const
+    {
+        int64_t balance = 0;
+        int64_t selloffer_reserve = 0;
+        int64_t accept_reserve = 0;
+        int64_t pending = 0;
+        int64_t metadex_reserve = 0;
+
+        TokenMap::const_iterator it = mp_token.find(propertyId);
+
+        if (it != mp_token.end()) {
+            const BalanceRecord& record = it->second;
+            balance = record.balance[BALANCE];
+            selloffer_reserve = record.balance[SELLOFFER_RESERVE];
+            accept_reserve = record.balance[ACCEPT_RESERVE];
+            pending = record.balance[PENDING];
+            metadex_reserve = record.balance[METADEX_RESERVE];
+        }
+
+        if (bDivisible) {
+            PrintToConsole("%22s [ SO_RESERVE= %22s, ACCEPT_RESERVE= %22s, METADEX_RESERVE= %22s ] %22s\n",
+                    FormatDivisibleMP(balance, true), FormatDivisibleMP(selloffer_reserve, true),
+                    FormatDivisibleMP(accept_reserve, true), FormatDivisibleMP(metadex_reserve, true),
+                    FormatDivisibleMP(pending, true));
+        } else {
+            PrintToConsole("%14d [ SO_RESERVE= %14d, ACCEPT_RESERVE= %14d, METADEX_RESERVE= %14d ] %14d\n",
+                    balance, selloffer_reserve, accept_reserve, metadex_reserve, pending);
+        }
+
+        return (balance + selloffer_reserve + accept_reserve + metadex_reserve);
+    }
 };
 
 /** LevelDB based storage for STO recipients.

--- a/src/omnicore/pending.h
+++ b/src/omnicore/pending.h
@@ -2,7 +2,7 @@
 #define OMNICORE_PENDING_H
 
 class uint256;
-class CMPPending;
+struct CMPPending;
 
 #include <stdint.h>
 #include <map>

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -786,7 +786,7 @@ Value getgrants_MP(const Array& params, bool fHelp)
 int check_prop_valid(int64_t tmpPropId, string error, string exist_error ) {
   CMPSPInfo::Entry sp;
 
-  if ((1 > tmpPropId) || (4294967295 < tmpPropId)) 
+  if ((1 > tmpPropId) || (4294967295LL < tmpPropId))
     throw JSONRPCError(RPC_INVALID_PARAMETER, error);
   if (false == _my_sps->getSP(tmpPropId, sp)) 
     throw JSONRPCError(RPC_INVALID_PARAMETER, exist_error);
@@ -861,7 +861,7 @@ Value gettradessince_MP(const Array& params, bool fHelp)
 
   unsigned int propertyIdSaleFilter = 0, propertyIdWantFilter = 0;
 
-  uint64_t timestamp = (params.size() > 0) ? params[0].get_int64() : GetLatestBlockTime() - 1209600; //2 weeks 
+  int64_t timestamp = (params.size() > 0) ? params[0].get_int64() : GetLatestBlockTime() - 1209600; // 2 weeks
 
   bool filter_by_one = (params.size() > 1) ? true : false;
   bool filter_by_both = (params.size() > 2) ? true : false;

--- a/src/omnicore/rpcvalues.cpp
+++ b/src/omnicore/rpcvalues.cpp
@@ -23,7 +23,7 @@ std::string ParseAddress(const json_spirit::Value& value)
 uint32_t ParsePropertyId(const json_spirit::Value& value)
 {
     int64_t propertyId = value.get_int64();
-    if (propertyId < 1 || 4294967295 < propertyId) {
+    if (propertyId < 1 || 4294967295LL < propertyId) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier is out of range");
     }
     return static_cast<uint32_t>(propertyId);

--- a/src/omnicore/test/alert_tests.cpp
+++ b/src/omnicore/test/alert_tests.cpp
@@ -139,11 +139,11 @@ BOOST_AUTO_TEST_CASE(alert_expiration_by_timestamp)
     BOOST_CHECK_EQUAL(GetOmniCoreAlertString(), testAlertRaw);
     BOOST_CHECK_EQUAL(GetOmniCoreAlertTextOnly(), testAlertMessage);
     BOOST_CHECK(!CheckExpiredAlerts(0, 0));
-    BOOST_CHECK(!CheckExpiredAlerts(2147483648, 0));
-    BOOST_CHECK(!CheckExpiredAlerts(350000, 2147483648));
+    BOOST_CHECK(!CheckExpiredAlerts(2147483648U, 0));
+    BOOST_CHECK(!CheckExpiredAlerts(350000, 2147483648U));
 
     // Expire the the alert
-    BOOST_CHECK(CheckExpiredAlerts(350001, 2147483649));
+    BOOST_CHECK(CheckExpiredAlerts(350001, 2147483649U));
     BOOST_CHECK(GetOmniCoreAlertString().empty());
     BOOST_CHECK(GetOmniCoreAlertTextOnly().empty());
 }

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(payload_create_crowdsale)
         std::string(""),                     // additional information
         static_cast<uint32_t>(1),            // property desired: MSC
         static_cast<int64_t>(100),           // tokens per unit vested
-        static_cast<uint64_t>(7731414000),   // deadline: 31 Dec 2214 23:00:00 UTC
+        static_cast<uint64_t>(7731414000L),  // deadline: 31 Dec 2214 23:00:00 UTC
         static_cast<uint8_t>(10),            // early bird bonus: 10 % per week
         static_cast<uint8_t>(12));           // issuer bonus: 12 %
 
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(payload_create_crowdsale_empty)
         std::string(""),                    // additional information
         static_cast<uint32_t>(1),           // property desired: MSC
         static_cast<int64_t>(100),          // tokens per unit vested
-        static_cast<uint64_t>(7731414000),  // deadline: 31 Dec 2214 23:00:00 UTC
+        static_cast<uint64_t>(7731414000L), // deadline: 31 Dec 2214 23:00:00 UTC
         static_cast<uint8_t>(10),           // early bird bonus: 10 % per week
         static_cast<uint8_t>(12));          // issuer bonus: 12 %
 
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(payload_create_crowdsale_full)
         std::string(700, 'x'),              // additional information
         static_cast<uint32_t>(1),           // property desired: MSC
         static_cast<int64_t>(100),          // tokens per unit vested
-        static_cast<uint64_t>(7731414000),  // deadline: 31 Dec 2214 23:00:00 UTC
+        static_cast<uint64_t>(7731414000L), // deadline: 31 Dec 2214 23:00:00 UTC
         static_cast<uint8_t>(10),           // early bird bonus: 10 % per week
         static_cast<uint8_t>(12));          // issuer bonus: 12 %
 

--- a/src/omnicore/test/rpc_requirements_tests.cpp
+++ b/src/omnicore/test/rpc_requirements_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(rpcrequirements_universal)
     BOOST_CHECK_NO_THROW(RequireExistingProperty(2));
     BOOST_CHECK_NO_THROW(RequireSameEcosystem(0, 0));
     BOOST_CHECK_NO_THROW(RequireSameEcosystem(1, 3));
-    BOOST_CHECK_NO_THROW(RequireSameEcosystem(3221225476, 2));
+    BOOST_CHECK_NO_THROW(RequireSameEcosystem(3221225476U, 2));
     BOOST_CHECK_NO_THROW(RequireDifferentIds(100000, 100001));
     BOOST_CHECK_NO_THROW(RequireNoOtherDExOffer("137uFtQ5EgMsreg4FVvL3xuhjkYGToVPqs", 1));
     BOOST_CHECK_NO_THROW(RequireNoOtherDExOffer("332r9K9t581aGVyzMK8uoPQr7ieH26u6J3", 2));
@@ -40,27 +40,27 @@ BOOST_AUTO_TEST_CASE(rpcrequirements_universal_failure)
     // no previous transactions.
     // Some of the checks fail for unrelated reasons, such as the DEx payment window or the
     // fee check: the offers don't exist, which also raises exceptions.
-    BOOST_CHECK_THROW(RequireBalance("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P", 2, int64_t(9223372036854775807)), Object);
+    BOOST_CHECK_THROW(RequireBalance("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P", 2, int64_t(9223372036854775807LL)), Object);
     BOOST_CHECK_THROW(RequirePrimaryToken(0), Object);
     BOOST_CHECK_THROW(RequirePrimaryToken(31), Object);
     BOOST_CHECK_THROW(RequirePropertyName(""), Object);
     BOOST_CHECK_THROW(RequireExistingProperty(uint32_t(2147483647)), Object); // last main identifier that may be created
-    BOOST_CHECK_THROW(RequireExistingProperty(uint32_t(4294967295)), Object); // last test identifier that may be created
-    BOOST_CHECK_THROW(RequireSameEcosystem(2147483650, 4294967295), Object);
-    BOOST_CHECK_THROW(RequireDifferentIds(4200000000, 4200000000), Object);
+    BOOST_CHECK_THROW(RequireExistingProperty(uint32_t(4294967295U)), Object); // last test identifier that may be created
+    BOOST_CHECK_THROW(RequireSameEcosystem(2147483650U, 4294967295U), Object);
+    BOOST_CHECK_THROW(RequireDifferentIds(4200000000U, 4200000000U), Object);
     BOOST_CHECK_THROW(RequireCrowdsale(uint32_t(2147483647)), Object);
-    BOOST_CHECK_THROW(RequireCrowdsale(uint32_t(4294967295)), Object);
+    BOOST_CHECK_THROW(RequireCrowdsale(uint32_t(4294967295U)), Object);
     BOOST_CHECK_THROW(RequireActiveCrowdsale(uint32_t(2147483647)), Object);
-    BOOST_CHECK_THROW(RequireActiveCrowdsale(uint32_t(4294967295)), Object);
+    BOOST_CHECK_THROW(RequireActiveCrowdsale(uint32_t(4294967295U)), Object);
     BOOST_CHECK_THROW(RequireManagedProperty(uint32_t(2147483647)), Object);
-    BOOST_CHECK_THROW(RequireManagedProperty(uint32_t(4294967295)), Object);
+    BOOST_CHECK_THROW(RequireManagedProperty(uint32_t(4294967295U)), Object);
     BOOST_CHECK_THROW(RequireTokenIssuer("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint32_t(2147483647)), Object);
     BOOST_CHECK_THROW(RequireSaneDExPaymentWindow("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint32_t(2147483647)), Object);
     BOOST_CHECK_THROW(RequireSaneDExFee("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint32_t(2147483647)), Object);
     BOOST_CHECK_THROW(RequireMatchingDExOffer("36fKL6YuaCKkWDkh4gce2E3PsucmDEyrR9", 3), Object);
     BOOST_CHECK_THROW(RequireMatchingDExOffer("1388enJtLbowR6LRQQUTjptWuChirfrhza", 7), Object);
     BOOST_CHECK_THROW(RequireSaneReferenceAmount(1000001), Object);
-    BOOST_CHECK_THROW(RequireSaneReferenceAmount(int64_t(210000000000000)), Object);
+    BOOST_CHECK_THROW(RequireSaneReferenceAmount(int64_t(210000000000000L)), Object);
     BOOST_CHECK_THROW(RequireHeightInChain(-1), Object);
     BOOST_CHECK_THROW(RequireHeightInChain(std::numeric_limits<int>::max()), Object);
 }

--- a/src/omnicore/test/rpc_value_tests.cpp
+++ b/src/omnicore/test/rpc_value_tests.cpp
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE(rpcvalues_property_id)
     // Valid input
     BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("1")), uint32_t(1));
     BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("31")), uint32_t(31));
-    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("2147483651")), uint32_t(2147483651));
-    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("4294967295")), uint32_t(4294967295));
+    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("2147483651")), uint32_t(2147483651U));
+    BOOST_CHECK_EQUAL(ParsePropertyId(ValueFromString("4294967295")), uint32_t(4294967295U));
     // Out of range
     BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("0")), Object);
     BOOST_CHECK_THROW(ParsePropertyId(ValueFromString("4294967296")), Object);
@@ -66,8 +66,8 @@ BOOST_AUTO_TEST_CASE(rpcvalues_indivisible_amounts)
     // Valid input
     BOOST_CHECK_EQUAL(ParseAmount(Value("1"), false), int64_t(1));
     BOOST_CHECK_EQUAL(ParseAmount(Value("100000000"), false), int64_t(100000000));
-    BOOST_CHECK_EQUAL(ParseAmount(Value("2147483651"), false), int64_t(2147483651));
-    BOOST_CHECK_EQUAL(ParseAmount(Value("9223372036854775807"), false), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("2147483651"), false), int64_t(2147483651LL));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("9223372036854775807"), false), int64_t(9223372036854775807LL));
     // Out of range
     BOOST_CHECK_THROW(ParseAmount(Value("0"), false), Object);
     BOOST_CHECK_THROW(ParseAmount(Value("-2"), false), Object);
@@ -89,10 +89,10 @@ BOOST_AUTO_TEST_CASE(rpcvalues_divisible_amounts)
     // Valid input
     BOOST_CHECK_EQUAL(ParseAmount(Value("0.00000001"), true), int64_t(1));
     BOOST_CHECK_EQUAL(ParseAmount(Value("1"), true), int64_t(100000000));
-    BOOST_CHECK_EQUAL(ParseAmount(Value("55555.555555"), true), int64_t(5555555555500));
-    BOOST_CHECK_EQUAL(ParseAmount(Value("21000000.0"), true), int64_t(2100000000000000));
-    BOOST_CHECK_EQUAL(ParseAmount(Value("21000000.00000009"), true), int64_t(2100000000000009));
-    BOOST_CHECK_EQUAL(ParseAmount(Value("92233720368.54775807"), true), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("55555.555555"), true), int64_t(5555555555500L));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("21000000.0"), true), int64_t(2100000000000000L));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("21000000.00000009"), true), int64_t(2100000000000009L));
+    BOOST_CHECK_EQUAL(ParseAmount(Value("92233720368.54775807"), true), int64_t(9223372036854775807LL));
     // Out of range
     BOOST_CHECK_THROW(ParseAmount(Value("0"), true), Object);
     BOOST_CHECK_THROW(ParseAmount(Value("0.000000001"), true), Object);
@@ -143,8 +143,8 @@ BOOST_AUTO_TEST_CASE(rpcvalues_dex_fee)
     BOOST_CHECK_EQUAL(ParseDExFee(Value("0")), int64_t(0));
     BOOST_CHECK_EQUAL(ParseDExFee(Value("0.00000")), int64_t(0));
     BOOST_CHECK_EQUAL(ParseDExFee(Value("0.00000001")), int64_t(1));
-    BOOST_CHECK_EQUAL(ParseDExFee(Value("777")), int64_t(77700000000));
-    BOOST_CHECK_EQUAL(ParseDExFee(Value("92233720368.54772323")), int64_t(9223372036854772323));
+    BOOST_CHECK_EQUAL(ParseDExFee(Value("777")), int64_t(77700000000L));
+    BOOST_CHECK_EQUAL(ParseDExFee(Value("92233720368.54772323")), int64_t(9223372036854772323L));
     // Invalid types
     BOOST_CHECK_THROW(ParseDExFee(Value()), std::runtime_error);
     BOOST_CHECK_THROW(ParseDExFee(ValueFromString("3")), std::runtime_error);
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(rpcvalues_deadline)
 {
     // Valid input
     BOOST_CHECK_EQUAL(ParseDeadline(ValueFromString("1231006505")), int64_t(1231006505));
-    BOOST_CHECK_EQUAL(ParseDeadline(ValueFromString("2147483648")), int64_t(2147483648));
+    BOOST_CHECK_EQUAL(ParseDeadline(ValueFromString("2147483648")), int64_t(2147483648LL));
     // Out of range
     BOOST_CHECK_THROW(ParseDeadline(ValueFromString("-1")), Object);
     BOOST_CHECK_THROW(ParseDeadline(ValueFromString("-2342342342434562345")), Object);

--- a/src/omnicore/test/strtoint64_tests.cpp
+++ b/src/omnicore/test/strtoint64_tests.cpp
@@ -14,9 +14,9 @@ BOOST_AUTO_TEST_CASE(strtoint64_invidisible)
     // zero amount
     BOOST_CHECK(StrToInt64("0", false) == 0);
     // big num
-    BOOST_CHECK(StrToInt64("4000000000000000", false) == static_cast<int64_t>(4000000000000000U));
+    BOOST_CHECK(StrToInt64("4000000000000000", false) == static_cast<int64_t>(4000000000000000LL));
     // max int64
-    BOOST_CHECK(StrToInt64("9223372036854775807", false) == static_cast<int64_t>(9223372036854775807U));
+    BOOST_CHECK(StrToInt64("9223372036854775807", false) == static_cast<int64_t>(9223372036854775807LL));
 }
 
 BOOST_AUTO_TEST_CASE(strtoint64_invidisible_truncate)
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(strtoint64_divisible)
 {
     // range 0 to max int64
     BOOST_CHECK(StrToInt64("0.000", true) == 0);    
-    BOOST_CHECK(StrToInt64("92233720368.54775807", true) == static_cast<int64_t>(9223372036854775807U));
+    BOOST_CHECK(StrToInt64("92233720368.54775807", true) == static_cast<int64_t>(9223372036854775807LL));
     // check padding
     BOOST_CHECK(StrToInt64("0.00000004", true) == 4);
     BOOST_CHECK(StrToInt64("0.0000004", true) == 40);
@@ -49,16 +49,16 @@ BOOST_AUTO_TEST_CASE(strtoint64_divisible)
     BOOST_CHECK(StrToInt64("0.4", true) == 40000000);
     BOOST_CHECK(StrToInt64("4.0", true) == 400000000);    
     // truncate after 8 digits
-    BOOST_CHECK(StrToInt64("40.00000000000099", true) == static_cast<int64_t>(4000000000U));
-    BOOST_CHECK(StrToInt64("92233720368.54775807000", true) == static_cast<int64_t>(9223372036854775807U));
+    BOOST_CHECK(StrToInt64("40.00000000000099", true) == static_cast<int64_t>(4000000000LL));
+    BOOST_CHECK(StrToInt64("92233720368.54775807000", true) == static_cast<int64_t>(9223372036854775807LL));
 }
 
 BOOST_AUTO_TEST_CASE(strtoint64_divisible_truncate)
 {
     // truncate after 8 digits
-    BOOST_CHECK(StrToInt64("40.00000000000099", true) == static_cast<int64_t>(4000000000U));
-    BOOST_CHECK(StrToInt64("92233720368.54775807000", true) == static_cast<int64_t>(9223372036854775807U));
-    BOOST_CHECK(StrToInt64("92233720368.54775807000", true) == static_cast<int64_t>(9223372036854775807U));
+    BOOST_CHECK(StrToInt64("40.00000000000099", true) == static_cast<int64_t>(4000000000LL));
+    BOOST_CHECK(StrToInt64("92233720368.54775807000", true) == static_cast<int64_t>(9223372036854775807LL));
+    BOOST_CHECK(StrToInt64("92233720368.54775807000", true) == static_cast<int64_t>(9223372036854775807LL));
 }
 
 BOOST_AUTO_TEST_CASE(strtoint64_divisible_invalid)

--- a/src/omnicore/test/tally_tests.cpp
+++ b/src/omnicore/test/tally_tests.cpp
@@ -1,0 +1,322 @@
+#include "omnicore/omnicore.h"
+
+#include <stdint.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_tally_tests)
+
+BOOST_AUTO_TEST_CASE(empty_tally)
+{
+    CMPTally tally;
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, BALANCE));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, SELLOFFER_RESERVE));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, ACCEPT_RESERVE));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, PENDING));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, METADEX_RESERVE));
+    // TallyType out of range:
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, static_cast<TallyType>(5)));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, static_cast<TallyType>(6)));
+    // TallyType out of range:
+    BOOST_CHECK(!tally.updateMoney(0, 1, static_cast<TallyType>(5)));
+    BOOST_CHECK(!tally.updateMoney(0, 1, static_cast<TallyType>(6)));
+
+    BOOST_CHECK_EQUAL(0, tally.init());
+    BOOST_CHECK_EQUAL(0, tally.next());
+
+    BOOST_CHECK_EQUAL(0, tally.getMoneyAvailable(0));
+    BOOST_CHECK_EQUAL(0, tally.getMoneyReserved(0));
+    BOOST_CHECK_EQUAL(0, tally.getMoneyAvailable(55));
+    BOOST_CHECK_EQUAL(0, tally.getMoneyReserved(55));
+}
+
+BOOST_AUTO_TEST_CASE(filled_tally)
+{
+    CMPTally tally;
+    BOOST_CHECK(tally.updateMoney(0, 0, BALANCE));
+    BOOST_CHECK(tally.updateMoney(0, 0, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(0, 0, ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(0, 0, PENDING));
+    BOOST_CHECK(tally.updateMoney(0, 0, METADEX_RESERVE));
+
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, BALANCE));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, SELLOFFER_RESERVE));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, ACCEPT_RESERVE));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, PENDING));
+    BOOST_CHECK_EQUAL(0, tally.getMoney(0, METADEX_RESERVE));
+
+    BOOST_CHECK_EQUAL(0, tally.getMoneyAvailable(0));
+    BOOST_CHECK_EQUAL(0, tally.getMoneyReserved(0));
+
+    BOOST_CHECK(tally.updateMoney(0, 1, BALANCE));
+    BOOST_CHECK(tally.updateMoney(0, 100, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807), ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(2, (-int64_t(9223372036854775807)-1), PENDING));
+    BOOST_CHECK(tally.updateMoney(5, int64_t(4294967296), METADEX_RESERVE));
+
+    BOOST_CHECK_EQUAL(tally.getMoney(0, BALANCE), 1);
+    BOOST_CHECK_EQUAL(tally.getMoney(0, SELLOFFER_RESERVE), 100);
+    BOOST_CHECK_EQUAL(tally.getMoney(0, ACCEPT_RESERVE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(0, PENDING), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(0, METADEX_RESERVE), 0);
+
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(0), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(0), 100);
+    
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(1, SELLOFFER_RESERVE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(1, ACCEPT_RESERVE), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(1, METADEX_RESERVE), 0);
+
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), int64_t(9223372036854775807));
+
+    BOOST_CHECK_EQUAL(tally.getMoney(2, BALANCE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(2, SELLOFFER_RESERVE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(2, ACCEPT_RESERVE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(2, PENDING), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK_EQUAL(tally.getMoney(2, METADEX_RESERVE), 0);
+
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(2), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), 0);
+
+    BOOST_CHECK_EQUAL(tally.getMoney(5, BALANCE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(5, SELLOFFER_RESERVE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(5, ACCEPT_RESERVE), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(5, PENDING), 0);
+    BOOST_CHECK_EQUAL(tally.getMoney(5, METADEX_RESERVE), int64_t(4294967296));
+
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(5), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(5), int64_t(4294967296));
+
+    /**
+     * Note:
+     * The internal iterator must be replaced via init(),
+     * after inserting a new entry via updateMoney().
+     */
+    BOOST_CHECK_EQUAL(0, tally.init());
+    BOOST_CHECK_EQUAL(0, tally.next());
+    BOOST_CHECK_EQUAL(1, tally.next());
+    BOOST_CHECK_EQUAL(2, tally.next());
+    BOOST_CHECK_EQUAL(5, tally.next());
+    BOOST_CHECK_EQUAL(0, tally.init());
+    BOOST_CHECK_EQUAL(0, tally.next());
+    BOOST_CHECK_EQUAL(1, tally.next());
+}
+
+BOOST_AUTO_TEST_CASE(tally_entry_order)
+{
+    CMPTally tally;
+
+    BOOST_CHECK(tally.updateMoney(1, 1, BALANCE));
+    BOOST_CHECK(tally.updateMoney(4, 1, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(3, 1, ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(9, 1, BALANCE));
+    BOOST_CHECK(tally.updateMoney(2, -1, PENDING));
+    BOOST_CHECK(tally.updateMoney(5, 1, METADEX_RESERVE));
+    BOOST_CHECK(tally.updateMoney(9, 3, BALANCE));
+    BOOST_CHECK(tally.updateMoney(9, -6, PENDING));
+    BOOST_CHECK(tally.updateMoney(8, 1, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(7, 1, ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(6, 3, BALANCE));
+    BOOST_CHECK(tally.updateMoney(9, 1, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(9, 2, ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(9, 3, METADEX_RESERVE));
+    BOOST_CHECK(tally.updateMoney(9, 4, METADEX_RESERVE));
+    BOOST_CHECK(tally.updateMoney(8, 1, BALANCE));
+    BOOST_CHECK(tally.updateMoney(70, 1, BALANCE));
+    BOOST_CHECK(tally.updateMoney(4, 1, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(5, 1, BALANCE));
+    BOOST_CHECK(tally.updateMoney(1, 1, BALANCE));
+    BOOST_CHECK(tally.updateMoney(6, -2, PENDING));
+    BOOST_CHECK(tally.updateMoney(3, 1, ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(2, 1, METADEX_RESERVE));
+    BOOST_CHECK(tally.updateMoney(4, -1, PENDING));
+    BOOST_CHECK(tally.updateMoney(2, -1, PENDING));
+
+    BOOST_CHECK_EQUAL(1, tally.init());
+    // Begin iterations:
+    BOOST_CHECK_EQUAL(1, tally.next());
+    BOOST_CHECK_EQUAL(2, tally.next());
+    BOOST_CHECK_EQUAL(3, tally.next());
+    BOOST_CHECK_EQUAL(4, tally.next());
+    BOOST_CHECK_EQUAL(5, tally.next());
+    BOOST_CHECK_EQUAL(6, tally.next());
+    BOOST_CHECK_EQUAL(7, tally.next());
+    BOOST_CHECK_EQUAL(8, tally.next());
+    BOOST_CHECK_EQUAL(9, tally.next());
+    BOOST_CHECK_EQUAL(70, tally.next());
+    // End of tally reached:
+    BOOST_CHECK_EQUAL(0, tally.next());
+
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), 2);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(2), -2);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(3), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), 2);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(4), -1);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(4), 2);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(5), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(5), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(6), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(6), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(7), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(7), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(8), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(8), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(9), -2);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(9), 10);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(70), 1);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(70), 0);
+}
+
+BOOST_AUTO_TEST_CASE(tally_equality)
+{
+    CMPTally tally1;
+    CMPTally tally2;
+
+    BOOST_CHECK(tally1 == tally2);
+    BOOST_CHECK(tally2 == tally1);
+
+    BOOST_CHECK(tally1.updateMoney(4, 5, ACCEPT_RESERVE));
+    BOOST_CHECK(tally1.updateMoney(3, 3, METADEX_RESERVE));
+    BOOST_CHECK(tally1.updateMoney(3, 7, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally1.updateMoney(1, 5, BALANCE));
+    BOOST_CHECK(tally1.updateMoney(9, 4, BALANCE));
+    BOOST_CHECK(tally1.updateMoney(1, 50, BALANCE));
+    BOOST_CHECK(tally1.updateMoney(1, -3, BALANCE));
+    BOOST_CHECK(tally1.updateMoney(1, -3, PENDING));
+
+    BOOST_CHECK(tally2.updateMoney(3, 4, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally2.updateMoney(1, 20, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(4, 5, ACCEPT_RESERVE));
+    BOOST_CHECK(tally2.updateMoney(9, 4, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(3, 3, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally2.updateMoney(1, 5, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(3, 3, METADEX_RESERVE));
+    BOOST_CHECK(tally2.updateMoney(1, 5, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(1, 28, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(1, -6, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(1, -3, PENDING));
+
+    BOOST_CHECK(tally1 == tally2);
+    BOOST_CHECK(tally2 == tally1);
+
+    BOOST_CHECK(tally1.getMoneyAvailable(1) == tally2.getMoneyAvailable(1));
+    BOOST_CHECK(tally1.getMoneyAvailable(3) == tally2.getMoneyAvailable(3));
+    BOOST_CHECK(tally1.getMoneyAvailable(4) == tally2.getMoneyAvailable(4));
+    BOOST_CHECK(tally1.getMoneyAvailable(9) == tally2.getMoneyAvailable(9));
+    BOOST_CHECK(tally1.getMoneyAvailable(0) == tally2.getMoneyAvailable(0));
+
+    BOOST_CHECK(tally2.getMoneyReserved(1) == tally1.getMoneyReserved(1));
+    BOOST_CHECK(tally2.getMoneyReserved(3) == tally1.getMoneyReserved(3));
+    BOOST_CHECK(tally2.getMoneyReserved(4) == tally1.getMoneyReserved(4));
+    BOOST_CHECK(tally2.getMoneyReserved(9) == tally1.getMoneyReserved(9));
+    BOOST_CHECK(tally2.getMoneyReserved(0) == tally1.getMoneyReserved(0));
+
+    BOOST_CHECK_EQUAL(1, tally1.init());
+    BOOST_CHECK_EQUAL(1, tally1.next());
+    BOOST_CHECK_EQUAL(3, tally1.next());
+    BOOST_CHECK_EQUAL(4, tally1.next());
+    BOOST_CHECK_EQUAL(9, tally1.next());
+    BOOST_CHECK_EQUAL(0, tally1.next());
+    BOOST_CHECK_EQUAL(1, tally2.init());
+    BOOST_CHECK_EQUAL(1, tally2.next());
+    BOOST_CHECK_EQUAL(3, tally2.next());
+    BOOST_CHECK_EQUAL(4, tally2.next());
+
+    BOOST_CHECK(tally1 == tally2);
+
+    BOOST_CHECK(tally1.updateMoney(9, -2, BALANCE));
+    BOOST_CHECK(tally1.updateMoney(9, -2, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(9, -4, BALANCE));
+    BOOST_CHECK(tally1 == tally2);
+    BOOST_CHECK(tally1.getMoneyAvailable(9) == 0);
+
+    BOOST_CHECK(tally1.updateMoney(8, 3, METADEX_RESERVE));
+    BOOST_CHECK(tally1 != tally2);
+    BOOST_CHECK(tally1.getMoneyReserved(8) == 3);
+
+    BOOST_CHECK(tally2.updateMoney(8, 4, METADEX_RESERVE));
+    BOOST_CHECK(tally1 != tally2);
+    BOOST_CHECK(tally2.getMoneyReserved(8) == 4);
+
+    BOOST_CHECK(tally2.updateMoney(8, -1, METADEX_RESERVE));
+    BOOST_CHECK(tally1 == tally2);
+    BOOST_CHECK(tally1.getMoneyReserved(8) == 3);
+
+    BOOST_CHECK(tally1.updateMoney(7, 1, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(5, 1, BALANCE));
+    BOOST_CHECK(tally1 != tally2);
+
+    BOOST_CHECK(tally1.updateMoney(5, 1, BALANCE));
+    BOOST_CHECK(tally2.updateMoney(7, 1, BALANCE));
+    BOOST_CHECK(tally1 == tally2);
+
+    BOOST_CHECK(tally1.getMoneyAvailable(5) == 1);
+    BOOST_CHECK(tally1.getMoneyAvailable(7) == 1);
+    BOOST_CHECK(tally2.getMoneyAvailable(5) == 1);
+    BOOST_CHECK(tally2.getMoneyAvailable(7) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(tally_overflow)
+{
+    CMPTally tally;
+
+    BOOST_CHECK(!tally.updateMoney(1, -1, BALANCE));
+    BOOST_CHECK(!tally.updateMoney(2, -34242, SELLOFFER_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(2, (-int64_t(9223372036854775807)-1), ACCEPT_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(3, -int64_t(1099511627777), METADEX_RESERVE));
+
+    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807), BALANCE));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), int64_t(9223372036854775807));
+
+    BOOST_CHECK(!tally.updateMoney(1, 1, BALANCE));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), int64_t(9223372036854775807));
+
+    BOOST_CHECK(tally.updateMoney(1, (-int64_t(9223372036854775807)-1), PENDING));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), -1);
+/*  Not yet specified:
+    BOOST_CHECK(!tally.updateMoney(1, -1, PENDING));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), -1);
+*/
+    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807), ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(2, int64_t(9223372036854775807), SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(3, int64_t(9223372036854775807), SELLOFFER_RESERVE));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807));
+
+    BOOST_CHECK(!tally.updateMoney(3, int64_t(9223372036854775807), SELLOFFER_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(3, (-int64_t(9223372036854775807)-1), SELLOFFER_RESERVE));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807));
+
+    BOOST_CHECK(tally.updateMoney(1, -int64_t(9223372036854775807), ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(1, 10000001, ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(1, 20000001, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(1, 30000001, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(1, 40000001, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(1, 50000001, METADEX_RESERVE));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), 150000005);
+
+    BOOST_CHECK(!tally.updateMoney(1, 1, BALANCE));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), -1);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(2), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(3), 0);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), 150000005);
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/tally_tests.cpp
+++ b/src/omnicore/test/tally_tests.cpp
@@ -35,11 +35,11 @@ BOOST_AUTO_TEST_CASE(empty_tally)
 BOOST_AUTO_TEST_CASE(filled_tally)
 {
     CMPTally tally;
-    BOOST_CHECK(tally.updateMoney(0, 0, BALANCE));
-    BOOST_CHECK(tally.updateMoney(0, 0, SELLOFFER_RESERVE));
-    BOOST_CHECK(tally.updateMoney(0, 0, ACCEPT_RESERVE));
-    BOOST_CHECK(tally.updateMoney(0, 0, PENDING));
-    BOOST_CHECK(tally.updateMoney(0, 0, METADEX_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(0, 0, BALANCE));
+    BOOST_CHECK(!tally.updateMoney(0, 0, SELLOFFER_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(0, 0, ACCEPT_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(0, 0, PENDING));
+    BOOST_CHECK(!tally.updateMoney(0, 0, METADEX_RESERVE));
 
     BOOST_CHECK_EQUAL(0, tally.getMoney(0, BALANCE));
     BOOST_CHECK_EQUAL(0, tally.getMoney(0, SELLOFFER_RESERVE));

--- a/src/omnicore/test/tally_tests.cpp
+++ b/src/omnicore/test/tally_tests.cpp
@@ -52,9 +52,9 @@ BOOST_AUTO_TEST_CASE(filled_tally)
 
     BOOST_CHECK(tally.updateMoney(0, 1, BALANCE));
     BOOST_CHECK(tally.updateMoney(0, 100, SELLOFFER_RESERVE));
-    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807), ACCEPT_RESERVE));
-    BOOST_CHECK(tally.updateMoney(2, (-int64_t(9223372036854775807)-1), PENDING));
-    BOOST_CHECK(tally.updateMoney(5, int64_t(4294967296), METADEX_RESERVE));
+    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807LL), ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(2, (-int64_t(9223372036854775807LL)-1), PENDING));
+    BOOST_CHECK(tally.updateMoney(5, int64_t(4294967296L), METADEX_RESERVE));
 
     BOOST_CHECK_EQUAL(tally.getMoney(0, BALANCE), 1);
     BOOST_CHECK_EQUAL(tally.getMoney(0, SELLOFFER_RESERVE), 100);
@@ -67,30 +67,30 @@ BOOST_AUTO_TEST_CASE(filled_tally)
     
     BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), 0);
     BOOST_CHECK_EQUAL(tally.getMoney(1, SELLOFFER_RESERVE), 0);
-    BOOST_CHECK_EQUAL(tally.getMoney(1, ACCEPT_RESERVE), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, ACCEPT_RESERVE), int64_t(9223372036854775807LL));
     BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), 0);
     BOOST_CHECK_EQUAL(tally.getMoney(1, METADEX_RESERVE), 0);
 
     BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), 0);
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), int64_t(9223372036854775807LL));
 
     BOOST_CHECK_EQUAL(tally.getMoney(2, BALANCE), 0);
     BOOST_CHECK_EQUAL(tally.getMoney(2, SELLOFFER_RESERVE), 0);
     BOOST_CHECK_EQUAL(tally.getMoney(2, ACCEPT_RESERVE), 0);
-    BOOST_CHECK_EQUAL(tally.getMoney(2, PENDING), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK_EQUAL(tally.getMoney(2, PENDING), (-int64_t(9223372036854775807LL)-1));
     BOOST_CHECK_EQUAL(tally.getMoney(2, METADEX_RESERVE), 0);
 
-    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(2), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(2), (-int64_t(9223372036854775807LL)-1));
     BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), 0);
 
     BOOST_CHECK_EQUAL(tally.getMoney(5, BALANCE), 0);
     BOOST_CHECK_EQUAL(tally.getMoney(5, SELLOFFER_RESERVE), 0);
     BOOST_CHECK_EQUAL(tally.getMoney(5, ACCEPT_RESERVE), 0);
     BOOST_CHECK_EQUAL(tally.getMoney(5, PENDING), 0);
-    BOOST_CHECK_EQUAL(tally.getMoney(5, METADEX_RESERVE), int64_t(4294967296));
+    BOOST_CHECK_EQUAL(tally.getMoney(5, METADEX_RESERVE), int64_t(4294967296L));
 
     BOOST_CHECK_EQUAL(tally.getMoneyAvailable(5), 0);
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(5), int64_t(4294967296));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(5), int64_t(4294967296L));
 
     /**
      * Note:
@@ -269,37 +269,37 @@ BOOST_AUTO_TEST_CASE(tally_overflow)
 
     BOOST_CHECK(!tally.updateMoney(1, -1, BALANCE));
     BOOST_CHECK(!tally.updateMoney(2, -34242, SELLOFFER_RESERVE));
-    BOOST_CHECK(!tally.updateMoney(2, (-int64_t(9223372036854775807)-1), ACCEPT_RESERVE));
-    BOOST_CHECK(!tally.updateMoney(3, -int64_t(1099511627777), METADEX_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(2, (-int64_t(9223372036854775807LL)-1), ACCEPT_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(3, -int64_t(1099511627777L), METADEX_RESERVE));
 
-    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807), BALANCE));
-    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
-    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), int64_t(9223372036854775807));
+    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807LL), BALANCE));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807LL));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), int64_t(9223372036854775807LL));
 
     BOOST_CHECK(!tally.updateMoney(1, 1, BALANCE));
-    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
-    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807LL));
+    BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), int64_t(9223372036854775807LL));
 
-    BOOST_CHECK(tally.updateMoney(1, (-int64_t(9223372036854775807)-1), PENDING));
-    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
-    BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK(tally.updateMoney(1, (-int64_t(9223372036854775807LL)-1), PENDING));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807LL));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), (-int64_t(9223372036854775807LL)-1));
     BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), -1);
 /*  Not yet specified:
     BOOST_CHECK(!tally.updateMoney(1, -1, PENDING));
-    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807));
-    BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), (-int64_t(9223372036854775807)-1));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, BALANCE), int64_t(9223372036854775807LL));
+    BOOST_CHECK_EQUAL(tally.getMoney(1, PENDING), (-int64_t(9223372036854775807LL)-1));
     BOOST_CHECK_EQUAL(tally.getMoneyAvailable(1), -1);
 */
-    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807), ACCEPT_RESERVE));
-    BOOST_CHECK(tally.updateMoney(2, int64_t(9223372036854775807), SELLOFFER_RESERVE));
-    BOOST_CHECK(tally.updateMoney(3, int64_t(9223372036854775807), SELLOFFER_RESERVE));
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), int64_t(9223372036854775807));
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), int64_t(9223372036854775807));
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807));
+    BOOST_CHECK(tally.updateMoney(1, int64_t(9223372036854775807LL), ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(2, int64_t(9223372036854775807LL), SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(3, int64_t(9223372036854775807LL), SELLOFFER_RESERVE));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), int64_t(9223372036854775807LL));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), int64_t(9223372036854775807LL));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807LL));
 
-    BOOST_CHECK(!tally.updateMoney(3, int64_t(9223372036854775807), SELLOFFER_RESERVE));
-    BOOST_CHECK(!tally.updateMoney(3, (-int64_t(9223372036854775807)-1), SELLOFFER_RESERVE));
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807));
+    BOOST_CHECK(!tally.updateMoney(3, int64_t(9223372036854775807LL), SELLOFFER_RESERVE));
+    BOOST_CHECK(!tally.updateMoney(3, (-int64_t(9223372036854775807LL)-1), SELLOFFER_RESERVE));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807LL));
 
     BOOST_CHECK(tally.updateMoney(1, -int64_t(9223372036854775807), ACCEPT_RESERVE));
     BOOST_CHECK(tally.updateMoney(1, 10000001, ACCEPT_RESERVE));
@@ -314,8 +314,8 @@ BOOST_AUTO_TEST_CASE(tally_overflow)
     BOOST_CHECK_EQUAL(tally.getMoneyAvailable(2), 0);
     BOOST_CHECK_EQUAL(tally.getMoneyAvailable(3), 0);
     BOOST_CHECK_EQUAL(tally.getMoneyReserved(1), 150000005);
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), int64_t(9223372036854775807));
-    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(2), int64_t(9223372036854775807LL));
+    BOOST_CHECK_EQUAL(tally.getMoneyReserved(3), int64_t(9223372036854775807LL));
 }
 
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1427,11 +1427,11 @@ int CMPTransaction::logicMath_GrantTokens()
 
     // overflow tokens check
     if (MAX_INT_8_BYTES - sp.num_tokens < nValue) {
-      char prettyTokens[256];
+      std::string prettyTokens;
       if (sp.isDivisible()) {
-        snprintf(prettyTokens, 256, "%lu.%08lu", nValue / COIN, nValue % COIN);
+        prettyTokens = FormatDivisibleMP(nValue);
       } else {
-        snprintf(prettyTokens, 256, "%lu", nValue);
+        prettyTokens = FormatIndivisibleMP(nValue);
       }
       PrintToLog("\tRejecting Grant: granting %s tokens on SP id:%u would overflow the maximum limit for tokens in a smart property\n", prettyTokens, property);
       return (PKT_ERROR_TOKENS - 27);

--- a/src/qt/lookupspdialog.cpp
+++ b/src/qt/lookupspdialog.cpp
@@ -295,7 +295,7 @@ void LookupSPDialog::updateDisplayedProperty()
     string strWalletTokens;
     int64_t totalTokens = getTotalTokens(propertyId);
     int64_t walletTokens = 0;
-    if (propertyId<2147483648)
+    if (propertyId<2147483648U)
     { walletTokens = global_balance_money_maineco[propertyId]; }
     else
     { walletTokens = global_balance_money_testeco[propertyId-2147483647]; }

--- a/src/qt/metadexcanceldialog.cpp
+++ b/src/qt/metadexcanceldialog.cpp
@@ -18,7 +18,6 @@
 #include "omnicore/sp.h"
 
 #include <stdint.h>
-#include <stdio.h> // printf!
 #include <map>
 #include <sstream>
 #include <string>
@@ -274,9 +273,6 @@ void MetaDExCancelDialog::SendCancelTransaction()
             if (matched) break;
         }
     }
-
-    // TODO: print to log (?)
-    printf("ForSale \"%s\"=%u  Desired \"%s\"=%u  Price \"%s\"  Action %d  AmountForSale %lu  AmountDesired %lu\n", propertyIdForSaleStr.c_str(), propertyIdForSale, propertyIdDesiredStr.c_str(), propertyIdDesired, priceStr.c_str(), (int)action, amountForSale, amountDesired);
 
     // confirmation dialog
     string strMsgText = "You are about to send the following MetaDEx trade cancellation transaction, please check the details thoroughly:\n\n";

--- a/src/qt/metadexdialog.cpp
+++ b/src/qt/metadexdialog.cpp
@@ -144,7 +144,7 @@ void MetaDExDialog::SwitchMarket()
         return;
     }
     // check that the value is in range
-    if ((searchPropertyId < 0) || (searchPropertyId > 4294967290)) {
+    if ((searchPropertyId < 0) || (searchPropertyId > 4294967295L)) {
         QMessageBox::critical( this, "Unable to switch market",
         "The property ID entered is outside the allowed range." );
         return;

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -188,7 +188,7 @@ void SendMPDialog::updateProperty()
 
     // populate balance for global wallet
     int64_t globalAvailable = 0;
-    if (propertyId<2147483648) { globalAvailable = global_balance_money_maineco[propertyId]; } else { globalAvailable = global_balance_money_testeco[propertyId-2147483647]; }
+    if (propertyId<2147483648U) { globalAvailable = global_balance_money_maineco[propertyId]; } else { globalAvailable = global_balance_money_testeco[propertyId-2147483647]; }
     ui->globalBalanceLabel->setText(QString::fromStdString("Wallet Balance (Available): " + FormatMP(propertyId, globalAvailable) + getTokenLabel(propertyId)));
 
 #if QT_VERSION >= 0x040700


### PR DESCRIPTION
The behavior of `CMPTally` is unchanged, but it's extended with:

```c++
/** Returns the number of available tokens. */
int64_t getMoneyAvailable(uint32_t propertyId) const;

/** Returns the number of reserved tokens. */
int64_t getMoneyReserved(uint32_t propertyId) const;

/** Compares the tally with another tally and returns true, if they are equal. */
bool operator==(const CMPTally& rhs) const;

/** Compares the tally with another tally and returns true, if they are not equal. */
bool operator!=(const CMPTally& rhs) const;
```