### PR TITLE
Serialize and deserialize SP entries as raw bytes

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -284,8 +284,6 @@ std::string FormatMP(uint32_t property, int64_t n, bool fSign)
     }
 }
 
-string const CMPSPInfo::watermarkKey("watermark");
-
 OfferMap mastercore::my_offers;
 AcceptMap mastercore::my_accepts;
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1522,7 +1522,7 @@ static int load_most_relevant_state()
   // check the SP database and roll it back to its latest valid state
   // according to the active chain
   uint256 spWatermark;
-  if (0 > _my_sps->getWatermark(spWatermark)) {
+  if (!_my_sps->getWatermark(spWatermark)) {
     //trigger a full reparse, if the SP database has no watermark
     return -1;
   }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1350,7 +1350,8 @@ int input_mp_crowdsale_string(const std::string& s)
             vals.push_back(boost::lexical_cast<int64_t>(*it));
         }
 
-        newCrowdsale.insertDatabase(entryData[0], vals);
+        uint256 txHash(entryData[0]);
+        newCrowdsale.insertDatabase(txHash, vals);
     }
 
     if (!my_crowds.insert(std::make_pair(sellerAddr, newCrowdsale)).second) {
@@ -3516,7 +3517,7 @@ int CMPTransaction::logicMath_SimpleSend()
                 std::vector<int64_t> txDataVec(txdata, txdata + sizeof(txdata) / sizeof(txdata[0]));
 
                 // Insert data about crowdsale participation
-                pcrowdsale->insertDatabase(txid.GetHex(), txDataVec);
+                pcrowdsale->insertDatabase(txid, txDataVec);
 
                 // Credit tokens for this fundraiser
                 update_tally_map(sender, pcrowdsale->getPropertyId(), tokens.first, BALANCE);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -437,9 +437,9 @@ int64_t before, after;
 
 // calculateFundraiser does token calculations per transaction
 // calcluateFractional does calculations for missed tokens
-void calculateFundraiser(uint64_t amtTransfer, unsigned char bonusPerc,
-        uint64_t fundraiserSecs, uint64_t currentSecs, uint64_t numProps, unsigned char issuerPerc, uint64_t totalTokens,
-        std::pair<uint64_t, uint64_t>& tokens, bool &close_crowdsale)
+static void calculateFundraiser(int64_t amtTransfer, uint8_t bonusPerc,
+        int64_t fundraiserSecs, int64_t currentSecs, int64_t numProps, uint8_t issuerPerc, int64_t totalTokens,
+        std::pair<int64_t, int64_t>& tokens, bool& close_crowdsale)
 {
     // Weeks in seconds
     int128_t weeks_sec_ = 604800L;
@@ -496,7 +496,7 @@ void calculateFundraiser(uint64_t amtTransfer, unsigned char bonusPerc,
     // The tokens to credit
     assert(createdTokens_int <= std::numeric_limits<int64_t>::max());
     assert(issuerTokens_int <= std::numeric_limits<int64_t>::max());
-    tokens = std::make_pair(createdTokens_int.convert_to<uint64_t>(), issuerTokens_int.convert_to<uint64_t>());
+    tokens = std::make_pair(createdTokens_int.convert_to<int64_t>(), issuerTokens_int.convert_to<int64_t>());
 }
 
 // certain transaction types are not live on the network until some specific block height
@@ -1342,10 +1342,10 @@ int input_mp_crowdsale_string(const string &s)
     std::vector<std::string> valueData;
     boost::split(valueData, entryData[1], boost::is_any_of(";"), token_compress_on);
 
-    std::vector<uint64_t> vals;
+    std::vector<int64_t> vals;
     std::vector<std::string>::const_iterator iter;
     for (iter = valueData.begin(); iter != valueData.end(); ++iter) {
-      vals.push_back(boost::lexical_cast<uint64_t>(*iter));
+      vals.push_back(boost::lexical_cast<int64_t>(*iter));
     }
 
     newCrowdsale.insertDatabase(entryData[0], vals);
@@ -3487,7 +3487,7 @@ int CMPTransaction::logicMath_SimpleSend()
 
             if (spFound) {
                 // Holds the tokens to be credited to the sender and receiver
-                std::pair<uint64_t, uint64_t> tokens;
+                std::pair<int64_t, int64_t> tokens;
 
                 // Passed by reference to determine, if max_tokens has been reached
                 bool close_crowdsale = false;
@@ -3505,7 +3505,7 @@ int CMPTransaction::logicMath_SimpleSend()
                 }
 
                 // Calculate the amounts to credit for this fundraiser
-                calculateFundraiser(nValue, sp.early_bird, sp.deadline, (uint64_t) blockTime,
+                calculateFundraiser(nValue, sp.early_bird, sp.deadline, blockTime,
                         sp.num_tokens, sp.percentage, getTotalTokens(pcrowdsale->getPropertyId()),
                         tokens, close_crowdsale);
 
@@ -3514,8 +3514,8 @@ int CMPTransaction::logicMath_SimpleSend()
                 pcrowdsale->incTokensIssuerCreated(tokens.second);
 
                 // Data to pass to txFundraiserData
-                uint64_t txdata[] = {(uint64_t) nValue, (uint64_t) blockTime, (uint64_t) tokens.first, (uint64_t) tokens.second};
-                std::vector<uint64_t> txDataVec(txdata, txdata + sizeof (txdata) / sizeof (txdata[0]));
+                int64_t txdata[] = {(int64_t) nValue, blockTime, tokens.first, tokens.second};
+                std::vector<int64_t> txDataVec(txdata, txdata + sizeof(txdata) / sizeof(txdata[0]));
 
                 // Insert data about crowdsale participation
                 pcrowdsale->insertDatabase(txid.GetHex(), txDataVec);

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -159,8 +159,8 @@ enum FILETYPES {
 // forward declarations
 std::string FormatDivisibleMP(int64_t n, bool fSign = false);
 std::string FormatDivisibleShortMP(int64_t);
-std::string FormatMP(unsigned int, int64_t n, bool fSign = false);
-bool feeCheck(const string &address, size_t nDataSize);
+std::string FormatMP(uint32_t, int64_t n, bool fSign = false);
+bool feeCheck(const std::string& address, size_t nDataSize);
 
 /** Returns the Exodus address. */
 const CBitcoinAddress ExodusAddress();
@@ -475,12 +475,11 @@ extern std::map<uint32_t, int64_t> global_balance_reserved;
 //! Vector containing a list of properties relative to the wallet
 extern std::set<uint32_t> global_wallet_property_list;
 
+int64_t getMPbalance(const std::string& address, uint32_t propertyId, TallyType ttype);
+int64_t getUserAvailableMPbalance(const std::string& address, uint32_t propertyId);
+int IsMyAddress(const std::string& address);
 
-int64_t getMPbalance(const string &Address, uint32_t property, TallyType ttype);
-int64_t getUserAvailableMPbalance(const string &Address, unsigned int property);
-int IsMyAddress(const std::string &address);
-
-string getLabel(const string &address);
+std::string getLabel(const std::string& address);
 
 /** Global handler to initialize Omni Core. */
 int mastercore_init();
@@ -500,31 +499,31 @@ int mastercore_save_state( CBlockIndex const *pBlockIndex );
 
 namespace mastercore
 {
-extern std::map<string, CMPTally> mp_tally_map;
+extern std::map<std::string, CMPTally> mp_tally_map;
 extern CMPTxList *p_txlistdb;
 extern CMPTradeList *t_tradelistdb;
 extern CMPSTOList *s_stolistdb;
 
-string strMPProperty(unsigned int i);
+std::string strMPProperty(uint32_t propertyId);
 
-int GetHeight(void);
-uint32_t GetLatestBlockTime(void);
+int GetHeight();
+uint32_t GetLatestBlockTime();
 CBlockIndex* GetBlockIndex(const uint256& hash);
 
 bool isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound);
 
 std::string FormatIndivisibleMP(int64_t n);
 
-int ClassAgnosticWalletTXBuilder(const string &senderAddress, const string &receiverAddress, const string &redemptionAddress,
-                 int64_t referenceAmount, const std::vector<unsigned char> &data, uint256 & txid, string &rawHex, bool commit);
+int ClassAgnosticWalletTXBuilder(const std::string& senderAddress, const std::string& receiverAddress, const std::string& redemptionAddress,
+                 int64_t referenceAmount, const std::vector<unsigned char>& data, uint256& txid, std::string& rawHex, bool commit);
 
-bool isTestEcosystemProperty(unsigned int property);
-bool isMainEcosystemProperty(unsigned int property);
+bool isTestEcosystemProperty(uint32_t propertyId);
+bool isMainEcosystemProperty(uint32_t propertyId);
 uint32_t GetNextPropertyId(bool maineco); // maybe move into sp
 
-CMPTally *getTally(const string & address);
+CMPTally* getTally(const std::string& address);
 
-int64_t getTotalTokens(unsigned int propertyId, int64_t *n_owners_total = NULL);
+int64_t getTotalTokens(uint32_t propertyId, int64_t* n_owners_total = NULL);
 
 char *c_strMasterProtocolTXType(int i);
 
@@ -532,9 +531,9 @@ bool isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int
 
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 
-bool update_tally_map(string who, unsigned int which_currency, int64_t amount, TallyType ttype);
+bool update_tally_map(const std::string& who, uint32_t propertyId, int64_t amount, TallyType ttype);
 
-std::string getTokenLabel(unsigned int propertyId);
+std::string getTokenLabel(uint32_t propertyId);
 }
 
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -47,10 +47,6 @@ int const MAX_STATE_HISTORY = 50;
 
 #define SP_STRING_FIELD_LEN 256
 
-// some boost formats
-#define FORMAT_BOOST_TXINDEXKEY "index-tx-%s"
-#define FORMAT_BOOST_SPKEY      "sp-%d"
-
 // Omni Layer Transaction Class
 #define OMNI_CLASS_A 1
 #define OMNI_CLASS_B 2

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -572,7 +572,7 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
 
     Object response;
     bool active = isCrowdsaleActive(propertyId);
-    std::map<std::string, std::vector<int64_t> > database;
+    std::map<uint256, std::vector<int64_t> > database;
 
     if (active) {
         bool crowdFound = false;
@@ -600,11 +600,11 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
     }
 
     Array participanttxs;
-    std::map<std::string, std::vector<int64_t> >::const_iterator it;
+    std::map<uint256, std::vector<int64_t> >::const_iterator it;
     for (it = database.begin(); it != database.end(); it++) {
         Object participanttx;
 
-        const std::string& txid = it->first;
+        const std::string& txid = it->first.GetHex();
         int64_t userTokens = it->second.at(2);
         int64_t issuerTokens = it->second.at(3);
         int64_t amountSent = it->second.at(0);
@@ -753,9 +753,9 @@ Value getgrants_MP(const Array& params, bool fHelp)
     int64_t totalTokens = getTotalTokens(propertyId);
 
     Array issuancetxs;
-    std::map<std::string, std::vector<int64_t> >::const_iterator it;
+    std::map<uint256, std::vector<int64_t> >::const_iterator it;
     for (it = sp.historicalData.begin(); it != sp.historicalData.end(); it++) {
-        const std::string& txid = it->first;
+        const std::string& txid = it->first.GetHex();
         int64_t grantedTokens = it->second.at(0);
         int64_t revokedTokens = it->second.at(1);
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -572,7 +572,7 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
 
     Object response;
     bool active = isCrowdsaleActive(propertyId);
-    std::map<std::string, std::vector<uint64_t> > database;
+    std::map<std::string, std::vector<int64_t> > database;
 
     if (active) {
         bool crowdFound = false;
@@ -600,7 +600,7 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
     }
 
     Array participanttxs;
-    std::map<std::string, std::vector<uint64_t> >::const_iterator it;
+    std::map<std::string, std::vector<int64_t> >::const_iterator it;
     for (it = database.begin(); it != database.end(); it++) {
         Object participanttx;
 
@@ -753,7 +753,7 @@ Value getgrants_MP(const Array& params, bool fHelp)
     int64_t totalTokens = getTotalTokens(propertyId);
 
     Array issuancetxs;
-    std::map<std::string, std::vector<uint64_t> >::const_iterator it;
+    std::map<std::string, std::vector<int64_t> >::const_iterator it;
     for (it = sp.historicalData.begin(); it != sp.historicalData.end(); it++) {
         const std::string& txid = it->first;
         int64_t grantedTokens = it->second.at(0);

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -369,7 +369,10 @@ int64_t CMPSPInfo::popBlock(const uint256& block_hash)
 void CMPSPInfo::setWatermark(const uint256& watermark)
 {
     leveldb::WriteBatch batch;
-    leveldb::Slice slKey(watermarkKey);
+
+    CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+    ssKey << 'B';
+    leveldb::Slice slKey(&ssKey[0], ssKey.size());
 
     CDataStream ssValue(SER_DISK, CLIENT_VERSION);
     ssValue.reserve(ssValue.GetSerializeSize(watermark));
@@ -387,7 +390,9 @@ void CMPSPInfo::setWatermark(const uint256& watermark)
 
 bool CMPSPInfo::getWatermark(uint256& watermark) const
 {
-    leveldb::Slice slKey(watermarkKey);
+    CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+    ssKey << 'B';
+    leveldb::Slice slKey(&ssKey[0], ssKey.size());
 
     std::string strValue;
     leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -484,9 +484,9 @@ CMPCrowd::CMPCrowd(uint32_t pid, int64_t nv, uint32_t cd, int64_t dl, uint8_t eb
 {
 }
 
-void CMPCrowd::insertDatabase(const std::string& txhash, const std::vector<int64_t>& txdata)
+void CMPCrowd::insertDatabase(const uint256& txHash, const std::vector<int64_t>& txData)
 {
-    txFundraiserData.insert(std::make_pair(txhash, txdata));
+    txFundraiserData.insert(std::make_pair(txHash, txData));
 }
 
 void CMPCrowd::print(const std::string& address, FILE* fp) const
@@ -511,9 +511,9 @@ void CMPCrowd::saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std:
             i_created);
 
     // append N pairs of address=nValue;blockTime for the database
-    std::map<std::string, std::vector<int64_t> >::const_iterator iter;
+    std::map<uint256, std::vector<int64_t> >::const_iterator iter;
     for (iter = txFundraiserData.begin(); iter != txFundraiserData.end(); ++iter) {
-        lineOut.append(strprintf(",%s=", (*iter).first));
+        lineOut.append(strprintf(",%s=", (*iter).first.GetHex()));
         std::vector<int64_t> const &vals = (*iter).second;
 
         std::vector<int64_t>::const_iterator valIter;
@@ -596,14 +596,14 @@ void mastercore::dumpCrowdsaleInfo(const std::string& address, const CMPCrowd& c
 // numProps: number of properties
 // issuerPerc: percentage of tokens to issuer
 int64_t mastercore::calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundraiserSecs,
-        int64_t numProps, uint8_t issuerPerc, const std::map<std::string, std::vector<int64_t> >& txFundraiserData,
+        int64_t numProps, uint8_t issuerPerc, const std::map<uint256, std::vector<int64_t> >& txFundraiserData,
         const int64_t amountPremined)
 {
     // initialize variables
     double totalCreated = 0;
     double issuerPercentage = (double) (issuerPerc * 0.01);
 
-    std::map<std::string, std::vector<int64_t> >::const_iterator it;
+    std::map<uint256, std::vector<int64_t> >::const_iterator it;
 
     // iterate through fundraiser data
     for (it = txFundraiserData.begin(); it != txFundraiserData.end(); it++) {
@@ -664,10 +664,10 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
     // check for an active crowdsale to this address
     CMPCrowd* pcrowdsale = getCrowd(address);
     if (pcrowdsale) {
-        std::map<std::string, std::vector<int64_t> >::const_iterator it;
-        const std::map<std::string, std::vector<int64_t> >& database = pcrowdsale->getDatabase();
+        std::map<uint256, std::vector<int64_t> >::const_iterator it;
+        const std::map<uint256, std::vector<int64_t> >& database = pcrowdsale->getDatabase();
         for (it = database.begin(); it != database.end(); it++) {
-            uint256 tmpTxid(it->first); // construct from string
+            const uint256& tmpTxid = it->first;
             if (tmpTxid == txid) {
                 *propertyId = pcrowdsale->getPropertyId();
                 *userTokens = it->second.at(2);
@@ -686,10 +686,10 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
         if (!_my_sps->getSP(tmpPropertyId, sp)) continue;
         if (sp.issuer != address) continue;
 
-        std::map<std::string, std::vector<int64_t> >::const_iterator it;
-        const std::map<std::string, std::vector<int64_t> >& database = sp.historicalData;
+        std::map<uint256, std::vector<int64_t> >::const_iterator it;
+        const std::map<uint256, std::vector<int64_t> >& database = sp.historicalData;
         for (it = database.begin(); it != database.end(); it++) {
-            uint256 tmpTxid(it->first); // construct from string
+            const uint256& tmpTxid = it->first;
             if (tmpTxid == txid) {
                 *propertyId = tmpPropertyId;
                 *userTokens = it->second.at(2);
@@ -704,10 +704,10 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
         if (!_my_sps->getSP(tmpPropertyId, sp)) continue;
         if (sp.issuer == address) continue;
 
-        std::map<std::string, std::vector<int64_t> >::const_iterator it;
-        const std::map<std::string, std::vector<int64_t> >& database = sp.historicalData;
+        std::map<uint256, std::vector<int64_t> >::const_iterator it;
+        const std::map<uint256, std::vector<int64_t> >& database = sp.historicalData;
         for (it = database.begin(); it != database.end(); it++) {
-            uint256 tmpTxid(it->first); // construct from string
+            const uint256& tmpTxid = it->first;
             if (tmpTxid == txid) {
                 *propertyId = tmpPropertyId;
                 *userTokens = it->second.at(2);

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -47,7 +47,7 @@ Object CMPSPInfo::Entry::toJSON() const
 {
     Object spInfo;
     spInfo.push_back(Pair("issuer", issuer));
-    spInfo.push_back(Pair("prop_type", prop_type));
+    spInfo.push_back(Pair("prop_type", (uint64_t) prop_type));
     spInfo.push_back(Pair("prev_prop_id", (uint64_t) prev_prop_id));
     spInfo.push_back(Pair("category", category));
     spInfo.push_back(Pair("subcategory", subcategory));
@@ -57,22 +57,22 @@ Object CMPSPInfo::Entry::toJSON() const
     spInfo.push_back(Pair("fixed", fixed));
     spInfo.push_back(Pair("manual", manual));
 
-    spInfo.push_back(Pair("num_tokens", strprintf("%d", num_tokens)));
+    spInfo.push_back(Pair("num_tokens", num_tokens));
     if (false == fixed && false == manual) {
         spInfo.push_back(Pair("property_desired", (uint64_t) property_desired));
-        spInfo.push_back(Pair("deadline", strprintf("%d", deadline)));
-        spInfo.push_back(Pair("early_bird", (int) early_bird));
-        spInfo.push_back(Pair("percentage", (int) percentage));
+        spInfo.push_back(Pair("deadline", deadline));
+        spInfo.push_back(Pair("early_bird", (uint64_t) early_bird));
+        spInfo.push_back(Pair("percentage", (uint64_t) percentage));
 
-        spInfo.push_back(Pair("close_early", (int) close_early));
-        spInfo.push_back(Pair("max_tokens", (int) max_tokens));
+        spInfo.push_back(Pair("close_early", close_early));
+        spInfo.push_back(Pair("max_tokens", max_tokens));
         spInfo.push_back(Pair("missedTokens", missedTokens));
-        spInfo.push_back(Pair("timeclosed", strprintf("%d", timeclosed)));
+        spInfo.push_back(Pair("timeclosed", timeclosed));
         spInfo.push_back(Pair("txid_close", txid_close.ToString()));
     }
 
     // Initialize values
-    std::map<std::string, std::vector<uint64_t> >::const_iterator it;
+    std::map<std::string, std::vector<int64_t> >::const_iterator it;
 
     std::string values_long;
     std::string values;
@@ -106,8 +106,8 @@ void CMPSPInfo::Entry::fromJSON(const Object& json)
 {
     unsigned int idx = 0;
     issuer = json[idx++].value_.get_str();
-    prop_type = (unsigned short)json[idx++].value_.get_int();
-    prev_prop_id = (unsigned int)json[idx++].value_.get_uint64();
+    prop_type = (uint16_t) json[idx++].value_.get_uint64();
+    prev_prop_id = (uint32_t) json[idx++].value_.get_uint64();
     category = json[idx++].value_.get_str();
     subcategory = json[idx++].value_.get_str();
     name = json[idx++].value_.get_str();
@@ -116,17 +116,17 @@ void CMPSPInfo::Entry::fromJSON(const Object& json)
     fixed = json[idx++].value_.get_bool();
     manual = json[idx++].value_.get_bool();
 
-    num_tokens = boost::lexical_cast<uint64_t>(json[idx++].value_.get_str());
+    num_tokens = json[idx++].value_.get_int64();
     if (false == fixed && false == manual) {
-        property_desired = (unsigned int)json[idx++].value_.get_uint64();
-        deadline = boost::lexical_cast<uint64_t>(json[idx++].value_.get_str());
-        early_bird = (unsigned char)json[idx++].value_.get_int();
-        percentage = (unsigned char)json[idx++].value_.get_int();
+        property_desired = (uint32_t) json[idx++].value_.get_uint64();
+        deadline = json[idx++].value_.get_int64();
+        early_bird = (uint8_t) json[idx++].value_.get_uint64();
+        percentage = (uint8_t) json[idx++].value_.get_uint64();
 
-        close_early = (unsigned char)json[idx++].value_.get_int();
-        max_tokens = (unsigned char)json[idx++].value_.get_int();
-        missedTokens = (unsigned char)json[idx++].value_.get_int();
-        timeclosed = boost::lexical_cast<uint64_t>(json[idx++].value_.get_str());
+        close_early = json[idx++].value_.get_bool();
+        max_tokens = json[idx++].value_.get_bool();
+        missedTokens = json[idx++].value_.get_int64();
+        timeclosed = json[idx++].value_.get_int64();
         txid_close = uint256(json[idx++].value_.get_str());
     }
 
@@ -147,16 +147,16 @@ void CMPSPInfo::Entry::fromJSON(const Object& json)
         std::vector<std::string> str_split_vec;
         boost::split(str_split_vec, strngs_vec[i], boost::is_any_of(":"));
 
-        std::vector<uint64_t> txDataVec;
+        std::vector<int64_t> txDataVec;
 
         if (crowdsale && str_split_vec.size() == 5) {
-            txDataVec.push_back(boost::lexical_cast<uint64_t>(str_split_vec.at(1)));
-            txDataVec.push_back(boost::lexical_cast<uint64_t>(str_split_vec.at(2)));
-            txDataVec.push_back(boost::lexical_cast<uint64_t>(str_split_vec.at(3)));
-            txDataVec.push_back(boost::lexical_cast<uint64_t>(str_split_vec.at(4)));
+            txDataVec.push_back(boost::lexical_cast<int64_t>(str_split_vec.at(1)));
+            txDataVec.push_back(boost::lexical_cast<int64_t>(str_split_vec.at(2)));
+            txDataVec.push_back(boost::lexical_cast<int64_t>(str_split_vec.at(3)));
+            txDataVec.push_back(boost::lexical_cast<int64_t>(str_split_vec.at(4)));
         } else if (manual && str_split_vec.size() == 3) {
-            txDataVec.push_back(boost::lexical_cast<uint64_t>(str_split_vec.at(1)));
-            txDataVec.push_back(boost::lexical_cast<uint64_t>(str_split_vec.at(2)));
+            txDataVec.push_back(boost::lexical_cast<int64_t>(str_split_vec.at(1)));
+            txDataVec.push_back(boost::lexical_cast<int64_t>(str_split_vec.at(2)));
         }
 
         historicalData.insert(std::make_pair(str_split_vec.at(0), txDataVec));
@@ -179,7 +179,7 @@ bool CMPSPInfo::Entry::isDivisible() const
 
 void CMPSPInfo::Entry::print() const
 {
-    PrintToConsole("%s:%s(Fixed=%s,Divisible=%s):%lu:%s/%s, %s %s\n",
+    PrintToConsole("%s:%s(Fixed=%s,Divisible=%s):%d:%s/%s, %s %s\n",
             issuer,
             name,
             fixed ? "Yes" : "No",
@@ -219,15 +219,15 @@ CMPSPInfo::~CMPSPInfo()
     if (msc_debug_persistence) PrintToLog("CMPSPInfo closed\n");
 }
 
-void CMPSPInfo::init(unsigned int nextSPID, unsigned int nextTestSPID)
+void CMPSPInfo::init(uint32_t nextSPID, uint32_t nextTestSPID)
 {
     next_spid = nextSPID;
     next_test_spid = nextTestSPID;
 }
 
-unsigned int CMPSPInfo::peekNextSPID(unsigned char ecosystem) const
+uint32_t CMPSPInfo::peekNextSPID(uint8_t ecosystem) const
 {
-    unsigned int nextId = 0;
+    uint32_t nextId = 0;
 
     switch (ecosystem) {
         case OMNI_PROPERTY_MSC: // Main ecosystem, MSC: 1, TMSC: 2, First available SP = 3
@@ -243,14 +243,14 @@ unsigned int CMPSPInfo::peekNextSPID(unsigned char ecosystem) const
     return nextId;
 }
 
-unsigned int CMPSPInfo::updateSP(unsigned int propertyID, const Entry& info)
+uint32_t CMPSPInfo::updateSP(uint32_t propertyID, const Entry& info)
 {
     // cannot update implied SP
     if (OMNI_PROPERTY_MSC == propertyID || OMNI_PROPERTY_TMSC == propertyID) {
         return propertyID;
     }
 
-    unsigned int res = propertyID;
+    uint32_t res = propertyID;
     Object spInfo = info.toJSON();
 
     // generate the SP id
@@ -272,9 +272,9 @@ unsigned int CMPSPInfo::updateSP(unsigned int propertyID, const Entry& info)
     return res;
 }
 
-unsigned int CMPSPInfo::putSP(unsigned char ecosystem, const Entry& info)
+uint32_t CMPSPInfo::putSP(uint8_t ecosystem, const Entry& info)
 {
-    unsigned int res = 0;
+    uint32_t res = 0;
     switch (ecosystem) {
         case OMNI_PROPERTY_MSC: // Main ecosystem, MSC: 1, TMSC: 2, First available SP = 3
             res = next_spid++;
@@ -311,7 +311,7 @@ unsigned int CMPSPInfo::putSP(unsigned char ecosystem, const Entry& info)
     return res;
 }
 
-bool CMPSPInfo::getSP(unsigned int spid, Entry& info) const
+bool CMPSPInfo::getSP(uint32_t spid, Entry& info) const
 {
     // special cases for constant SPs MSC and TMSC
     if (OMNI_PROPERTY_MSC == spid) {
@@ -340,7 +340,7 @@ bool CMPSPInfo::getSP(unsigned int spid, Entry& info) const
     return true;
 }
 
-bool CMPSPInfo::hasSP(unsigned int spid) const
+bool CMPSPInfo::hasSP(uint32_t spid) const
 {
     // special cases for constant SPs MSC and TMSC
     if (OMNI_PROPERTY_MSC == spid || OMNI_PROPERTY_TMSC == spid) {
@@ -357,14 +357,14 @@ bool CMPSPInfo::hasSP(unsigned int spid) const
     return res;
 }
 
-unsigned int CMPSPInfo::findSPByTX(const uint256& txid) const
+uint32_t CMPSPInfo::findSPByTX(const uint256& txid) const
 {
-    unsigned int res = 0;
+    uint32_t res = 0;
 
     std::string txIndexKey = strprintf(FORMAT_BOOST_TXINDEXKEY, txid.ToString());
     std::string spidStr;
     if (pdb->Get(readoptions, txIndexKey, &spidStr).ok()) {
-        res = boost::lexical_cast<unsigned int>(spidStr);
+        res = boost::lexical_cast<uint32_t>(spidStr);
     }
 
     return res;
@@ -394,7 +394,7 @@ int CMPSPInfo::popBlock(const uint256& block_hash)
                     std::vector<std::string> vstr;
                     std::string key = iter->key().ToString();
                     boost::split(vstr, key, boost::is_any_of("-"), boost::token_compress_on);
-                    unsigned int propertyID = boost::lexical_cast<unsigned int>(vstr[1]);
+                    uint32_t propertyID = boost::lexical_cast<uint32_t>(vstr[1]);
 
                     std::string spPrevKey = strprintf("blk-%s:sp-%d", info.update_block.ToString(), propertyID);
                     std::string spPrevValue;
@@ -452,7 +452,7 @@ int CMPSPInfo::getWatermark(uint256& watermark) const // TODO: return bool
 void CMPSPInfo::printAll() const
 {
     // print off the hard coded MSC and TMSC entries
-    for (unsigned int idx = OMNI_PROPERTY_MSC; idx <= OMNI_PROPERTY_TMSC; idx++) {
+    for (uint32_t idx = OMNI_PROPERTY_MSC; idx <= OMNI_PROPERTY_TMSC; idx++) {
         Entry info;
         PrintToConsole("%10d => ", idx);
         if (getSP(idx, info)) {
@@ -493,20 +493,20 @@ CMPCrowd::CMPCrowd()
 {
 }
 
-CMPCrowd::CMPCrowd(unsigned int pid, uint64_t nv, unsigned int cd, uint64_t dl, unsigned char eb, unsigned char per, uint64_t uct, uint64_t ict)
+CMPCrowd::CMPCrowd(uint32_t pid, int64_t nv, uint32_t cd, int64_t dl, uint8_t eb, uint8_t per, int64_t uct, int64_t ict)
   : propertyId(pid), nValue(nv), property_desired(cd), deadline(dl),
     early_bird(eb), percentage(per), u_created(uct), i_created(ict)
 {
 }
 
-void CMPCrowd::insertDatabase(const std::string& txhash, const std::vector<uint64_t>& txdata)
+void CMPCrowd::insertDatabase(const std::string& txhash, const std::vector<int64_t>& txdata)
 {
     txFundraiserData.insert(std::make_pair(txhash, txdata));
 }
 
 void CMPCrowd::print(const std::string& address, FILE* fp) const
 {
-    fprintf(fp, "%34s : id=%u=%X; prop=%u, value= %lu, deadline: %s (%lX)\n", address.c_str(), propertyId, propertyId,
+    fprintf(fp, "%34s : id=%u=%X; prop=%u, value= %li, deadline: %s (%lX)\n", address.c_str(), propertyId, propertyId,
         property_desired, nValue, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline).c_str(), deadline);
 }
 
@@ -520,18 +520,18 @@ void CMPCrowd::saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std:
             nValue,
             property_desired,
             deadline,
-            (int) early_bird,
-            (int) percentage,
+            early_bird,
+            percentage,
             u_created,
             i_created);
 
     // append N pairs of address=nValue;blockTime for the database
-    std::map<std::string, std::vector<uint64_t> >::const_iterator iter;
+    std::map<std::string, std::vector<int64_t> >::const_iterator iter;
     for (iter = txFundraiserData.begin(); iter != txFundraiserData.end(); ++iter) {
         lineOut.append(strprintf(",%s=", (*iter).first));
-        std::vector<uint64_t> const &vals = (*iter).second;
+        std::vector<int64_t> const &vals = (*iter).second;
 
-        std::vector<uint64_t>::const_iterator valIter;
+        std::vector<int64_t>::const_iterator valIter;
         for (valIter = vals.begin(); valIter != vals.end(); ++valIter) {
             if (valIter != vals.begin()) {
                 lineOut.append(";");
@@ -557,7 +557,7 @@ CMPCrowd* mastercore::getCrowd(const std::string& address)
     return (CMPCrowd *)NULL;
 }
 
-bool mastercore::isPropertyDivisible(unsigned int propertyId)
+bool mastercore::isPropertyDivisible(uint32_t propertyId)
 {
     // TODO: is a lock here needed
     CMPSPInfo::Entry sp;
@@ -567,18 +567,18 @@ bool mastercore::isPropertyDivisible(unsigned int propertyId)
     return true;
 }
 
-std::string mastercore::getPropertyName(unsigned int propertyId)
+std::string mastercore::getPropertyName(uint32_t propertyId)
 {
     CMPSPInfo::Entry sp;
     if (_my_sps->getSP(propertyId, sp)) return sp.name;
     return "Property Name Not Found";
 }
 
-bool mastercore::isCrowdsaleActive(unsigned int propertyId)
+bool mastercore::isCrowdsaleActive(uint32_t propertyId)
 {
     for (CrowdMap::const_iterator it = my_crowds.begin(); it != my_crowds.end(); ++it) {
         const CMPCrowd& crowd = it->second;
-        unsigned int foundPropertyId = crowd.getPropertyId();
+        uint32_t foundPropertyId = crowd.getPropertyId();
         if (foundPropertyId == propertyId) return true;
     }
     return false;
@@ -610,25 +610,25 @@ void mastercore::dumpCrowdsaleInfo(const std::string& address, const CMPCrowd& c
 // currentSecs: number of seconds of current tx
 // numProps: number of properties
 // issuerPerc: percentage of tokens to issuer
-int mastercore::calculateFractional(unsigned short int propType, unsigned char bonusPerc, uint64_t fundraiserSecs,
-        uint64_t numProps, unsigned char issuerPerc, const std::map<std::string, std::vector<uint64_t> >& txFundraiserData,
-        const uint64_t amountPremined)
+int64_t mastercore::calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundraiserSecs,
+        int64_t numProps, uint8_t issuerPerc, const std::map<std::string, std::vector<int64_t> >& txFundraiserData,
+        const int64_t amountPremined)
 {
     // initialize variables
     double totalCreated = 0;
     double issuerPercentage = (double) (issuerPerc * 0.01);
 
-    std::map<std::string, std::vector<uint64_t> >::const_iterator it;
+    std::map<std::string, std::vector<int64_t> >::const_iterator it;
 
     // iterate through fundraiser data
     for (it = txFundraiserData.begin(); it != txFundraiserData.end(); it++) {
 
         // grab the seconds and amt transferred from this tx
-        uint64_t currentSecs = it->second.at(1);
+        int64_t currentSecs = it->second.at(1);
         double amtTransfer = it->second.at(0);
 
         // make calc for bonus given in sec
-        uint64_t bonusSeconds = fundraiserSecs - currentSecs;
+        int64_t bonusSeconds = fundraiserSecs - currentSecs;
 
         // turn it into weeks
         double weeks = bonusSeconds / (double) 604800;
@@ -649,7 +649,7 @@ int mastercore::calculateFractional(unsigned short int propType, unsigned char b
             totalCreated += createdTokens;
         } else {
             // same here
-            createdTokens = (uint64_t) ((amtTransfer / 1e8) * (double) numProps * bonusPercentage);
+            createdTokens = (int64_t) ((amtTransfer / 1e8) * (double) numProps * bonusPercentage);
 
             totalCreated += createdTokens;
         }
@@ -663,7 +663,7 @@ int mastercore::calculateFractional(unsigned short int propType, unsigned char b
     if (2 == propType) {
         missedTokens = totalPremined - amountPremined;
     } else {
-        missedTokens = (uint64_t) (totalPremined - amountPremined);
+        missedTokens = (int64_t) (totalPremined - amountPremined);
     }
 
     return missedTokens;
@@ -679,8 +679,8 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
     // check for an active crowdsale to this address
     CMPCrowd* pcrowdsale = getCrowd(address);
     if (pcrowdsale) {
-        std::map<std::string, std::vector<uint64_t> >::const_iterator it;
-        const std::map<std::string, std::vector<uint64_t> >& database = pcrowdsale->getDatabase();
+        std::map<std::string, std::vector<int64_t> >::const_iterator it;
+        const std::map<std::string, std::vector<int64_t> >& database = pcrowdsale->getDatabase();
         for (it = database.begin(); it != database.end(); it++) {
             uint256 tmpTxid(it->first); // construct from string
             if (tmpTxid == txid) {
@@ -693,16 +693,16 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
     }
 
     // if we still haven't found txid, check non active crowdsales to this address
-    unsigned int nextSPID = _my_sps->peekNextSPID(1);
-    unsigned int nextTestSPID = _my_sps->peekNextSPID(2);
+    uint32_t nextSPID = _my_sps->peekNextSPID(1);
+    uint32_t nextTestSPID = _my_sps->peekNextSPID(2);
 
-    for (int64_t tmpPropertyId = 1; tmpPropertyId < nextSPID; tmpPropertyId++) {
+    for (uint32_t tmpPropertyId = 1; tmpPropertyId < nextSPID; tmpPropertyId++) {
         CMPSPInfo::Entry sp;
         if (!_my_sps->getSP(tmpPropertyId, sp)) continue;
         if (sp.issuer != address) continue;
 
-        std::map<std::string, std::vector<uint64_t> >::const_iterator it;
-        const std::map<std::string, std::vector<uint64_t> >& database = sp.historicalData;
+        std::map<std::string, std::vector<int64_t> >::const_iterator it;
+        const std::map<std::string, std::vector<int64_t> >& database = sp.historicalData;
         for (it = database.begin(); it != database.end(); it++) {
             uint256 tmpTxid(it->first); // construct from string
             if (tmpTxid == txid) {
@@ -714,13 +714,13 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
         }
     }
 
-    for (int64_t tmpPropertyId = TEST_ECO_PROPERTY_1; tmpPropertyId < nextTestSPID; tmpPropertyId++) {
+    for (uint32_t tmpPropertyId = TEST_ECO_PROPERTY_1; tmpPropertyId < nextTestSPID; tmpPropertyId++) {
         CMPSPInfo::Entry sp;
         if (!_my_sps->getSP(tmpPropertyId, sp)) continue;
         if (sp.issuer == address) continue;
 
-        std::map<std::string, std::vector<uint64_t> >::const_iterator it;
-        const std::map<std::string, std::vector<uint64_t> >& database = sp.historicalData;
+        std::map<std::string, std::vector<int64_t> >::const_iterator it;
+        const std::map<std::string, std::vector<int64_t> >& database = sp.historicalData;
         for (it = database.begin(); it != database.end(); it++) {
             uint256 tmpTxid(it->first); // construct from string
             if (tmpTxid == txid) {
@@ -736,7 +736,7 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
     return false;
 }
 
-void mastercore::eraseMaxedCrowdsale(const std::string& address, uint64_t blockTime, int block)
+void mastercore::eraseMaxedCrowdsale(const std::string& address, int64_t blockTime, int block)
 {
     CrowdMap::iterator it = my_crowds.find(address);
 
@@ -752,8 +752,8 @@ void mastercore::eraseMaxedCrowdsale(const std::string& address, uint64_t blockT
 
         // get txdata
         sp.historicalData = crowdsale.getDatabase();
-        sp.close_early = 1;
-        sp.max_tokens = 1;
+        sp.close_early = true;
+        sp.max_tokens = true;
         sp.timeclosed = blockTime;
 
         // update SP with this data
@@ -777,7 +777,7 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
         const std::string& address = my_it->first;
         const CMPCrowd& crowdsale = my_it->second;
 
-        if (blockTime > (int64_t) crowdsale.getDeadline()) {
+        if (blockTime > crowdsale.getDeadline()) {
             PrintToLog("%s() FOUND EXPIRED CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, address);
 
             // TODO: dump the info about this crowdsale being delete into a TXT file (JSON perhaps)
@@ -817,7 +817,7 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
     return how_many_erased;
 }
 
-const char* mastercore::c_strPropertyType(int propertyType)
+const char* mastercore::c_strPropertyType(uint16_t propertyType)
 {
     switch (propertyType) {
         case MSC_PROPERTY_TYPE_DIVISIBLE: return "divisible";

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -176,9 +176,10 @@ uint32_t CMPSPInfo::putSP(uint8_t ecosystem, const Entry& info)
     ssSpValue << info;
     leveldb::Slice slSpValue(&ssSpValue[0], ssSpValue.size());
 
-    // DB key for identifier lookup entry: "index-tx-%s"
-    std::string txIndexKey = strprintf(FORMAT_BOOST_TXINDEXKEY, info.txid.ToString());
-    leveldb::Slice slTxIndexKey(txIndexKey);
+    // DB key for identifier lookup entry
+    CDataStream ssTxIndexKey(SER_DISK, CLIENT_VERSION);
+    ssTxIndexKey << std::make_pair('t', info.txid);
+    leveldb::Slice slTxIndexKey(&ssTxIndexKey[0], ssTxIndexKey.size());
 
     // DB value for identifier
     CDataStream ssTxValue(SER_DISK, CLIENT_VERSION);
@@ -267,9 +268,10 @@ uint32_t CMPSPInfo::findSPByTX(const uint256& txid) const
 {
     uint32_t propertyId = 0;
 
-    // DB key for identifier lookup entry: "index-tx-%s"
-    std::string strTxIndexKey = strprintf(FORMAT_BOOST_TXINDEXKEY, txid.ToString());
-    leveldb::Slice slTxIndexKey(strTxIndexKey);
+    // DB key for identifier lookup entry
+    CDataStream ssTxIndexKey(SER_DISK, CLIENT_VERSION);
+    ssTxIndexKey << std::make_pair('t', txid);
+    leveldb::Slice slTxIndexKey(&ssTxIndexKey[0], ssTxIndexKey.size());
 
     // DB value for identifier
     std::string strTxIndexValue;
@@ -319,8 +321,9 @@ int64_t CMPSPInfo::popBlock(const uint256& block_hash)
             // need to roll this SP back
             if (info.update_block == info.creation_block) {
                 // this is the block that created this SP, so delete the SP and the tx index entry
-                std::string strTxIndexKey = strprintf(FORMAT_BOOST_TXINDEXKEY, info.txid.ToString());
-                leveldb::Slice slTxIndexKey(strTxIndexKey);
+                CDataStream ssTxIndexKey(SER_DISK, CLIENT_VERSION);
+                ssTxIndexKey << std::make_pair('t', info.txid);
+                leveldb::Slice slTxIndexKey(&ssTxIndexKey[0], ssTxIndexKey.size());
                 commitBatch.Delete(slSpKey);
                 commitBatch.Delete(slTxIndexKey);
             } else {

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -85,9 +85,11 @@ public:
         bool fixed;
         bool manual;
 
-        // for crowdsale properties, schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
-        // for manual properties, schema is 'txid:grantAmount:revokeAmount;'
-        std::map<std::string, std::vector<int64_t> > historicalData;
+        // For crowdsale properties:
+        //   txid -> amount invested, crowdsale deadline, user issued tokens, issuer issued tokens
+        // For managed properties:
+        //   txid -> granted amount, revoked amount
+        std::map<uint256, std::vector<int64_t> > historicalData;
 
         Entry();
 
@@ -172,7 +174,9 @@ private:
 
     uint256 txid; // NOTE: not persisted as it doesnt seem used
 
-    std::map<std::string, std::vector<int64_t> > txFundraiserData; // schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
+    // Schema:
+    //   txid -> amount invested, crowdsale deadline, user issued tokens, issuer issued tokens
+    std::map<uint256, std::vector<int64_t> > txFundraiserData;
 
 public:
     CMPCrowd();
@@ -189,8 +193,8 @@ public:
     int64_t getUserCreated() const { return u_created; }
     int64_t getIssuerCreated() const { return i_created; }
 
-    void insertDatabase(const std::string& txhash, const std::vector<int64_t>& txdata);
-    std::map<std::string, std::vector<int64_t> > getDatabase() const { return txFundraiserData; }
+    void insertDatabase(const uint256& txHash, const std::vector<int64_t>& txData);
+    std::map<uint256, std::vector<int64_t> > getDatabase() const { return txFundraiserData; }
 
     void print(const std::string& address, FILE* fp = stdout) const;
     void saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& addr) const;
@@ -215,7 +219,7 @@ bool isCrowdsalePurchase(const uint256& txid, const std::string& address, int64_
 
 // TODO: check, if this could be combined with the other calculate* functions
 int64_t calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundraiserSecs,
-        int64_t numProps, uint8_t issuerPerc, const std::map<std::string, std::vector<int64_t> >& txFundraiserData,
+        int64_t numProps, uint8_t issuerPerc, const std::map<uint256, std::vector<int64_t> >& txFundraiserData,
         const int64_t amountPremined);
 
 void eraseMaxedCrowdsale(const std::string& address, int64_t blockTime, int block);

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -38,7 +38,8 @@ class uint256;
  *      CMPSPInfo::Entry info
  *
  *  Key:
- *      std::string "index-tx-[hashTxid]"
+ *      char 't'
+ *      uint256 hashTxid
  *  Value:
  *      uint32_t propertyId
  *

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -114,10 +114,10 @@ public:
     void init(uint32_t nextSPID = 0x3UL, uint32_t nextTestSPID = TEST_ECO_PROPERTY_1);
 
     uint32_t peekNextSPID(uint8_t ecosystem) const;
-    uint32_t updateSP(uint32_t propertyID, const Entry& info);
+    bool updateSP(uint32_t propertyId, const Entry& info);
     uint32_t putSP(uint8_t ecosystem, const Entry& info);
-    bool getSP(uint32_t spid, Entry& info) const;
-    bool hasSP(uint32_t spid) const;
+    bool getSP(uint32_t propertyId, Entry& info) const;
+    bool hasSP(uint32_t propertyId) const;
     uint32_t findSPByTX(const uint256& txid) const;
 
     int64_t popBlock(const uint256& block_hash);

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -96,7 +96,7 @@ public:
 
     static std::string const watermarkKey;
     void setWatermark(const uint256& watermark);
-    int getWatermark(uint256& watermark) const;
+    bool getWatermark(uint256& watermark) const;
 
     void printAll() const;
 };

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -27,7 +27,7 @@ class uint256;
  * DB Schema:
  *
  *  Key:
- *      std::string "watermark"
+ *      char 'B'
  *  Value:
  *      uint256 hashBlock
  *
@@ -145,7 +145,6 @@ public:
 
     int64_t popBlock(const uint256& block_hash);
 
-    static std::string const watermarkKey;
     void setWatermark(const uint256& watermark);
     bool getWatermark(uint256& watermark) const;
 

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -8,11 +8,11 @@
 class CBlockIndex;
 class uint256;
 
+#include "serialize.h"
+
 #include <boost/filesystem.hpp>
 
 #include <openssl/sha.h>
-
-#include "json/json_spirit_value.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -65,8 +65,36 @@ public:
 
         Entry();
 
-        json_spirit::Object toJSON() const;
-        void fromJSON(const json_spirit::Object& json);
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+            READWRITE(issuer);
+            READWRITE(prop_type);
+            READWRITE(prev_prop_id);
+            READWRITE(category);
+            READWRITE(subcategory);
+            READWRITE(name);
+            READWRITE(url);
+            READWRITE(data);
+            READWRITE(num_tokens);
+            READWRITE(property_desired);
+            READWRITE(deadline);
+            READWRITE(early_bird);
+            READWRITE(percentage);
+            READWRITE(close_early);
+            READWRITE(max_tokens);
+            READWRITE(missedTokens);
+            READWRITE(timeclosed);
+            READWRITE(txid_close);
+            READWRITE(txid);
+            READWRITE(creation_block);
+            READWRITE(update_block);
+            READWRITE(fixed);
+            READWRITE(manual);
+            READWRITE(historicalData);
+        }
+
         bool isDivisible() const;
         void print() const;
     };
@@ -92,7 +120,7 @@ public:
     bool hasSP(uint32_t spid) const;
     uint32_t findSPByTX(const uint256& txid) const;
 
-    int popBlock(const uint256& block_hash);
+    int64_t popBlock(const uint256& block_hash);
 
     static std::string const watermarkKey;
     void setWatermark(const uint256& watermark);

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -30,26 +30,26 @@ public:
     struct Entry {
         // common SP data
         std::string issuer;
-        unsigned short prop_type;
-        unsigned int prev_prop_id;
+        uint16_t prop_type;
+        uint32_t prev_prop_id;
         std::string category;
         std::string subcategory;
         std::string name;
         std::string url;
         std::string data;
-        uint64_t num_tokens;
+        int64_t num_tokens;
 
         // crowdsale generated SP
-        unsigned int property_desired;
-        uint64_t deadline;
-        unsigned char early_bird;
-        unsigned char percentage;
+        uint32_t property_desired;
+        int64_t deadline;
+        uint8_t early_bird;
+        uint8_t percentage;
 
         // closedearly states, if the SP was a crowdsale and closed due to MAXTOKENS or CLOSE command
         bool close_early;
         bool max_tokens;
-        uint64_t missedTokens;
-        uint64_t timeclosed;
+        int64_t missedTokens;
+        int64_t timeclosed;
         uint256 txid_close;
 
         // other information
@@ -61,7 +61,7 @@ public:
 
         // for crowdsale properties, schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
         // for manual properties, schema is 'txid:grantAmount:revokeAmount;'
-        std::map<std::string, std::vector<uint64_t> > historicalData;
+        std::map<std::string, std::vector<int64_t> > historicalData;
 
         Entry();
 
@@ -76,21 +76,21 @@ private:
     Entry implied_msc;
     Entry implied_tmsc;
 
-    unsigned int next_spid;
-    unsigned int next_test_spid;
+    uint32_t next_spid;
+    uint32_t next_test_spid;
 
 public:
     CMPSPInfo(const boost::filesystem::path& path, bool fWipe);
     virtual ~CMPSPInfo();
 
-    void init(unsigned int nextSPID = 0x3UL, unsigned int nextTestSPID = TEST_ECO_PROPERTY_1);
+    void init(uint32_t nextSPID = 0x3UL, uint32_t nextTestSPID = TEST_ECO_PROPERTY_1);
 
-    unsigned int peekNextSPID(unsigned char ecosystem) const;
-    unsigned int updateSP(unsigned int propertyID, const Entry& info);
-    unsigned int putSP(unsigned char ecosystem, const Entry& info);
-    bool getSP(unsigned int spid, Entry& info) const;
-    bool hasSP(unsigned int spid) const;
-    unsigned int findSPByTX(const uint256& txid) const;
+    uint32_t peekNextSPID(uint8_t ecosystem) const;
+    uint32_t updateSP(uint32_t propertyID, const Entry& info);
+    uint32_t putSP(uint8_t ecosystem, const Entry& info);
+    bool getSP(uint32_t spid, Entry& info) const;
+    bool hasSP(uint32_t spid) const;
+    uint32_t findSPByTX(const uint256& txid) const;
 
     int popBlock(const uint256& block_hash);
 
@@ -106,39 +106,38 @@ public:
 class CMPCrowd
 {
 private:
-    unsigned int propertyId;
+    uint32_t propertyId;
+    int64_t nValue;
 
-    uint64_t nValue;
+    uint32_t property_desired;
+    int64_t deadline;
+    uint8_t early_bird;
+    uint8_t percentage;
 
-    unsigned int property_desired;
-    uint64_t deadline;
-    unsigned char early_bird;
-    unsigned char percentage;
-
-    uint64_t u_created;
-    uint64_t i_created;
+    int64_t u_created;
+    int64_t i_created;
 
     uint256 txid; // NOTE: not persisted as it doesnt seem used
 
-    std::map<std::string, std::vector<uint64_t> > txFundraiserData; // schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
+    std::map<std::string, std::vector<int64_t> > txFundraiserData; // schema is 'txid:amtSent:deadlineUnix:userIssuedTokens:IssuerIssuedTokens;'
 
 public:
     CMPCrowd();
-    CMPCrowd(unsigned int pid, uint64_t nv, unsigned int cd, uint64_t dl, unsigned char eb, unsigned char per, uint64_t uct, uint64_t ict);
+    CMPCrowd(uint32_t pid, int64_t nv, uint32_t cd, int64_t dl, uint8_t eb, uint8_t per, int64_t uct, int64_t ict);
 
-    unsigned int getPropertyId() const { return propertyId; }
+    uint32_t getPropertyId() const { return propertyId; }
 
-    uint64_t getDeadline() const { return deadline; }
-    uint64_t getCurrDes() const { return property_desired; }
+    int64_t getDeadline() const { return deadline; }
+    uint32_t getCurrDes() const { return property_desired; }
 
-    void incTokensUserCreated(uint64_t amount) { u_created += amount; }
-    void incTokensIssuerCreated(uint64_t amount) { i_created += amount; }
+    void incTokensUserCreated(int64_t amount) { u_created += amount; }
+    void incTokensIssuerCreated(int64_t amount) { i_created += amount; }
 
-    uint64_t getUserCreated() const { return u_created; }
-    uint64_t getIssuerCreated() const { return i_created; }
+    int64_t getUserCreated() const { return u_created; }
+    int64_t getIssuerCreated() const { return i_created; }
 
-    void insertDatabase(const std::string& txhash, const std::vector<uint64_t>& txdata);
-    std::map<std::string, std::vector<uint64_t> > getDatabase() const { return txFundraiserData; }
+    void insertDatabase(const std::string& txhash, const std::vector<int64_t>& txdata);
+    std::map<std::string, std::vector<int64_t> > getDatabase() const { return txFundraiserData; }
 
     void print(const std::string& address, FILE* fp = stdout) const;
     void saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& addr) const;
@@ -151,22 +150,22 @@ typedef std::map<std::string, CMPCrowd> CrowdMap;
 extern CMPSPInfo* _my_sps;
 extern CrowdMap my_crowds;
 
-const char* c_strPropertyType(int propertyType);
+const char* c_strPropertyType(uint16_t propertyType);
 
-std::string getPropertyName(unsigned int propertyId);
-bool isPropertyDivisible(unsigned int propertyId);
+std::string getPropertyName(uint32_t propertyId);
+bool isPropertyDivisible(uint32_t propertyId);
 
 CMPCrowd* getCrowd(const std::string& address);
 
-bool isCrowdsaleActive(unsigned int propertyId);
+bool isCrowdsaleActive(uint32_t propertyId);
 bool isCrowdsalePurchase(const uint256& txid, const std::string& address, int64_t* propertyId, int64_t* userTokens, int64_t* issuerTokens);
 
 // TODO: check, if this could be combined with the other calculate* functions
-int calculateFractional(unsigned short int propType, unsigned char bonusPerc, uint64_t fundraiserSecs, 
-  uint64_t numProps, unsigned char issuerPerc, const std::map<std::string, std::vector<uint64_t> >& txFundraiserData, 
-  const uint64_t amountPremined);
+int64_t calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundraiserSecs,
+        int64_t numProps, uint8_t issuerPerc, const std::map<std::string, std::vector<int64_t> >& txFundraiserData,
+        const int64_t amountPremined);
 
-void eraseMaxedCrowdsale(const std::string& address, uint64_t blockTime, int block);
+void eraseMaxedCrowdsale(const std::string& address, int64_t blockTime, int block);
 
 unsigned int eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex);
 

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -23,6 +23,29 @@ class uint256;
 #include <vector>
 
 /** LevelDB based storage for currencies, smart properties and tokens.
+ *
+ * DB Schema:
+ *
+ *  Key:
+ *      std::string "watermark"
+ *  Value:
+ *      uint256 hashBlock
+ *
+ *  Key:
+ *      char 's'
+ *      uint32_t propertyId
+ *  Value:
+ *      CMPSPInfo::Entry info
+ *
+ *  Key:
+ *      std::string "index-tx-[hashTxid]"
+ *  Value:
+ *      uint32_t propertyId
+ *
+ *  Key:
+ *      std::string "blk-[hashBlock]:sp-[propertyId]"
+ *  Value:
+ *      CMPSPInfo::Entry info
  */
 class CMPSPInfo : public CDBBase
 {

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -44,7 +44,9 @@ class uint256;
  *      uint32_t propertyId
  *
  *  Key:
- *      std::string "blk-[hashBlock]:sp-[propertyId]"
+ *      char 'b'
+ *      uint256 hashBlock
+ *      uint32_t propertyId
  *  Value:
  *      CMPSPInfo::Entry info
  */

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1447,8 +1447,7 @@ int CMPTransaction::logicMath_GrantTokens()
     std::vector<int64_t> dataPt;
     dataPt.push_back(nValue);
     dataPt.push_back(0);
-    std::string txidStr = txid.ToString();
-    sp.historicalData.insert(std::make_pair(txidStr, dataPt));
+    sp.historicalData.insert(std::make_pair(txid, dataPt));
     sp.update_block = chainActive[block]->GetBlockHash();
     _my_sps->updateSP(property, sp);
 
@@ -1498,8 +1497,7 @@ int CMPTransaction::logicMath_RevokeTokens()
     std::vector<int64_t> dataPt;
     dataPt.push_back(0);
     dataPt.push_back(nValue);
-    std::string txidStr = txid.ToString();
-    sp.historicalData.insert(std::make_pair(txidStr, dataPt));
+    sp.historicalData.insert(std::make_pair(txid, dataPt));
     sp.update_block = chainActive[block]->GetBlockHash();
     _my_sps->updateSP(property, sp);
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1199,7 +1199,7 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
     if (MSC_PROPERTY_TYPE_INDIVISIBLE != prop_type && MSC_PROPERTY_TYPE_DIVISIBLE != prop_type) {
         return (PKT_ERROR_SP -502);
     }
-    unsigned int prop_id = _my_sps->peekNextSPID(ecosystem);
+    uint32_t prop_id = _my_sps->peekNextSPID(ecosystem);
     if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
         return (PKT_ERROR_SP -503);
     }
@@ -1230,7 +1230,7 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
     newSP.fixed = true;
     newSP.creation_block = newSP.update_block = chainActive[block]->GetBlockHash();
 
-    const unsigned int id = _my_sps->putSP(ecosystem, newSP);
+    const uint32_t id = _my_sps->putSP(ecosystem, newSP);
     update_tally_map(sender, id, nValue, BALANCE);
 
     rc = 0;
@@ -1245,7 +1245,7 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
     if (MSC_PROPERTY_TYPE_INDIVISIBLE != prop_type && MSC_PROPERTY_TYPE_DIVISIBLE != prop_type) {
         return (PKT_ERROR_SP -502);
     }
-    unsigned int prop_id = _my_sps->peekNextSPID(ecosystem);
+    uint32_t prop_id = _my_sps->peekNextSPID(ecosystem);
     if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
         return (PKT_ERROR_SP -503);
     }
@@ -1261,7 +1261,7 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
     }
     if (!deadline) return (PKT_ERROR_SP - 203); // deadline cannot be 0
     // deadline can not be smaller than the timestamp of the current block
-    if (deadline < (uint64_t) blockTime) return (PKT_ERROR_SP - 204);
+    if ((int64_t) deadline < blockTime) return (PKT_ERROR_SP - 204);
     // ------------------------------------------
 
     int rc = -1;
@@ -1289,7 +1289,7 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
     newSP.percentage = percentage;
     newSP.creation_block = newSP.update_block = chainActive[block]->GetBlockHash();
 
-    const unsigned int id = _my_sps->putSP(ecosystem, newSP);
+    const uint32_t id = _my_sps->putSP(ecosystem, newSP);
     my_crowds.insert(std::make_pair(sender, CMPCrowd(id, nValue, property, deadline, early_bird, percentage, 0, 0)));
     PrintToLog("CREATED CROWDSALE id: %u value: %lu property: %u\n", id, nValue, property);
 
@@ -1355,7 +1355,7 @@ int CMPTransaction::logicMath_CreatePropertyMananged()
     if (MSC_PROPERTY_TYPE_INDIVISIBLE != prop_type && MSC_PROPERTY_TYPE_DIVISIBLE != prop_type) {
         return (PKT_ERROR_SP -502);
     }
-    unsigned int prop_id = _my_sps->peekNextSPID(ecosystem);
+    uint32_t prop_id = _my_sps->peekNextSPID(ecosystem);
     if (!isTransactionTypeAllowed(block, prop_id, type, version)) {
         return (PKT_ERROR_SP -503);
     }
@@ -1378,7 +1378,7 @@ int CMPTransaction::logicMath_CreatePropertyMananged()
     newSP.fixed = false;
     newSP.manual = true;
 
-    const unsigned int id = _my_sps->putSP(ecosystem, newSP);
+    uint32_t id = _my_sps->putSP(ecosystem, newSP);
     PrintToLog("CREATED MANUAL PROPERTY id: %u admin: %s \n", id, sender);
 
     rc = 0;
@@ -1444,10 +1444,10 @@ int CMPTransaction::logicMath_GrantTokens()
     rc = logicMath_SimpleSend();
 
     // record this grant
-    std::vector<uint64_t> dataPt;
+    std::vector<int64_t> dataPt;
     dataPt.push_back(nValue);
     dataPt.push_back(0);
-    string txidStr = txid.ToString();
+    std::string txidStr = txid.ToString();
     sp.historicalData.insert(std::make_pair(txidStr, dataPt));
     sp.update_block = chainActive[block]->GetBlockHash();
     _my_sps->updateSP(property, sp);
@@ -1495,10 +1495,10 @@ int CMPTransaction::logicMath_RevokeTokens()
     }
 
     // record this revoke
-    std::vector<uint64_t> dataPt;
+    std::vector<int64_t> dataPt;
     dataPt.push_back(0);
     dataPt.push_back(nValue);
-    string txidStr = txid.ToString();
+    std::string txidStr = txid.ToString();
     sp.historicalData.insert(std::make_pair(txidStr, dataPt));
     sp.update_block = chainActive[block]->GetBlockHash();
     _my_sps->updateSP(property, sp);


### PR DESCRIPTION
This PR replaces the string based LevelDB persistence with byte based storage, and updates a few related data types to correct, fixed size length types. Code, which was touched, was formatted here and there.

The updated DB schema of `MP_spinfo/` is as follows:
```
Last processed block (watermark):

  Key:
      char 'B'
  Value:
      uint256 hashBlock


SP entries:

  Key:
      char 's'
      uint32_t propertyId
  Value:
      CMPSPInfo::Entry info


Historical SP entries:

  Key:
      char 'b'
      uint256 hashBlock
      uint32_t propertyId
  Value:
      CMPSPInfo::Entry info


SP identifiers indexed by creation transactions:

  Key:
      char 't'
      uint256 hashTxid
  Value:
      uint32_t propertyId
```

It's significantly faster, and it resolves #88, and it resolves #84 hopefully, too.