### PR TITLE
When closing a crowdsale, write info to debug log, not file

### DIFF
--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -16,7 +16,6 @@
 
 // Default log files
 const std::string LOG_FILENAME    = "omnicore.log";
-const std::string INFO_FILENAME   = "mastercore_crowdsales.log";
 
 // Options
 static const long LOG_BUFFERSIZE  =  8000000; //  8 MB

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -18,9 +18,6 @@ void InitDebugLogLevels();
 /** Scrolls log file, if it's getting too big. */
 void ShrinkDebugLog();
 
-// Log files
-extern const std::string INFO_FILENAME;
-
 // Debug flags
 extern bool msc_debug_parser_data;
 extern bool msc_debug_parser;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4430,9 +4430,9 @@ int CMPTransaction::logicMath_SimpleSend()
                         tokens, close_crowdsale);
 
                 if (msc_debug_sp) {
-                    PrintToLog("%s(): granting via crowdsale to user: %s %d (%s)",
+                    PrintToLog("%s(): granting via crowdsale to user: %s %d (%s)\n",
                             __func__, FormatMP(property, tokens.first), property, strMPProperty(property));
-                    PrintToLog("%s(): granting via crowdsale to issuer: %s %d (%s)",
+                    PrintToLog("%s(): granting via crowdsale to issuer: %s %d (%s)\n",
                             __func__, FormatMP(property, tokens.second), property, strMPProperty(property));
                 }
 

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -575,26 +575,6 @@ bool mastercore::isCrowdsaleActive(uint32_t propertyId)
     return false;
 }
 
-// save info from the crowdsale that's being erased
-void mastercore::dumpCrowdsaleInfo(const std::string& address, const CMPCrowd& crowd, bool bExpired)
-{
-    boost::filesystem::path pathInfo = GetDataDir() / INFO_FILENAME;
-    FILE* fp = fopen(pathInfo.string().c_str(), "a");
-
-    if (!fp) {
-        PrintToLog("\nPROBLEM writing %s, errno= %d\n", INFO_FILENAME, errno);
-        return;
-    }
-
-    fprintf(fp, "\n%s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-    fprintf(fp, "\nCrowdsale ended: %s\n", bExpired ? "Expired" : "Was closed");
-
-    crowd.print(address, fp);
-
-    fflush(fp);
-    fclose(fp);
-}
-
 // calculates and returns fundraiser bonus, issuer premine, and total tokens
 // propType : divisible/indiv
 // bonusPerc: bonus percentage
@@ -731,9 +711,7 @@ void mastercore::eraseMaxedCrowdsale(const std::string& address, int64_t blockTi
 
     if (it != my_crowds.end()) {
         const CMPCrowd& crowdsale = it->second;
-        PrintToLog("%s() FOUND MAXED OUT CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, address);
-
-        dumpCrowdsaleInfo(address, crowdsale);
+        PrintToLog("%s(): FOUND MAXED OUT CROWDSALE from address=%s, erasing...\n", __func__, address);
 
         // get sp from data struct
         CMPSPInfo::Entry sp;
@@ -767,10 +745,7 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
         const CMPCrowd& crowdsale = my_it->second;
 
         if (blockTime > crowdsale.getDeadline()) {
-            PrintToLog("%s() FOUND EXPIRED CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, address);
-
-            // TODO: dump the info about this crowdsale being delete into a TXT file (JSON perhaps)
-            dumpCrowdsaleInfo(address, crowdsale, true);
+            PrintToLog("%s(): FOUND EXPIRED CROWDSALE from address=%s, erasing...\n", __func__, address);
 
             // get sp from data struct
             CMPSPInfo::Entry sp;

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -196,6 +196,7 @@ public:
     void insertDatabase(const uint256& txHash, const std::vector<int64_t>& txData);
     std::map<uint256, std::vector<int64_t> > getDatabase() const { return txFundraiserData; }
 
+    std::string toString(const std::string& address) const;
     void print(const std::string& address, FILE* fp = stdout) const;
     void saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& addr) const;
 };

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -225,9 +225,6 @@ int64_t calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundra
 void eraseMaxedCrowdsale(const std::string& address, int64_t blockTime, int block);
 
 unsigned int eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex);
-
-// TODO: depreciate
-void dumpCrowdsaleInfo(const std::string& address, const CMPCrowd& crowd, bool bExpired = false);
 }
 
 


### PR DESCRIPTION
Storing extra information about a crowdsale, when closing one, in a file provides no gain, and this information is instead written to the log.

This resolves #130.