### PR TITLE
Fix reindex shutdown crash, refine startup dialogs

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -46,7 +46,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         LogPrintf("CDBEnv::EnvShutdown : Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
-        DbEnv(0).remove(path.string().c_str(), 0);
+        DbEnv(0).remove(strPath.c_str(), 0);
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)
@@ -72,10 +72,10 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
 
     boost::this_thread::interruption_point();
 
-    path = pathIn;
-    filesystem::path pathLogDir = path / "database";
+    strPath = pathIn.string();
+    filesystem::path pathLogDir = pathIn / "database";
     TryCreateDirectory(pathLogDir);
-    filesystem::path pathErrorFile = path / "db.log";
+    filesystem::path pathErrorFile = pathIn / "db.log";
     LogPrintf("CDBEnv::Open : LogDir=%s ErrorFile=%s\n", pathLogDir.string(), pathErrorFile.string());
 
     unsigned int nEnvFlags = 0;
@@ -92,7 +92,7 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
     dbenv.set_flags(DB_AUTO_COMMIT, 1);
     dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
     dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-    int ret = dbenv.open(path.string().c_str(),
+    int ret = dbenv.open(strPath.c_str(),
                          DB_CREATE |
                              DB_INIT_LOCK |
                              DB_INIT_LOG |
@@ -447,7 +447,7 @@ void CDBEnv::Flush(bool fShutdown)
                 dbenv.log_archive(&listp, DB_ARCH_REMOVE);
                 Close();
                 if (!fMockDb)
-                    boost::filesystem::remove_all(path / "database");
+                    boost::filesystem::remove_all(boost::filesystem::path(strPath) / "database");
             }
         }
     }

--- a/src/db.h
+++ b/src/db.h
@@ -35,7 +35,9 @@ class CDBEnv
 private:
     bool fDbEnvInit;
     bool fMockDb;
-    boost::filesystem::path path;
+    // Don't change into boost::filesystem::path, as that can result in
+    // shutdown problems/crashes caused by a static initialized internal pointer.
+    std::string strPath;
 
     void EnvShutdown();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1131,7 +1131,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                             "Configuration file"); // allow translation of main text body while still allowing differing config file string
         msg += ": " + GetConfigFile().string() + "\n\n";
         msg += _("Would you like Omni Core to attempt to update your configuration file accordingly?");
-        bool fRet = uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
+        bool fRet = uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_INFORMATION | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL | CClientUIInterface::BTN_ABORT);
         if (fRet) {
             // add txindex=1 to config file in GetConfigFile()
             boost::filesystem::path configPathInfo = GetConfigFile();
@@ -1146,8 +1146,11 @@ bool AppInit2(boost::thread_group& threadGroup)
             fprintf(fp, "\ntxindex=1\n");
             fflush(fp);
             fclose(fp);
-            return InitError(_("Your configuration file has been updated.\n\n"
-                               "Omni Core will now shutdown - please restart the client for your new configuration to take effect."));
+            std::string strUpdated = _(
+                    "Your configuration file has been updated.\n\n"
+                    "Omni Core will now shutdown - please restart the client for your new configuration to take effect.");
+            uiInterface.ThreadSafeMessageBox(strUpdated, "", CClientUIInterface::MSG_INFORMATION | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+            StartShutdown();
         } else {
             return InitError(_("Please add txindex=1 to your configuration file manually.\n\nOmni Core will now shutdown."));
         }

--- a/src/qt/forms/intro.ui
+++ b/src/qt/forms/intro.ui
@@ -20,7 +20,7 @@
       <string notr="true">QLabel { font-style:italic; }</string>
      </property>
      <property name="text">
-      <string>Welcome to Bitcoin Core.</string>
+      <string>Welcome to Omni Core.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -46,7 +46,7 @@
    <item>
     <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</string>
+      <string>As this is the first time the program is launched, you can choose where Omni Core will store its data.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -56,7 +56,7 @@
    <item>
     <widget class="QLabel" name="sizeWarningLabel">
      <property name="text">
-      <string>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</string>
+      <string>Omni Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
- Fix the shutdown crash, when trying to reindex during startup (cherry-picked from upstream).

- Show `INFORMATION` icons, instead of `ERROR` icons, when asking to set the `txindex` flag. When a new user starts the client the first time, then it is expected that this dialog (and the confirmation dialog) pop up, and therefore it's not an exceptional state, which doesn't justify an error or warning.

- Finally, rebrand the intro dialog, where the user can choose a datadir.

This resolves #120.