### PR TITLE
Seperate block height restrictions and feature activation

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -17,12 +17,14 @@ OMNICORE_H = \
   omnicore/rpctx.h \
   omnicore/rpctxobject.h \
   omnicore/rpcvalues.h \
+  omnicore/rules.h \
   omnicore/script.h \
   omnicore/sp.h \
   omnicore/sto.h \
   omnicore/tally.h \
   omnicore/tx.h \
   omnicore/utils.h \
+  omnicore/utilsbitcoin.h \
   omnicore/version.h \
   omnicore/walletcache.h
 
@@ -44,12 +46,14 @@ OMNICORE_CPP = \
   omnicore/rpctx.cpp \
   omnicore/rpctxobject.cpp \
   omnicore/rpcvalues.cpp \
+  omnicore/rules.cpp \
   omnicore/script.cpp \
   omnicore/sp.cpp \
   omnicore/sto.cpp \
   omnicore/tally.cpp \
   omnicore/tx.cpp \
   omnicore/utils.cpp \
+  omnicore/utilsbitcoin.cpp \
   omnicore/version.cpp \
   omnicore/walletcache.cpp
 

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -17,6 +17,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/rounduint64_tests.cpp \
   omnicore/test/rpc_requirements_tests.cpp \
   omnicore/test/rpc_value_tests.cpp \
+  omnicore/test/rules_txs_tests.cpp \
   omnicore/test/script_dust_tests.cpp \
   omnicore/test/script_extraction_tests.cpp \
   omnicore/test/script_solver_tests.cpp \

--- a/src/omnicore/fetchwallettx.cpp
+++ b/src/omnicore/fetchwallettx.cpp
@@ -1,7 +1,9 @@
 // The fetch functions provide a sorted list of transaction hashes ordered by block, position in block and position in wallet including STO receipts
 #include "omnicore/fetchwallettx.h"
+
 #include "omnicore/omnicore.h"
 #include "omnicore/pending.h"
+#include "omnicore/utilsbitcoin.h"
 
 #include "init.h"
 #include "wallet.h"

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -2,6 +2,7 @@
 
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
 #include "omnicore/version.h"
 
 #include "main.h"

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -95,26 +95,6 @@ enum TransactionType {
 #define MSC_PROPERTY_TYPE_INDIVISIBLE_APPENDING   129
 #define MSC_PROPERTY_TYPE_DIVISIBLE_APPENDING     130
 
-// block height (MainNet) with which the corresponding transaction is considered valid, per spec
-enum BLOCKHEIGHTRESTRICTIONS {
-// starting block for parsing on TestNet
-  START_TESTNET_BLOCK=263000,
-  START_REGTEST_BLOCK=5,
-  MONEYMAN_REGTEST_BLOCK= 101, // new address to assign MSC & TMSC on RegTest
-  MONEYMAN_TESTNET_BLOCK= 270775, // new address to assign MSC & TMSC on TestNet
-  POST_EXODUS_BLOCK = 255366,
-  MSC_DEX_BLOCK     = 290630,
-  MSC_SP_BLOCK      = 297110,
-  GENESIS_BLOCK     = 249498,
-  LAST_EXODUS_BLOCK = 255365,
-  MSC_STO_BLOCK     = 342650,
-  MSC_METADEX_BLOCK = 999999,
-  MSC_BET_BLOCK     = 999999,
-  MSC_MANUALSP_BLOCK= 323230,
-  P2SH_BLOCK        = 322000,
-  OP_RETURN_BLOCK   = 999999
-};
-
 enum FILETYPES {
   FILETYPE_BALANCES = 0,
   FILETYPE_OFFERS,
@@ -303,10 +283,6 @@ extern CCriticalSection cs_tx_cache;
 
 std::string strMPProperty(uint32_t propertyId);
 
-int GetHeight();
-uint32_t GetLatestBlockTime();
-CBlockIndex* GetBlockIndex(const uint256& hash);
-
 bool isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound);
 
 std::string FormatIndivisibleMP(int64_t n);
@@ -324,12 +300,6 @@ int64_t getTotalTokens(uint32_t propertyId, int64_t* n_owners_total = NULL);
 
 std::string c_strMasterProtocolTXType(uint16_t txType);
 
-/** Checks, if the script type is allowed as input. */
-bool IsAllowedInputType(int whichType, int nBlock);
-/** Checks, if the script type qualifies as output. */
-bool IsAllowedOutputType(int whichType, int nBlock);
-/** Checks, if the transaction type and version is supported and enabled. */
-bool IsTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty = false);
 /** Returns the encoding class, used to embed a payload. */
 int GetEncodingClass(const CTransaction& tx, int nBlock);
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -17,6 +17,7 @@
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
 #include "omnicore/tx.h"
+#include "omnicore/utilsbitcoin.h"
 #include "omnicore/version.h"
 
 #include "amount.h"

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -3,6 +3,7 @@
 #include "omnicore/dex.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/sp.h"
+#include "omnicore/utilsbitcoin.h"
 
 #include "amount.h"
 #include "main.h"

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -15,6 +15,7 @@
 #include "omnicore/sp.h"
 #include "omnicore/tx.h"
 #include "omnicore/pending.h"
+#include "omnicore/utilsbitcoin.h"
 
 // Boost includes
 #include <boost/lexical_cast.hpp>

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -1,0 +1,132 @@
+/**
+ * @file rules.cpp
+ *
+ * This file contains consensus rules and restrictions.
+ */
+
+#include "omnicore/rules.h"
+
+#include "omnicore/log.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/utilsbitcoin.h"
+
+#include "script/standard.h"
+
+#include <stdint.h>
+
+namespace mastercore
+{
+/** A mapping of transaction types, versions and the blocks at which they are enabled.
+ */
+static const int txRestrictionsRules[][3] = {
+    {MSC_TYPE_SIMPLE_SEND,                GENESIS_BLOCK,          MP_TX_PKT_V0},
+    {MSC_TYPE_TRADE_OFFER,                MSC_DEX_BLOCK,          MP_TX_PKT_V1},
+    {MSC_TYPE_ACCEPT_OFFER_BTC,           MSC_DEX_BLOCK,          MP_TX_PKT_V0},
+    {MSC_TYPE_CREATE_PROPERTY_FIXED,      MSC_SP_BLOCK,           MP_TX_PKT_V0},
+    {MSC_TYPE_CREATE_PROPERTY_VARIABLE,   MSC_SP_BLOCK,           MP_TX_PKT_V1},
+    {MSC_TYPE_CLOSE_CROWDSALE,            MSC_SP_BLOCK,           MP_TX_PKT_V0},
+    {MSC_TYPE_CREATE_PROPERTY_MANUAL,     MSC_MANUALSP_BLOCK,     MP_TX_PKT_V0},
+    {MSC_TYPE_GRANT_PROPERTY_TOKENS,      MSC_MANUALSP_BLOCK,     MP_TX_PKT_V0},
+    {MSC_TYPE_REVOKE_PROPERTY_TOKENS,     MSC_MANUALSP_BLOCK,     MP_TX_PKT_V0},
+    {MSC_TYPE_CHANGE_ISSUER_ADDRESS,      MSC_MANUALSP_BLOCK,     MP_TX_PKT_V0},
+    {MSC_TYPE_SEND_TO_OWNERS,             MSC_STO_BLOCK,          MP_TX_PKT_V0},
+    {MSC_TYPE_METADEX_TRADE,              MSC_METADEX_BLOCK,      MP_TX_PKT_V0},
+    {MSC_TYPE_METADEX_CANCEL_PRICE,       MSC_METADEX_BLOCK,      MP_TX_PKT_V0},
+    {MSC_TYPE_METADEX_CANCEL_PAIR,        MSC_METADEX_BLOCK,      MP_TX_PKT_V0},
+    {MSC_TYPE_METADEX_CANCEL_ECOSYSTEM,   MSC_METADEX_BLOCK,      MP_TX_PKT_V0},
+    {MSC_TYPE_OFFER_ACCEPT_A_BET,         MSC_BET_BLOCK,          MP_TX_PKT_V0},
+
+    // end of array marker, in addition to sizeof/sizeof
+    {-1,-1},
+};
+
+/**
+ * Checks, if the script type is allowed as input.
+ */
+bool IsAllowedInputType(int whichType, int nBlock)
+{
+    switch (whichType)
+    {
+        case TX_PUBKEYHASH:
+            return true;
+
+        case TX_SCRIPTHASH:
+            return (P2SH_BLOCK <= nBlock || isNonMainNet());
+    }
+
+    return false;
+}
+
+/**
+ * Checks, if the script type qualifies as output.
+ */
+bool IsAllowedOutputType(int whichType, int nBlock)
+{
+    switch (whichType)
+    {
+        case TX_PUBKEYHASH:
+            return true;
+
+        case TX_MULTISIG:
+            return true;
+
+        case TX_SCRIPTHASH:
+            return (P2SH_BLOCK <= nBlock || isNonMainNet());
+
+        case TX_NULL_DATA:
+            return (OP_RETURN_BLOCK <= nBlock || isNonMainNet());
+    }
+
+    return false;
+}
+
+/**
+ * Checks, if the transaction type and version is supported and enabled.
+ *
+ * Certain transaction types are not live/enabled until some specific block height.
+ * Certain transactions will be unknown to the client, i.e. "black holes" based on their version.
+ *
+ * The restrictions array is as such:
+ *   type, block-allowed-in, top-version-allowed
+ */
+bool IsTransactionTypeAllowed(int txBlock, uint32_t txProperty, uint16_t txType, uint16_t version, bool bAllowNullProperty) {
+    bool bAllowed = false;
+    bool bBlackHole = false;
+    unsigned int type;
+    int block_FirstAllowed;
+    unsigned short version_TopAllowed;
+
+    // bitcoin as property is never allowed, unless explicitly stated otherwise
+    if ((OMNI_PROPERTY_BTC == txProperty) && !bAllowNullProperty) return false;
+
+    // everything is always allowed on Bitcoin's TestNet or with TMSC/TestEcosystem on MainNet
+    if (isNonMainNet() || isTestEcosystemProperty(txProperty)) {
+        bAllowed = true;
+    }
+
+    for (unsigned int i = 0; i < sizeof(txRestrictionsRules)/sizeof(txRestrictionsRules[0]); i++) {
+        type = txRestrictionsRules[i][0];
+        block_FirstAllowed = txRestrictionsRules[i][1];
+        version_TopAllowed = txRestrictionsRules[i][2];
+
+        if (txType != type) continue;
+
+        if (version_TopAllowed < version) {
+            PrintToLog("Black Hole identified !!! %d, %u, %u, %u\n", txBlock, txProperty, txType, version);
+
+            bBlackHole = true;
+
+            // TODO: what else?
+            // ...
+        }
+
+        if (0 > block_FirstAllowed) break; // array contains a negative -- nothing's allowed or done parsing
+
+        if (block_FirstAllowed <= txBlock) bAllowed = true;
+    }
+
+    return bAllowed && !bBlackHole;
+}
+
+
+} // namespace mastercore

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -5,38 +5,34 @@
 
 namespace mastercore
 {
-/** The block heights with which corresponding transactions or features are considered as valid or enabled.
- */
-enum BLOCKHEIGHTRESTRICTIONS {
-    //! Starting block for parsing in regtest mode
-    START_REGTEST_BLOCK = 5,
-    //! Block to enable the Exodus fundraiser address in regtest mode
-    MONEYMAN_REGTEST_BLOCK = 101,
-    //! Starting block for parsing on testnet
-    START_TESTNET_BLOCK = 263000,
-    //! Block to enable the Exodus fundraiser address on testnet
-    MONEYMAN_TESTNET_BLOCK = 270775,
-    //! First block of the Exodus fundraiser
-    GENESIS_BLOCK = 249498,
-    //! Last block of the Exodus fundraiser
-    LAST_EXODUS_BLOCK = 255365,
-    //! Block to enable DEx transactions
-    MSC_DEX_BLOCK = 290630,
-    //! Block to enable smart property transactions
-    MSC_SP_BLOCK = 297110,
-    //! Block to enable managed properties
-    MSC_MANUALSP_BLOCK = 323230,
-    //! Block to enable send-to-owners transactions
-    MSC_STO_BLOCK = 342650,
-    //! Block to enable MetaDEx transactions
-    MSC_METADEX_BLOCK = 999999,
-    //! Block to enable betting transactions
-    MSC_BET_BLOCK = 999999,
-    //! Block to enable pay-to-script-hash support
-    P2SH_BLOCK = 322000,
-    //! Block to enable OP_RETURN based encoding
-    OP_RETURN_BLOCK = 999999
-};
+//! Starting block for parsing in regtest mode
+const int START_REGTEST_BLOCK = 5;
+//! Block to enable the Exodus fundraiser address in regtest mode
+const int MONEYMAN_REGTEST_BLOCK = 101;
+//! Starting block for parsing on testnet
+const int START_TESTNET_BLOCK = 263000;
+//! Block to enable the Exodus fundraiser address on testnet
+const int MONEYMAN_TESTNET_BLOCK = 270775;
+//! First block of the Exodus fundraiser
+const int GENESIS_BLOCK = 249498;
+//! Last block of the Exodus fundraiser
+const int LAST_EXODUS_BLOCK = 255365;
+//! Block to enable DEx transactions
+const int MSC_DEX_BLOCK = 290630;
+//! Block to enable smart property transactions
+const int MSC_SP_BLOCK = 297110;
+//! Block to enable managed properties
+const int MSC_MANUALSP_BLOCK = 323230;
+//! Block to enable send-to-owners transactions
+const int MSC_STO_BLOCK = 342650;
+//! Block to enable MetaDEx transactions
+const int MSC_METADEX_BLOCK = 999999;
+//! Block to enable betting transactions
+const int MSC_BET_BLOCK = 999999;
+//! Block to enable pay-to-script-hash support
+const int P2SH_BLOCK = 322000;
+//! Block to enable OP_RETURN based encoding
+const int OP_RETURN_BLOCK = 999999;
 
 /** Checks, if the script type is allowed as input. */
 bool IsAllowedInputType(int whichType, int nBlock);

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -1,0 +1,49 @@
+#ifndef OMNICORE_RULES_H
+#define OMNICORE_RULES_H
+
+#include <stdint.h>
+
+namespace mastercore
+{
+/** The block heights with which corresponding transactions or features are considered as valid or enabled.
+ */
+enum BLOCKHEIGHTRESTRICTIONS {
+    //! Starting block for parsing in regtest mode
+    START_REGTEST_BLOCK = 5,
+    //! Block to enable the Exodus fundraiser address in regtest mode
+    MONEYMAN_REGTEST_BLOCK = 101,
+    //! Starting block for parsing on testnet
+    START_TESTNET_BLOCK = 263000,
+    //! Block to enable the Exodus fundraiser address on testnet
+    MONEYMAN_TESTNET_BLOCK = 270775,
+    //! First block of the Exodus fundraiser
+    GENESIS_BLOCK = 249498,
+    //! Last block of the Exodus fundraiser
+    LAST_EXODUS_BLOCK = 255365,
+    //! Block to enable DEx transactions
+    MSC_DEX_BLOCK = 290630,
+    //! Block to enable smart property transactions
+    MSC_SP_BLOCK = 297110,
+    //! Block to enable managed properties
+    MSC_MANUALSP_BLOCK = 323230,
+    //! Block to enable send-to-owners transactions
+    MSC_STO_BLOCK = 342650,
+    //! Block to enable MetaDEx transactions
+    MSC_METADEX_BLOCK = 999999,
+    //! Block to enable betting transactions
+    MSC_BET_BLOCK = 999999,
+    //! Block to enable pay-to-script-hash support
+    P2SH_BLOCK = 322000,
+    //! Block to enable OP_RETURN based encoding
+    OP_RETURN_BLOCK = 999999
+};
+
+/** Checks, if the script type is allowed as input. */
+bool IsAllowedInputType(int whichType, int nBlock);
+/** Checks, if the script type qualifies as output. */
+bool IsAllowedOutputType(int whichType, int nBlock);
+/** Checks, if the transaction type and version is supported and enabled. */
+bool IsTransactionTypeAllowed(int txBlock, uint32_t txProperty, uint16_t txType, uint16_t version, bool bAllowNullProperty = false);
+}
+
+#endif // OMNICORE_RULES_H

--- a/src/omnicore/test/exodus_tests.cpp
+++ b/src/omnicore/test/exodus_tests.cpp
@@ -1,4 +1,5 @@
 #include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
 
 #include "base58.h"
 #include "chainparams.h"

--- a/src/omnicore/test/marker_tests.cpp
+++ b/src/omnicore/test/marker_tests.cpp
@@ -1,6 +1,7 @@
 #include "omnicore/test/utils_tx.h"
 
 #include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
 #include "omnicore/script.h"
 
 #include "primitives/transaction.h"

--- a/src/omnicore/test/output_restriction_tests.cpp
+++ b/src/omnicore/test/output_restriction_tests.cpp
@@ -1,4 +1,5 @@
 #include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
 
 #include "chainparams.h"
 #include "script/standard.h"

--- a/src/omnicore/test/parsing_a_tests.cpp
+++ b/src/omnicore/test/parsing_a_tests.cpp
@@ -3,6 +3,7 @@
 #include "omnicore/createpayload.h"
 #include "omnicore/encoding.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
 #include "omnicore/script.h"
 #include "omnicore/tx.h"
 

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -3,6 +3,7 @@
 #include "omnicore/createpayload.h"
 #include "omnicore/encoding.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
 #include "omnicore/script.h"
 #include "omnicore/tx.h"
 

--- a/src/omnicore/test/rules_txs_tests.cpp
+++ b/src/omnicore/test/rules_txs_tests.cpp
@@ -1,0 +1,34 @@
+#include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
+
+#include <stdint.h>
+#include <limits>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_rules_txs_tests)
+
+const int MAX_BLOCK = std::numeric_limits<int>().max();
+const int MAX_VERSION = std::numeric_limits<uint16_t>().max();
+
+BOOST_AUTO_TEST_CASE(simple_send_restrictions)
+{
+    BOOST_CHECK(!IsTransactionTypeAllowed(0,               OMNI_PROPERTY_BTC,  MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V0));
+    BOOST_CHECK(!IsTransactionTypeAllowed(GENESIS_BLOCK,   OMNI_PROPERTY_BTC,  MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V0));
+    BOOST_CHECK(!IsTransactionTypeAllowed(MAX_BLOCK,       OMNI_PROPERTY_BTC,  MSC_TYPE_SIMPLE_SEND, MAX_VERSION));
+    BOOST_CHECK(!IsTransactionTypeAllowed(0,               OMNI_PROPERTY_MSC,  MSC_TYPE_SIMPLE_SEND, MAX_VERSION));
+    BOOST_CHECK(!IsTransactionTypeAllowed(GENESIS_BLOCK-1, OMNI_PROPERTY_MSC,  MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V0));
+    BOOST_CHECK(!IsTransactionTypeAllowed(MAX_BLOCK,       OMNI_PROPERTY_MSC,  MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V1));
+    BOOST_CHECK(!IsTransactionTypeAllowed(GENESIS_BLOCK,   OMNI_PROPERTY_TMSC, MSC_TYPE_SIMPLE_SEND, MAX_VERSION));
+    BOOST_CHECK(!IsTransactionTypeAllowed(MAX_BLOCK,       OMNI_PROPERTY_TMSC, MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V1));
+
+    BOOST_CHECK(IsTransactionTypeAllowed(GENESIS_BLOCK,    OMNI_PROPERTY_MSC,  MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V0));
+    BOOST_CHECK(IsTransactionTypeAllowed(MAX_BLOCK,        OMNI_PROPERTY_MSC,  MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V0));
+    BOOST_CHECK(IsTransactionTypeAllowed(0,                OMNI_PROPERTY_TMSC, MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V0));
+    BOOST_CHECK(IsTransactionTypeAllowed(MAX_BLOCK,        OMNI_PROPERTY_TMSC, MSC_TYPE_SIMPLE_SEND, MP_TX_PKT_V0));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -8,6 +8,7 @@
 #include "omnicore/mdex.h"
 #include "omnicore/notifications.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
 #include "omnicore/sp.h"
 #include "omnicore/sto.h"
 

--- a/src/omnicore/utilsbitcoin.cpp
+++ b/src/omnicore/utilsbitcoin.cpp
@@ -1,0 +1,79 @@
+/**
+ * @file utilsbitcoin.cpp
+ *
+ * This file contains certain helpers to access information about Bitcoin.
+ */
+
+#include "chain.h"
+#include "chainparams.h"
+#include "main.h"
+#include "sync.h"
+
+#include <stdint.h>
+#include <string>
+
+namespace mastercore
+{
+/**
+ * @return The current chain length.
+ */
+int GetHeight()
+{
+    LOCK(cs_main);
+    return chainActive.Height();
+}
+
+/**
+ * @return The timestamp of the latest block.
+ */
+uint32_t GetLatestBlockTime()
+{
+    LOCK(cs_main);
+    if (chainActive.Tip())
+        return chainActive.Tip()->GetBlockTime();
+    else
+        return Params().GenesisBlock().nTime;
+}
+
+/**
+ * @return The CBlockIndex, or NULL, if the block isn't available.
+ */
+CBlockIndex* GetBlockIndex(const uint256& hash)
+{
+    CBlockIndex* pBlockIndex = NULL;
+    LOCK(cs_main);
+    BlockMap::const_iterator it = mapBlockIndex.find(hash);
+    if (it != mapBlockIndex.end()) {
+        pBlockIndex = it->second;
+    }
+
+    return pBlockIndex;
+}
+
+bool MainNet()
+{
+    return Params().NetworkIDString() == "main";
+}
+
+bool TestNet()
+{
+    return Params().NetworkIDString() == "test";
+}
+
+bool RegTest()
+{
+    return Params().NetworkIDString() == "regtest";
+}
+
+bool UnitTest()
+{
+    return Params().NetworkIDString() == "unittest";
+}
+
+bool isNonMainNet()
+{
+    return !MainNet() && !UnitTest();
+}
+
+
+} // namespace mastercore

--- a/src/omnicore/utilsbitcoin.h
+++ b/src/omnicore/utilsbitcoin.h
@@ -1,0 +1,25 @@
+#ifndef OMNICORE_BITCOIN_H
+#define	OMNICORE_BITCOIN_H
+
+class CBlockIndex;
+class uint256;
+
+#include <stdint.h>
+
+namespace mastercore
+{
+/** Returns the current chain length. */
+int GetHeight();
+/** Returns the timestamp of the latest block. */
+uint32_t GetLatestBlockTime();
+/** Returns the CBlockIndex for a given block hash, or NULL. */
+CBlockIndex* GetBlockIndex(const uint256& hash);
+
+bool MainNet();
+bool TestNet();
+bool RegTest();
+bool UnitTest();
+bool isNonMainNet();
+}
+
+#endif // OMNICORE_BITCOIN_H

--- a/src/qt/metadexcanceldialog.cpp
+++ b/src/qt/metadexcanceldialog.cpp
@@ -17,6 +17,7 @@
 #include "omnicore/omnicore.h"
 #include "omnicore/sp.h"
 #include "omnicore/pending.h"
+#include "omnicore/utilsbitcoin.h"
 
 #include <stdint.h>
 #include <map>

--- a/src/qt/metadexdialog.cpp
+++ b/src/qt/metadexdialog.cpp
@@ -18,6 +18,7 @@
 #include "omnicore/pending.h"
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
+#include "omnicore/utilsbitcoin.h"
 
 #include "amount.h"
 #include "sync.h"

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -19,6 +19,7 @@
 #include "omnicore/sp.h"
 #include "omnicore/tx.h"
 #include "omnicore/pending.h"
+#include "omnicore/utilsbitcoin.h"
 
 #include "main.h"
 #include "sync.h"

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -17,6 +17,7 @@
 #include "omnicore/pending.h"
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
+#include "omnicore/utilsbitcoin.h"
 
 #include "amount.h"
 #include "base58.h"

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -19,6 +19,7 @@
 #include "omnicore/rpctxobject.h"
 #include "omnicore/sp.h"
 #include "omnicore/tx.h"
+#include "omnicore/utilsbitcoin.h"
 
 #include "amount.h"
 #include "init.h"

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -18,6 +18,7 @@
 #include "omnicore/rpctxobject.h"
 #include "omnicore/sp.h"
 #include "omnicore/tx.h"
+#include "omnicore/utilsbitcoin.h"
 #include "omnicore/walletcache.h"
 
 #include "init.h"


### PR DESCRIPTION
This PR moves the helpers to get the lastest block height etc. into `utilsbitcoin`, and the block height restrictions, as well as the allowed input and output types into `rules`.

The enum `BLOCKHEIGHTRESTRICTIONS` was flattened to plain numbers.

From here on, I see a few options:

- move the block restrictions into a namespace, which would allow something like `mastercore::consensus::P2SH_BLOCK`

- provide public getters, such as `IsEnabled_P2SH()`

- introduce seperate restrictions for each network (i.e. `main`, `test`, `regtest`)

- refine and introduce a structure like `Params()` (see: [chainparams.h](https://github.com/OmniLayer/omnicore/blob/omnicore-0.0.10/src/chainparams.h), [chainparams.cpp](https://github.com/OmniLayer/omnicore/blob/omnicore-0.0.10/src/chainparams.cpp), [chainparamsbase.cpp](https://github.com/OmniLayer/omnicore/blob/omnicore-0.0.10/src/chainparamsbase.cpp))

To go on with #104, it could basically go like this: old, already enabled features remain to have hardcoded `const int` block height restrictions, while the not-yet-enabled features are changed to `int`. There could be a function like `EnableFeature_XXX(int block)`, which would update these values.