### PR TITLE
Add missing header include after PR #116

### DIFF
--- a/src/qt/metadexdialog.cpp
+++ b/src/qt/metadexdialog.cpp
@@ -16,6 +16,7 @@
 #include "omnicore/omnicore.h"
 #include "omnicore/parse_string.h"
 #include "omnicore/pending.h"
+#include "omnicore/rules.h"
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
 #include "omnicore/utilsbitcoin.h"


### PR DESCRIPTION
Between pushing PR 116 and the merge of PR 116, the dependencies of metadexdialog.cpp have changed.