### PR TITLE
Lock initialization, handlers and core logic

### DIFF
--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -5,6 +5,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/create_payload_tests.cpp \
   omnicore/test/encoding_b_tests.cpp \
   omnicore/test/encoding_c_tests.cpp \
+  omnicore/test/lock_tests.cpp \
   omnicore/test/obfuscation_tests.cpp \
   omnicore/test/rounduint64_tests.cpp \
   omnicore/test/rpc_requirements_tests.cpp \

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1401,9 +1401,12 @@ static int msc_file_load(const string &filename, int what, bool verifyHash = fal
   switch (what)
   {
     case FILETYPE_BALANCES:
+    {
+      LOCK(cs_tally);
       mp_tally_map.clear();
       inputLineFunc = input_msc_balances_string;
       break;
+    }
 
     case FILETYPE_OFFERS:
       my_offers.clear();
@@ -1887,7 +1890,10 @@ int mastercore_save_state( CBlockIndex const *pBlockIndex )
 static void clear_all_state()
 {
     // Memory based storage
-    mp_tally_map.clear();
+    {
+        LOCK(cs_tally);
+        mp_tally_map.clear();
+    }
     my_offers.clear();
     my_accepts.clear();
     my_crowds.clear();

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1892,7 +1892,10 @@ static void clear_all_state()
     my_accepts.clear();
     my_crowds.clear();
     metadex.clear();
-    my_pending.clear();
+    {
+        LOCK(cs_pending);
+        my_pending.clear();
+    }
 
     // LevelDB based storage
     _my_sps->Clear();

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -609,6 +609,8 @@ uint32_t mastercore::GetNextPropertyId(bool maineco)
 
 void CheckWalletUpdate(bool forceUpdate)
 {
+    LOCK(cs_tally);
+
     if (!WalletCacheUpdate()) {
         // no balance changes were detected that affect wallet addresses, signal a generic change to overall Omni state
         if (!forceUpdate) {
@@ -620,7 +622,6 @@ void CheckWalletUpdate(bool forceUpdate)
     // balance changes were found in the wallet, update the global totals and signal a Omni balance change
     global_balance_money.clear();
     global_balance_reserved.clear();
-    LOCK(cs_tally);
 
     // populate global balance totals and wallet property list - note global balances do not include additional balances from watch-only addresses
     for (std::map<std::string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it) {

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -186,12 +186,6 @@ private:
     //! Internal iterator pointing to a balance record
     TokenMap::iterator my_it;
 
-    // TODO: lock outside of CMPTally
-    //
-    // There are usually many tally operations, and the
-    // global tally map must be locked anyway, so locking
-    // here is redundant and might be costly.
-
 public:
     /** Resets the internal iterator. */
     uint32_t init()
@@ -222,11 +216,7 @@ public:
             return false;
         }
         bool bRet = false;
-        int64_t now64 = 0;
-
-        LOCK(cs_tally);
-
-        now64 = mp_token[propertyId].balance[ttype];
+        int64_t now64 = mp_token[propertyId].balance[ttype];
 
         if (PENDING != ttype && (now64 + amount) < 0) {
             // NOTE:
@@ -254,8 +244,6 @@ public:
             return 0;
         }
         int64_t money = 0;
-
-        LOCK(cs_tally);
         TokenMap::const_iterator it = mp_token.find(propertyId);
 
         if (it != mp_token.end()) {
@@ -269,7 +257,6 @@ public:
     /** Returns the number of available tokens. */
     int64_t getMoneyAvailable(uint32_t propertyId) const
     {
-        LOCK(cs_tally);
         TokenMap::const_iterator it = mp_token.find(propertyId);
 
         if (it != mp_token.end()) {
@@ -288,8 +275,6 @@ public:
     int64_t getMoneyReserved(uint32_t propertyId) const
     {
         int64_t money = 0;
-
-        LOCK(cs_tally);
         TokenMap::const_iterator it = mp_token.find(propertyId);
 
         if (it != mp_token.end()) {
@@ -305,8 +290,6 @@ public:
     /** Compares the tally with another tally and returns true, if they are equal. */
     bool operator==(const CMPTally& rhs) const
     {
-        LOCK(cs_tally);
-
         if (mp_token.size() != rhs.mp_token.size()) {
             return false;
         }

--- a/src/omnicore/pending.h
+++ b/src/omnicore/pending.h
@@ -4,6 +4,8 @@
 class uint256;
 struct CMPPending;
 
+#include "sync.h"
+
 #include <stdint.h>
 #include <map>
 #include <string>
@@ -12,6 +14,8 @@ namespace mastercore
 {
 //! Map of pending transaction objects
 typedef std::map<uint256, CMPPending> PendingMap;
+//! Guards my_pending
+extern CCriticalSection cs_pending;
 //! Global map of pending transaction objects
 extern PendingMap my_pending;
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -170,23 +170,20 @@ int extra2 = 0, extra3 = 0;
   // various extra tests
   switch (extra)
   {
-    case 0: // the old output
+    case 0:
     {
-    uint64_t total = 0;
+        LOCK(cs_tally);
 
+        int64_t total = 0;
         // display all balances
-        for(map<string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it)
-        {
-          // my_it->first = key
-          // my_it->second = value
-
-          PrintToConsole("%34s => ", my_it->first);
-          total += (my_it->second).print(extra2, bDivisible);
+        for (std::map<std::string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it) {
+            PrintToConsole("%34s => ", my_it->first);
+            total += (my_it->second).print(extra2, bDivisible);
         }
 
         PrintToConsole("total for property %d  = %X is %s\n", extra2, extra2, FormatDivisibleMP(total));
-      }
-      break;
+        break;
+    }
 
     case 1:
       // display the whole CMPTxList (leveldb)
@@ -200,24 +197,22 @@ int extra2 = 0, extra3 = 0;
       break;
 
     case 3:
-        unsigned int id;
+    {
+        LOCK(cs_tally);
+
+        uint32_t id = 0;
         // for each address display all currencies it holds
-        for(map<string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it)
-        {
-          // my_it->first = key
-          // my_it->second = value
-
-          PrintToConsole("%34s => ", my_it->first);
-          (my_it->second).print(extra2);
-
-          (my_it->second).init();
-          while (0 != (id = (my_it->second).next()))
-          {
-            PrintToConsole("Id: %u=0x%X ", id, id);
-          }
-          PrintToConsole("\n");
+        for (std::map<std::string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it) {
+            PrintToConsole("%34s => ", my_it->first);
+            (my_it->second).print(extra2);
+            (my_it->second).init();
+            while (0 != (id = (my_it->second).next())) {
+                PrintToConsole("Id: %u=0x%X ", id, id);
+            }
+            PrintToConsole("\n");
         }
-      break;
+        break;
+    }
 
     case 4:
       for(CrowdMap::const_iterator it = my_crowds.begin(); it != my_crowds.end(); ++it)
@@ -351,6 +346,8 @@ Value getallbalancesforid_MP(const Array& params, bool fHelp)
     Array response;
     bool isDivisible = isPropertyDivisible(propertyId); // we want to check this BEFORE the loop
 
+    LOCK(cs_tally);
+
     for (std::map<std::string, CMPTally>::iterator it = mp_tally_map.begin(); it != mp_tally_map.end(); ++it) {
         uint32_t id = 0;
         bool includeAddress = false;
@@ -400,6 +397,8 @@ Value getallbalancesforaddress_MP(const Array& params, bool fHelp)
     std::string address = ParseAddress(params[0]);
 
     Array response;
+
+    LOCK(cs_tally);
 
     CMPTally* addressTally = getTally(address);
 

--- a/src/omnicore/test/lock_tests.cpp
+++ b/src/omnicore/test/lock_tests.cpp
@@ -1,0 +1,47 @@
+#include "random.h"
+#include "sync.h"
+#include "utiltime.h"
+
+#include <boost/bind.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/thread.hpp>
+
+namespace number
+{
+    int n = 0;
+}
+
+namespace locker
+{
+    CCriticalSection cs_number;
+}
+
+static void plusOneThread(int nIterations)
+{
+    for (int i = 0; i < nIterations; ++i) {
+        LOCK(locker::cs_number);
+        int n = number::n;
+        int nSleep = GetRandInt(10);
+        MilliSleep(nSleep);
+        number::n = n + 1;
+    }
+}
+
+BOOST_AUTO_TEST_SUITE(omnicore_lock_tests)
+
+BOOST_AUTO_TEST_CASE(multithread_locking)
+{
+    int nThreadsNum = 4;
+    int nIterations = 20;
+
+    boost::thread_group threadGroup;
+    for (int i = 0; i < nThreadsNum; ++i) {
+        threadGroup.create_thread(boost::bind(&plusOneThread, nIterations));
+    }
+
+    threadGroup.join_all();
+    BOOST_CHECK_EQUAL(number::n, (nThreadsNum * nIterations));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -881,8 +881,6 @@ void CMPTransaction::printInfo(FILE *fp)
 
 int CMPTransaction::logicMath_SendToOwners()
 {
-    LOCK(cs_tally);
-
     if (!isTransactionTypeAllowed(block, property, type, version)) {
         return (PKT_ERROR_STO -22);
     }

--- a/src/omnicore/walletcache.h
+++ b/src/omnicore/walletcache.h
@@ -1,10 +1,15 @@
 #ifndef OMNICORE_WALLETCACHE_H
 #define OMNICORE_WALLETCACHE_H
 
-#include <string>
+class uint256;
+
+#include <vector>
+
+//! Global vector of Omni transactions in the wallet
+extern std::vector<uint256> walletTXIDCache;
 
 /** Adds a txid to the wallet txid cache, performing duplicate detection */
-void WalletTXIDCacheAdd(uint256 hash);
+void WalletTXIDCacheAdd(const uint256& hash);
 
 /** Performs initial population of the wallet txid cache */
 void WalletTXIDCacheInit();
@@ -12,8 +17,5 @@ void WalletTXIDCacheInit();
 /** Updates the cache and returns whether any wallet addresses were changed */
 int WalletCacheUpdate();
 
-//! Global vector of Omni transactions in the wallet
-extern std::vector<uint256> walletTXIDCache;
+
 #endif // OMNICORE_WALLETCACHE_H
-
-

--- a/src/qt/balancesdialog.cpp
+++ b/src/qt/balancesdialog.cpp
@@ -139,10 +139,10 @@ void BalancesDialog::setWalletModel(WalletModel *model)
 
 void BalancesDialog::UpdatePropSelector()
 {
+    LOCK(cs_tally);
+
     // don't waste time updating if there are no new properties
     if ((uint32_t)ui->propSelectorWidget->count() > global_wallet_property_list.size()) return;
-
-    LOCK(cs_tally);
 
     // a new property has been added to the wallet, update the property selector
     QString spId = ui->propSelectorWidget->itemData(ui->propSelectorWidget->currentIndex()).toString();

--- a/src/qt/lookupspdialog.cpp
+++ b/src/qt/lookupspdialog.cpp
@@ -294,7 +294,11 @@ void LookupSPDialog::updateDisplayedProperty()
     string strTotalTokens;
     string strWalletTokens;
     int64_t totalTokens = getTotalTokens(propertyId);
-    int64_t walletTokens = global_balance_money[propertyId];
+    int64_t walletTokens = 0;
+    {
+        LOCK(cs_tally);
+        walletTokens = global_balance_money[propertyId];
+    }
     string tokenLabel;
     if (propertyId > 2)
     {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -3,10 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "transactionrecord.h"
+
 #include "omnicore/omnicore.h"
 #include "omnicore/pending.h"
 
 #include "base58.h"
+#include "sync.h"
 #include "timedata.h"
 #include "wallet.h"
 
@@ -45,8 +47,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     // Omni override - since we use multiple outputs these show up as multiple transaction records
     // and cause duplicate entries to be displayed in bitcoin history and overview recent
     bool omniOverride = false;
-    PendingMap::iterator it = my_pending.find(hash);
-    if (it != my_pending.end()) omniOverride = true;
+    {
+        LOCK(cs_pending);
+
+        PendingMap::iterator it = my_pending.find(hash);
+        if (it != my_pending.end()) omniOverride = true;
+    }
     if (p_txlistdb->exists(hash)) omniOverride = true;
     if (omniOverride) {
         TransactionRecord sub(hash, nTime);


### PR DESCRIPTION
... as well as the pending transactions and global balance cache.

This should do the trick for the core, but there are still unguarded reads from the UI and RPC for globals other than `my_tally_map`, `my_pending` or the balance cache.