### PR TITLE
Add RPC to decode raw Omni transactions

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -14,6 +14,7 @@ OMNICORE_H = \
   omnicore/pending.h \
   omnicore/persistence.h \
   omnicore/rpc.h \
+  omnicore/rpcrawtx.h \
   omnicore/rpcrequirements.h \
   omnicore/rpctx.h \
   omnicore/rpctxobject.h \
@@ -47,6 +48,7 @@ OMNICORE_CPP = \
   omnicore/pending.cpp \
   omnicore/persistence.cpp \
   omnicore/rpc.cpp \
+  omnicore/rpcrawtx.cpp \
   omnicore/rpcrequirements.cpp \
   omnicore/rpctx.cpp \
   omnicore/rpctxobject.cpp \

--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -1251,6 +1251,66 @@ $ omnicore-cli "omni_gettradehistoryforaddress" "1MCHESTptvd2LnNp7wmr2sGTpRomteA
 
 ---
 
+## Raw transactions
+
+The RPCs for raw transactions can be used to decode or create raw Omni transactions.
+
+### omni_decodetransaction
+
+Decodes an Omni transaction.
+
+If the inputs of the transaction are not in the chain, then they must be provided, because the transaction inputs are used to identify the sender of a transaction.
+
+**Arguments:**
+
+| Name                | Type    | Presence | Description                                                                                  |
+|---------------------|---------|----------|----------------------------------------------------------------------------------------------|
+| `txhex`             | string  | required | the raw transaction to decode                                                                |
+| `prevtxs`           | string  | optional | a JSON array of transaction inputs (default: none)                                           |
+
+The format of `prevtxs` is as following:
+
+```js
+[
+  {
+    "txid" : "hash",         // (string, required) the transaction hash
+    "vout" : n,              // (number, required) the output number
+    "scriptPubKey" : "hex",  // (string, required) the output script
+    "value" : n.nnnnnnnn     // (number, required) the output value
+  }
+  ,...
+]
+```
+
+**Result:**
+```js
+Result:
+{
+  "txid" : "hash",                 // (string) the hex-encoded hash of the transaction
+  "fee" : "n.nnnnnnnn",            // (string) the transaction fee in bitcoins
+  "sendingaddress" : "address",    // (string) the Bitcoin address of the sender
+  "referenceaddress" : "address",  // (string) a Bitcoin address used as reference (if any)
+  "ismine" : true|false,           // (boolean) whether the transaction involes an address in the wallet
+  "version" : n,                   // (number) the transaction version
+  "type_int" : n,                  // (number) the transaction type as number
+  "type" : "type",                 // (string) the transaction type as string
+  [...]                            // (mixed) other transaction type specific properties
+}
+```
+
+**Example:**
+
+```bash
+$ omnicore-cli "omni_decodetransaction" "010000000163af14ce6d477e1c793507e32a5b7696288fa89705c0d02a3f66beb3c \
+    5b8afee0100000000ffffffff02ac020000000000004751210261ea979f6a06f9dafe00fb1263ea0aca959875a7073556a088cdf \
+    adcd494b3752102a3fd0a8a067e06941e066f78d930bfc47746f097fcd3f7ab27db8ddf37168b6b52ae22020000000000001976a \
+    914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000" \
+    "[{\"txid\":\"eeafb8c5b3be663f2ad0c00597a88f2896765b2ae30735791c7e476dce14af63\",\"vout\":1, \
+    \"scriptPubKey\":\"76a9149084c0bd89289bc025d0264f7f23148fb683d56c88ac\",\"value\":0.0001123}]"
+```
+
+---
+
 ## Depreciated API calls
 
 To ensure backwards compatibility, depreciated RPCs are kept for at least one major version.

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -49,6 +49,9 @@ using std::runtime_error;
 using namespace json_spirit;
 using namespace mastercore;
 
+/**
+ * Throws a JSONRPCError, depending on error code.
+ */
 void PopulateFailure(int error)
 {
     switch (error) {

--- a/src/omnicore/rpc.h
+++ b/src/omnicore/rpc.h
@@ -1,4 +1,8 @@
 #ifndef OMNICORE_RPC_H
 #define OMNICORE_RPC_H
 
+/** Throws a JSONRPCError, depending on error code. */
+void PopulateFailure(int error);
+
+
 #endif // OMNICORE_RPC_H

--- a/src/omnicore/rpcrawtx.cpp
+++ b/src/omnicore/rpcrawtx.cpp
@@ -22,6 +22,8 @@
 #include <stdexcept>
 #include <string>
 
+extern CCriticalSection cs_main;
+
 using mastercore::GetHeight;
 using mastercore::cs_tx_cache;
 using mastercore::view;
@@ -109,7 +111,7 @@ Value omni_decodetransaction(const Array& params, bool fHelp)
     Object txObj;
     int populateResult = -3331;
     {
-        LOCK(cs_tx_cache);
+        LOCK2(cs_main, cs_tx_cache);
         // temporarily switch global coins view cache for transaction inputs
         std::swap(view, viewTemp);
         // then get the results

--- a/src/omnicore/rpcrawtx.cpp
+++ b/src/omnicore/rpcrawtx.cpp
@@ -1,0 +1,125 @@
+#include "omnicore/rpcrawtx.h"
+
+#include "omnicore/omnicore.h"
+#include "omnicore/rpc.h"
+#include "omnicore/rpctxobject.h"
+#include "omnicore/utilsbitcoin.h"
+
+#include "coins.h"
+#include "core_io.h"
+#include "primitives/transaction.h"
+#include "rpcserver.h"
+#include "sync.h"
+#include "uint256.h"
+
+#include "json/json_spirit_value.h"
+
+#include <boost/assign/list_of.hpp>
+#include <boost/foreach.hpp>
+
+#include <stdint.h>
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+using mastercore::GetHeight;
+using mastercore::cs_tx_cache;
+using mastercore::view;
+
+using namespace json_spirit;
+
+Value omni_decodetransaction(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 2)
+        throw std::runtime_error(
+            "omni_decodetransaction \"txhex\" ( \"prevtxs\" )\n"
+
+            "\nDecodes an Omni transaction.\n"
+
+            "\nIf the inputs of the transaction are not in the chain, then they must be provided, because "
+            "the transaction inputs are used to identify the sender of a transaction.\n"
+
+            "\nArguments:\n"
+            "1. txhex                (string, required) the raw transaction to decode\n"
+            "2. prevtxs              (string, optional) a JSON array of transaction inputs (default: none)\n"
+            "     [\n"
+            "       {\n"
+            "         \"txid\":\"hash\",          (string, required) the transaction hash\n"
+            "         \"vout\":n,               (number, required) the output number\n"
+            "         \"scriptPubKey\":\"hex\",   (string, required) the output script\n"
+            "         \"value\":n.nnnnnnnn      (number, required) the output value\n"
+            "       }\n"
+            "       ,...\n"
+            "     ]\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"txid\" : \"hash\",                  (string) the hex-encoded hash of the transaction\n"
+            "  \"fee\" : \"n.nnnnnnnn\",             (string) the transaction fee in bitcoins\n"
+            "  \"sendingaddress\" : \"address\",     (string) the Bitcoin address of the sender\n"
+            "  \"referenceaddress\" : \"address\",   (string) a Bitcoin address used as reference (if any)\n"
+            "  \"ismine\" : true|false,            (boolean) whether the transaction involes an address in the wallet\n"
+            "  \"version\" : n,                    (number) the transaction version\n"
+            "  \"type_int\" : n,                   (number) the transaction type as number\n"
+            "  \"type\" : \"type\",                  (string) the transaction type as string\n"
+            "  [...]                             (mixed) other transaction type specific properties\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("omni_decodetransaction", "\"010000000163af14ce6d477e1c793507e32a5b7696288fa89705c0d02a3f66beb3c5b8afee0100000000ffffffff02ac020000000000004751210261ea979f6a06f9dafe00fb1263ea0aca959875a7073556a088cdfadcd494b3752102a3fd0a8a067e06941e066f78d930bfc47746f097fcd3f7ab27db8ddf37168b6b52ae22020000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000\" \"[{\\\"txid\\\":\\\"eeafb8c5b3be663f2ad0c00597a88f2896765b2ae30735791c7e476dce14af63\\\",\\\"vout\\\":1,\\\"scriptPubKey\\\":\\\"76a9149084c0bd89289bc025d0264f7f23148fb683d56c88ac\\\",\\\"value\\\":0.0001123}]\"")
+            + HelpExampleRpc("omni_decodetransaction", "\"010000000163af14ce6d477e1c793507e32a5b7696288fa89705c0d02a3f66beb3c5b8afee0100000000ffffffff02ac020000000000004751210261ea979f6a06f9dafe00fb1263ea0aca959875a7073556a088cdfadcd494b3752102a3fd0a8a067e06941e066f78d930bfc47746f097fcd3f7ab27db8ddf37168b6b52ae22020000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000\", \"[{\\\"txid\\\":\\\"eeafb8c5b3be663f2ad0c00597a88f2896765b2ae30735791c7e476dce14af63\\\",\\\"vout\\\":1,\\\"scriptPubKey\\\":\\\"76a9149084c0bd89289bc025d0264f7f23148fb683d56c88ac\\\",\\\"value\\\":0.0001123}]\"")
+        );
+
+    CTransaction tx;
+    if (!DecodeHexTx(tx, params[0].get_str())) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Transaction deserialization failed");
+    }
+
+    // use a dummy coins view to store the user provided transaction inputs
+    CCoinsView viewDummyTemp;
+    CCoinsViewCache viewTemp(&viewDummyTemp);
+
+    if (params.size() > 1 && params[1].type() != json_spirit::null_type) {
+        Array prevTxs = params[1].get_array();
+        BOOST_FOREACH(Value& p, prevTxs) {
+            if (p.type() != json_spirit::obj_type) {
+                throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "expected object with {\"txid'\",\"vout\",\"scriptPubKey\",\"value\":n.nnnnnnnn}");
+            }
+            Object prevOut = p.get_obj();
+            RPCTypeCheck(prevOut, boost::assign::map_list_of("txid", json_spirit::str_type)("vout", json_spirit::int_type)("scriptPubKey", json_spirit::str_type)("value", json_spirit::real_type));
+
+            uint256 txid = ParseHashO(prevOut, "txid");
+            int nOut = json_spirit::find_value(prevOut, "vout").get_int();
+            if (nOut < 0) {
+                throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "vout must be positive");
+            }
+            std::vector<unsigned char> pkData(ParseHexO(prevOut, "scriptPubKey"));
+            Value outputValue = json_spirit::find_value(prevOut, "value");
+            {
+                CCoinsModifier coins = viewTemp.ModifyCoins(txid);
+                if ((size_t) nOut >= coins->vout.size()) {
+                    coins->vout.resize(nOut+1);
+                }
+                coins->vout[nOut].scriptPubKey = CScript(pkData.begin(), pkData.end());
+                coins->vout[nOut].nValue = AmountFromValue(outputValue);
+            }
+        }
+    }
+
+    Object txObj;
+    int populateResult = -3331;
+    {
+        LOCK(cs_tx_cache);
+        // temporarily switch global coins view cache for transaction inputs
+        std::swap(view, viewTemp);
+        // then get the results
+        populateResult = populateRPCTransactionObject(tx, 0, txObj);
+        // and restore the original, unpolluted coins view cache
+        std::swap(viewTemp, view);
+    }
+
+    if (populateResult != 0) PopulateFailure(populateResult);
+
+    return txObj;
+}
+

--- a/src/omnicore/rpcrawtx.h
+++ b/src/omnicore/rpcrawtx.h
@@ -1,0 +1,10 @@
+#ifndef OMNICORE_RPCRAWTX_H
+#define OMNICORE_RPCRAWTX_H
+
+#include "json/json_spirit_value.h"
+
+json_spirit::Value omni_decodetransaction(const json_spirit::Array& params, bool fHelp);
+
+
+
+#endif // OMNICORE_RPCRAWTX_H

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -9,6 +9,7 @@ class CMPTransaction;
 class CTransaction;
 
 int populateRPCTransactionObject(const uint256& txid, json_spirit::Object& txobj, std::string filterAddress = "", bool extendedDetails = false, std::string extendedDetailsFilter = "");
+int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHash, json_spirit::Object& txobj, std::string filterAddress = "", bool extendedDetails = false, std::string extendedDetailsFilter = "");
 
 void populateRPCTypeInfo(CMPTransaction& mp_obj, json_spirit::Object& txobj, uint32_t txType, bool extendedDetails, std::string extendedDetailsFilter);
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -169,6 +169,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendalert", 2 },
     { "omni_sendalert", 3 },
     { "omni_sendalert", 4 },
+
+    /* Omni Core - raw transaction calls */
+    { "omni_decodetransaction", 1 },
 };
 
 class CRPCConvertTable

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -410,6 +410,10 @@ static const CRPCCommand vRPCCommands[] =
 #endif
     { "hidden",                              "mscrpc",                          &mscrpc,                          true,       true,       false },
 
+    /* Omni Core raw transaction calls */
+    /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
+    { "omni layer (raw transactions)",       "omni_decodetransaction",          &omni_decodetransaction,          true,       true,       false },
+
     /* Omni Core hidden calls - aliased calls for backwards compatibiltiy - to be depreciated (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
     { "hidden",                              "getinfo_MP",                      &omni_getinfo,                    true,       true,       false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -275,6 +275,9 @@ extern json_spirit::Value mscrpc(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_sendactivation(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_sendalert(const json_spirit::Array& params, bool fHelp);
 
+/* Omni Core raw transaction calls */
+extern json_spirit::Value omni_decodetransaction(const json_spirit::Array& params, bool fHelp);
+
 /* Omni Core hidden calls - aliased calls for backwards compatibiltiy - to be depreciated (not shown in help) */
 extern json_spirit::Value trade_MP(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo_MP(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
The new RPC "omni_decodetransaction" can be used to decode raw Omni transactions.

If the inputs of the transaction are not in the chain, then they must be provided, because the transaction inputs are used to identify the sender of a transaction.

An empty coins view is created, and populated with the user provided transaction information. Right before the decoding, the global coins view is temporarily swapped with the dummy view, to make it available to "ParseTransaction". Afterwards the view is swapped back. Access to the coins view is blocked during the decoding.