### PR TITLE
Avoid using variable length array in parseTransaction()

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1693,7 +1693,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             // ### PREPARE A FEW VARS ###
             std::string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
             PrepareObfuscatedHashes(strSender, strObfuscatedHashes);
-            unsigned char packets[nPackets][32];
+            unsigned char packets[MAX_PACKETS][32];
             unsigned int mdata_count = 0;  // multisig data count
 
             // ### DEOBFUSCATE MULTISIG PACKETS ###


### PR DESCRIPTION
Some [build configurations](https://travis-ci.org/OmniLayer/omnicore/jobs/69076400#L1912) don't like:
```c++
unsigned int nPackets = multisig_script_data.size();
// ...
unsigned char packets[nPackets][32];
```
And this pull request reverts this part of the recent update back to:
```c++
unsigned char packets[MAX_PACKETS][32];
```

`nPackets` is guaranteed to be smaller or equal than `MAX_PACKETS`, so this is safe.