### PR TITLE
Reduce amount of verbose logging by default

### DIFF
--- a/src/omnicore/fetchwallettx.cpp
+++ b/src/omnicore/fetchwallettx.cpp
@@ -60,7 +60,9 @@ std::map<std::string,uint256> FetchWalletOmniTransactions(int count, int startBl
         mySTOReceipts = s_stolistdb->getMySTOReceipts("");
     }
     std::vector<std::string> vecReceipts;
-    boost::split(vecReceipts, mySTOReceipts, boost::is_any_of(","), boost::token_compress_on);
+    if (!mySTOReceipts.empty()) {
+        boost::split(vecReceipts, mySTOReceipts, boost::is_any_of(","), boost::token_compress_on);
+    }
     for (size_t i = 0; i < vecReceipts.size(); i++) {
         std::vector<std::string> svstr;
         boost::split(svstr, vecReceipts[i], boost::is_any_of(":"), boost::token_compress_on);

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -24,6 +24,7 @@ static const long LOG_SHRINKSIZE  = 50000000; // 50 MB
 
 // Debug flags
 bool msc_debug_parser_data        = 0;
+bool msc_debug_parser_readonly    = 0;
 bool msc_debug_parser             = 0;
 bool msc_debug_verbose            = 0;
 bool msc_debug_verbose2           = 0;
@@ -219,6 +220,7 @@ void InitDebugLogLevels()
 
     for (std::vector<std::string>::const_iterator it = debugLevels.begin(); it != debugLevels.end(); ++it) {
         if (*it == "parser_data") msc_debug_parser_data = true;
+        if (*it == "parser_readonly") msc_debug_parser_readonly = true;
         if (*it == "parser") msc_debug_parser = true;
         if (*it == "verbose") msc_debug_verbose = true;
         if (*it == "verbose2") msc_debug_verbose2 = true;
@@ -247,6 +249,7 @@ void InitDebugLogLevels()
             bool allDebugState = false;
             if (*it == "all") allDebugState = true;
             msc_debug_parser_data = allDebugState;
+            msc_debug_parser_readonly = allDebugState;
             msc_debug_parser = allDebugState;
             msc_debug_verbose = allDebugState;
             msc_debug_verbose2 = allDebugState;

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -50,6 +50,8 @@ bool msc_debug_metadex2           = 0;
 bool msc_debug_metadex3           = 0;
 //! Print transaction fields, when interpreting packets
 bool msc_debug_packets            = 1;
+//! Print transaction fields, when interpreting packets (in RPC mode)
+bool msc_debug_packets_readonly   = 0;
 bool msc_debug_walletcache        = 0;
 
 /**
@@ -244,6 +246,7 @@ void InitDebugLogLevels()
         if (*it == "metadex2") msc_debug_metadex2 = true;
         if (*it == "metadex3") msc_debug_metadex3 = true;
         if (*it == "packets") msc_debug_packets = true;
+        if (*it == "packets_readonly") msc_debug_packets_readonly = true;
         if (*it == "walletcache") msc_debug_walletcache = true;
         if (*it == "none" || *it == "all") {
             bool allDebugState = false;
@@ -273,6 +276,7 @@ void InitDebugLogLevels()
             msc_debug_metadex2 = allDebugState;
             msc_debug_metadex3 = allDebugState;
             msc_debug_packets =  allDebugState;
+            msc_debug_packets_readonly =  allDebugState;
             msc_debug_walletcache = allDebugState;
         }
     }

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -23,6 +23,7 @@ extern const std::string INFO_FILENAME;
 
 // Debug flags
 extern bool msc_debug_parser_data;
+extern bool msc_debug_parser_readonly;
 extern bool msc_debug_parser;
 extern bool msc_debug_verbose;
 extern bool msc_debug_verbose2;

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -47,6 +47,7 @@ extern bool msc_debug_metadex1;
 extern bool msc_debug_metadex2;
 extern bool msc_debug_metadex3;
 extern bool msc_debug_packets;
+extern bool msc_debug_packets_readonly;
 extern bool msc_debug_walletcache;
 
 /* When we switch to C++11, this can be switched to variadic templates instead

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1958,10 +1958,10 @@ int input_msc_balances_string(const std::string& s)
         int64_t acceptReserved = boost::lexical_cast<int64_t>(curBalance[2]);
         int64_t metadexReserved = boost::lexical_cast<int64_t>(curBalance[3]);
 
-        update_tally_map(strAddress, propertyId, balance, BALANCE);
-        update_tally_map(strAddress, propertyId, sellReserved, SELLOFFER_RESERVE);
-        update_tally_map(strAddress, propertyId, acceptReserved, ACCEPT_RESERVE);
-        update_tally_map(strAddress, propertyId, metadexReserved, METADEX_RESERVE);
+        if (balance) update_tally_map(strAddress, propertyId, balance, BALANCE);
+        if (sellReserved) update_tally_map(strAddress, propertyId, sellReserved, SELLOFFER_RESERVE);
+        if (acceptReserved) update_tally_map(strAddress, propertyId, acceptReserved, ACCEPT_RESERVE);
+        if (metadexReserved) update_tally_map(strAddress, propertyId, metadexReserved, METADEX_RESERVE);
     }
 
     return 0;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -929,8 +929,10 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         return -1;
     }
 
-    PrintToLog("____________________________________________________________________________________________________________________________________\n");
-    PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
+    if (!bRPConly || msc_debug_parser_readonly) {
+        PrintToLog("____________________________________________________________________________________________________________________________________\n");
+        PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
+    }
 
     // now save output addresses & scripts for later use
     // also determine if there is a multisig in there, if so = Class B
@@ -1201,8 +1203,10 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         if (strDataAddress.empty()) // an empty Data Address here means it is not Class A valid and should be defaulted to a BTC payment
         {
             // this must be the BTC payment - validate (?)
-            PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
-            PrintToLog("!! this may be the BTC payment for an offer !!\n");
+            if (!bRPConly || msc_debug_parser_readonly) {
+                PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
+                PrintToLog("!! this may be the BTC payment for an offer !!\n");
+            }
 
             // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
 
@@ -1216,7 +1220,9 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                         const std::string strAddress = CBitcoinAddress(dest).ToString();
 
                         if (exodus_address == strAddress) continue;
-                        PrintToLog("payment #%d %s %11.8lf\n", count, strAddress, (double) wtx.vout[i].nValue / (double) COIN);
+                        if (!bRPConly || msc_debug_parser_readonly) {
+                            PrintToLog("payment #%d %s %11.8lf\n", count, strAddress, (double) wtx.vout[i].nValue / (double) COIN);
+                        }
 
                         // check everything & pay BTC for the property we are buying here...
                         if (bRPConly) count = 55555; // no real way to validate a payment during simple RPC call
@@ -1380,8 +1386,11 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
     if (omniClass == NO_MARKER) {
         return -1; // No Exodus/Omni marker, thus not a valid Omni transaction
     }
-    PrintToLog("____________________________________________________________________________________________________________________________________\n");
-    PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
+
+    if (!bRPConly || msc_debug_parser_readonly) {
+        PrintToLog("____________________________________________________________________________________________________________________________________\n");
+        PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
+    }
 
     // Add previous transaction inputs to the cache
     if (!FillTxInputCache(wtx)) {
@@ -1599,8 +1608,10 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             memcpy(single_pkt, &ParseHex(strScriptData)[0], packet_size);
         } else {
             // ### BTC PAYMENT FOR DEX HANDLING ###
-            PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
-            PrintToLog("!! this may be the BTC payment for an offer !!\n");
+            if (!bRPConly || msc_debug_parser_readonly) {
+                PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
+                PrintToLog("!! this may be the BTC payment for an offer !!\n");
+            }
             // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
             int count = 0;
             for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
@@ -1611,7 +1622,9 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                         continue;
                     }
                     std::string strAddress = address.ToString();
-                    PrintToLog("payment #%d %s %s\n", count, strAddress, FormatIndivisibleMP(wtx.vout[n].nValue));
+                    if (!bRPConly || msc_debug_parser_readonly) {
+                        PrintToLog("payment #%d %s %s\n", count, strAddress, FormatIndivisibleMP(wtx.vout[n].nValue));
+                    }
                     // check everything & pay BTC for the property we are buying here...
                     if (bRPConly) count = 55555;  // no real way to validate a payment during simple RPC call
                     else if (0 == DEx_payment(wtx.GetHash(), n, strAddress, strSender, wtx.vout[n].nValue, nBlock)) ++count;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4076,7 +4076,7 @@ int validity = 0;
   std::vector<std::string> vstr;
   boost::split(vstr, result, boost::is_any_of(":"), token_compress_on);
 
-  PrintToLog("%s() size=%lu : %s\n", __FUNCTION__, vstr.size(), result);
+  if (msc_debug_txdb) PrintToLog("%s() size=%lu : %s\n", __FUNCTION__, vstr.size(), result);
 
   if (1 <= vstr.size()) validity = atoi(vstr[0]);
 
@@ -4098,7 +4098,7 @@ int validity = 0;
     else nAmended = 0;
   }
 
-  p_txlistdb->printStats();
+  if (msc_debug_txdb) p_txlistdb->printStats();
 
   if ((int)0 == validity) return false;
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -40,9 +40,7 @@ int const MAX_STATE_HISTORY = 50;
 // maximum numeric values from the spec:
 #define MAX_INT_8_BYTES (9223372036854775807UL)
 
-// what should've been in the Exodus address for this block if none were spent
-#define DEV_MSC_BLOCK_290629 (1743358325718)
-
+// maximum size of string fields
 #define SP_STRING_FIELD_LEN 256
 
 // Omni Layer Transaction Class

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -158,7 +158,7 @@ bool CMPTransaction::interpret_TransactionType()
     version = txVersion;
     type = txType;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t------------------------------\n");
         PrintToLog("\t         version: %d, class %s\n", txVersion, intToClass(multi));
         PrintToLog("\t            type: %d (%s)\n", txType, c_strMasterProtocolTXType(txType));
@@ -179,7 +179,7 @@ bool CMPTransaction::interpret_SimpleSend()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
     }
@@ -199,7 +199,7 @@ bool CMPTransaction::interpret_SendToOwners()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
     }
@@ -225,7 +225,7 @@ bool CMPTransaction::interpret_TradeOffer()
     swapByteOrder64(amount_desired);
     swapByteOrder64(min_fee);
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
         PrintToLog("\t  amount desired: %s\n", FormatDivisibleMP(amount_desired));
@@ -249,7 +249,7 @@ bool CMPTransaction::interpret_AcceptOfferBTC()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
     }
@@ -275,7 +275,7 @@ bool CMPTransaction::interpret_MetaDExTrade()
 
     action = CMPTransaction::ADD; // depreciated
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
         PrintToLog("\tdesired property: %d (%s)\n", desired_property, strMPProperty(desired_property));
@@ -303,7 +303,7 @@ bool CMPTransaction::interpret_MetaDExCancelPrice()
 
     action = CMPTransaction::CANCEL_AT_PRICE; // depreciated
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
         PrintToLog("\tdesired property: %d (%s)\n", desired_property, strMPProperty(desired_property));
@@ -329,7 +329,7 @@ bool CMPTransaction::interpret_MetaDExCancelPair()
     desired_value = 0; // depreciated
     action = CMPTransaction::CANCEL_ALL_FOR_PAIR; // depreciated
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\tdesired property: %d (%s)\n", desired_property, strMPProperty(desired_property));
     }
@@ -352,7 +352,7 @@ bool CMPTransaction::interpret_MetaDExCancelEcosystem()
     desired_value = 0; // depreciated
     action = CMPTransaction::CANCEL_EVERYTHING; // depreciated
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", (int)ecosystem);
     }
 
@@ -387,7 +387,7 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
     p += 8;
     nNewValue = nValue;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", ecosystem);
         PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
         PrintToLog("\tprev property id: %d\n", prev_prop_id);
@@ -443,7 +443,7 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
     memcpy(&early_bird, p++, 1);
     memcpy(&percentage, p++, 1);
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", ecosystem);
         PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
         PrintToLog("\tprev property id: %d\n", prev_prop_id);
@@ -476,7 +476,7 @@ bool CMPTransaction::interpret_CloseCrowdsale()
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
     }
 
@@ -507,7 +507,7 @@ bool CMPTransaction::interpret_CreatePropertyManaged()
     memcpy(url, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(url)-1)); i++;
     memcpy(data, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(data)-1)); i++;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", ecosystem);
         PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
         PrintToLog("\tprev property id: %d\n", prev_prop_id);
@@ -538,7 +538,7 @@ bool CMPTransaction::interpret_GrantTokens()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
     }
@@ -558,7 +558,7 @@ bool CMPTransaction::interpret_RevokeTokens()
     swapByteOrder64(nValue);
     nNewValue = nValue;
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
     }
@@ -575,7 +575,7 @@ bool CMPTransaction::interpret_ChangeIssuer()
     memcpy(&property, &pkt[4], 4);
     swapByteOrder32(property);
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
     }
 
@@ -592,7 +592,7 @@ bool CMPTransaction::interpret_Alert()
     std::string spstr(p);
     memcpy(alertString, spstr.c_str(), std::min(spstr.length(), sizeof(alertString)-1));
 
-    if (msc_debug_packets) {
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t           alert: %s\n", alertString);
     }
 

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -83,6 +83,9 @@ private:
     // Alert
     char alertString[SP_STRING_FIELD_LEN];
 
+    // Indicates whether the transaction can be used to execute logic
+    bool rpcOnly;
+
     /** Checks whether a pointer to the payload is past it's last position. */
     bool isOverrun(const char* p);
 
@@ -161,6 +164,7 @@ public:
     uint64_t getNewAmount() const { return nNewValue; }
     std::string getSPName() const { return name; }
     std::string getAlertString() const { return alertString; }
+    bool isRpcOnly() const { return rpcOnly; }
 
     /** Creates a new CMPTransaction object. */
     CMPTransaction()
@@ -205,6 +209,7 @@ public:
         min_fee = 0;
         subaction = 0;
         memset(&alertString, 0, sizeof(alertString));
+        rpcOnly = true;
     }
 
     /** Sets the given values. */
@@ -238,6 +243,9 @@ public:
 
     /** Interprets the payload and executes the logic. */
     int interpretPacket();
+
+    /** Enables access of interpretPacket. */
+    void unlockLogic() { rpcOnly = false; };
 
     /** Compares transaction objects based on block height and position within the block. */
     bool operator<(const CMPTransaction& other) const


### PR DESCRIPTION
The PR serves to remove some of the verbosity from the log generated by re-parsing transactions at the RPC/UI layers unless explicitly requested with debug flags.