### PR TITLE
Implement tally hashing for consensus testing and checkpoints

### DIFF
--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -49,8 +49,10 @@ bool msc_debug_metadex3           = 0;
 //! Print transaction fields, when interpreting packets
 bool msc_debug_packets            = 1;
 bool msc_debug_walletcache        = 0;
-//! Print consensus hashes for each block when parsing
+//! Print each line added to consensus hash
 bool msc_debug_consensus_hash     = 0;
+//! Print consensus hashes for each block when parsing
+bool msc_debug_consensus_hash_every_block = 0;
 
 /**
  * LogPrintf() has been broken a couple of times now
@@ -245,6 +247,7 @@ void InitDebugLogLevels()
         if (*it == "packets") msc_debug_packets = true;
         if (*it == "walletcache") msc_debug_walletcache = true;
         if (*it == "consensus_hash") msc_debug_consensus_hash = true;
+        if (*it == "consensus_hash_every_block") msc_debug_consensus_hash_every_block = true;
         if (*it == "none" || *it == "all") {
             bool allDebugState = false;
             if (*it == "all") allDebugState = true;
@@ -274,6 +277,7 @@ void InitDebugLogLevels()
             msc_debug_packets =  allDebugState;
             msc_debug_walletcache = allDebugState;
             msc_debug_consensus_hash = allDebugState;
+            msc_debug_consensus_hash_every_block = allDebugState;
         }
     }
 }

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -49,6 +49,8 @@ bool msc_debug_metadex3           = 0;
 //! Print transaction fields, when interpreting packets
 bool msc_debug_packets            = 1;
 bool msc_debug_walletcache        = 0;
+//! Print consensus hashes for each block when parsing
+bool msc_debug_consensus_hash     = 0;
 
 /**
  * LogPrintf() has been broken a couple of times now
@@ -242,6 +244,7 @@ void InitDebugLogLevels()
         if (*it == "metadex3") msc_debug_metadex3 = true;
         if (*it == "packets") msc_debug_packets = true;
         if (*it == "walletcache") msc_debug_walletcache = true;
+        if (*it == "consensus_hash") msc_debug_consensus_hash = true;
         if (*it == "none" || *it == "all") {
             bool allDebugState = false;
             if (*it == "all") allDebugState = true;
@@ -270,6 +273,7 @@ void InitDebugLogLevels()
             msc_debug_metadex3 = allDebugState;
             msc_debug_packets =  allDebugState;
             msc_debug_walletcache = allDebugState;
+            msc_debug_consensus_hash = allDebugState;
         }
     }
 }

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -44,6 +44,7 @@ extern bool msc_debug_metadex2;
 extern bool msc_debug_metadex3;
 extern bool msc_debug_packets;
 extern bool msc_debug_walletcache;
+extern bool msc_debug_consensus_hash;
 
 /* When we switch to C++11, this can be switched to variadic templates instead
  * of this macro-based construction (see tinyformat.h).

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -45,6 +45,7 @@ extern bool msc_debug_metadex3;
 extern bool msc_debug_packets;
 extern bool msc_debug_walletcache;
 extern bool msc_debug_consensus_hash;
+extern bool msc_debug_consensus_hash_every_block;
 
 /* When we switch to C++11, this can be switched to variadic templates instead
  * of this macro-based construction (see tinyformat.h).

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4087,6 +4087,12 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
         mastercore_save_state(pBlockIndex);
     }
 
+    // calculate and print a consensus hash if required
+    if (msc_debug_consensus_hash) {
+        uint256 consensusHash = GetConsensusHash();
+        PrintToLog("Consensus hash for block %d: %s\n", nBlockNow, consensusHash.GetHex());
+    }
+
     return 0;
 }
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4095,7 +4095,12 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
 
     // request checkpoint verification
     bool checkpointValid = VerifyCheckpoint(nBlockNow, pBlockIndex->GetBlockHash());
-    assert(checkpointValid);
+    if (!checkpointValid) {
+        // failed checkpoint, can't be trusted to provide valid data - shutdown client
+        const std::string& msg = strprintf("Shutting down due to failed checkpoint for block %d (hash %s)\n", nBlockNow, pBlockIndex->GetBlockHash().GetHex());
+        PrintToLog(msg);
+        if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode(msg, msg);
+    }
 
     return 0;
 }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4093,6 +4093,10 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
         PrintToLog("Consensus hash for block %d: %s\n", nBlockNow, consensusHash.GetHex());
     }
 
+    // request checkpoint verification
+    bool checkpointValid = VerifyCheckpoint(nBlockNow);
+    assert(checkpointValid);
+
     return 0;
 }
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4094,7 +4094,7 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     }
 
     // request checkpoint verification
-    bool checkpointValid = VerifyCheckpoint(nBlockNow);
+    bool checkpointValid = VerifyCheckpoint(nBlockNow, pBlockIndex->GetBlockHash());
     assert(checkpointValid);
 
     return 0;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4088,7 +4088,7 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     }
 
     // calculate and print a consensus hash if required
-    if (msc_debug_consensus_hash) {
+    if (msc_debug_consensus_hash_every_block) {
         uint256 consensusHash = GetConsensusHash();
         PrintToLog("Consensus hash for block %d: %s\n", nBlockNow, consensusHash.GetHex());
     }

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1562,10 +1562,15 @@ Value omni_getcurrentconsensushash(const Array& params, bool fHelp)
     LOCK(cs_main); // TODO - will this ensure we don't take in a new block in the couple of ms it takes to calculate the consensus hash?
 
     int block = GetHeight();
+
+    CBlockIndex* pblockindex = chainActive[block];
+    uint256 blockHash = pblockindex->GetBlockHash();
+
     uint256 consensusHash = GetConsensusHash();
 
     Object response;
     response.push_back(Pair("block", block));
+    response.push_back(Pair("blockhash", blockHash.GetHex()));
     response.push_back(Pair("consensushash", consensusHash.GetHex()));
 
     return response;

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1562,8 +1562,7 @@ Value omni_getcurrentconsensushash(const Array& params, bool fHelp)
     LOCK(cs_main); // TODO - will this ensure we don't take in a new block in the couple of ms it takes to calculate the consensus hash?
 
     int block = GetHeight();
-    uint256 consensusHash;
-    consensusHash = GetConsensusHash();
+    uint256 consensusHash = GetConsensusHash();
 
     Object response;
     response.push_back(Pair("block", block));

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1549,14 +1549,25 @@ Value omni_getcurrentconsensushash(const Array& params, bool fHelp)
             "omni_getcurrentconsensushash\n"
             "\nReturns the consensus hash for all balances for the current block.\n"
             "\nResult:\n"
-            "\"hash\",                 (string) the consensus hash for the current block\n"
+            "{\n"
+            "  \"block\" : nnnnnn,                              (number) the index of the block this consensus hash applies to\n"
+            "  \"consensushash\" : \"hash\",                    (string) the consensus hash for the block\n"
+            "}\n"
+
             "\nExamples:\n"
             + HelpExampleCli("omni_getcurrentconsensushash", "")
             + HelpExampleRpc("omni_getcurrentconsensushash", "")
         );
 
+    LOCK(cs_main); // TODO - will this ensure we don't take in a new block in the couple of ms it takes to calculate the consensus hash?
+
+    int block = GetHeight();
     uint256 consensusHash;
     consensusHash = GetConsensusHash();
 
-    return consensusHash.GetHex();
+    Object response;
+    response.push_back(Pair("block", block));
+    response.push_back(Pair("consensushash", consensusHash.GetHex()));
+
+    return response;
 }

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -14,6 +14,7 @@
 #include "omnicore/rpctx.h"
 #include "omnicore/rpctxobject.h"
 #include "omnicore/rpcvalues.h"
+#include "omnicore/rules.h"
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
 #include "omnicore/tx.h"
@@ -1541,3 +1542,21 @@ Value omni_gettrade(const Array& params, bool fHelp)
     return txobj;
 }
 
+Value omni_getcurrentconsensushash(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "omni_getcurrentconsensushash\n"
+            "\nReturns the consensus hash for all balances for the current block.\n"
+            "\nResult:\n"
+            "\"hash\",                 (string) the consensus hash for the current block\n"
+            "\nExamples:\n"
+            + HelpExampleCli("omni_getcurrentconsensushash", "")
+            + HelpExampleRpc("omni_getcurrentconsensushash", "")
+        );
+
+    uint256 consensusHash;
+    consensusHash = GetConsensusHash();
+
+    return consensusHash.GetHex();
+}

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -154,6 +154,8 @@ uint256 GetConsensusHash()
 
     LOCK(cs_tally);
 
+    if (msc_debug_consensus_hash) PrintToLog("Beginning generation of current consensus hash...\n");
+
     // loop through the tally map, updating the sha context with the data from each balance & type
     for (std::map<string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it) {
         const std::string& address = my_it->first;
@@ -185,6 +187,8 @@ uint256 GetConsensusHash()
                                          FormatIndivisibleMP(acceptReserve) + "|" +
                                          FormatIndivisibleMP(metaDExReserve);
 
+            if (msc_debug_consensus_hash) PrintToLog("Adding data to consensus hash: %s\n", dataStr);
+
             // update the sha context with the data string
             SHA256_Update(&shaCtx, dataStr.c_str(), dataStr.length());
         }
@@ -193,6 +197,8 @@ uint256 GetConsensusHash()
     // extract the final result and return the hash
     uint256 consensusHash;
     SHA256_Final((unsigned char*)&consensusHash, &shaCtx);
+    if (msc_debug_consensus_hash) PrintToLog("Finished generation of consensus hash.  Result: %s\n", consensusHash.GetHex());
+
     return consensusHash;
 }
 

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -19,9 +19,19 @@ namespace mastercore
 /** Checkpoints - block and consensus hash.
  */
 static const std::pair<int, std::string> checkpoints[] = {
-    std::make_pair(250000, "dummy")
+    std::make_pair(250000, "f8ca97346756bbe3b530d052c884b2f54c14edc1498ba2176214857dee13f3ca"),
+    std::make_pair(260000, "e8b5445bbfc915e59164a6c22e4d84b23539569ee3c95b49eefaeaca86ea98a0"),
+    std::make_pair(270000, "4eb6f75c961308c18dad1e2677170465f30d367489e61cb2510e400dc3d21117"),
+    std::make_pair(280000, "5896745cfde2423d1c896865b49953cac76d87f8d29c619793698d06c14f11d6"),
+    std::make_pair(290000, "28f4c64fa05adee082c7fb10f3b768747fef28bff1e29f22482ed17e9dfe130c"),
+    std::make_pair(300000, "51b429776f26ee4b9ebf2de669c7c01f420004ce29d4df92a2e3d7b0248cbe8e"),
+    std::make_pair(310000, "f8ab77846e859ccc5094f4944e0b6fbf7f1e1435578fd3debffc0e0db4afda58"),
+    std::make_pair(320000, "ac76516b2be5fd6391ac1511c409e19eab0c5b55754883a72d2473457af9299e"),
+    std::make_pair(330000, "158c9640fd4376569e439f7c6f4b7ac17e14dffc9f9b99a7e6b38b57c7ff5ece"),
+    std::make_pair(340000, "85655b4e01fa328f5d1c955d00f27989e644a38931280d1448b83c98f78d3a25"),
+    std::make_pair(350000, "c562ebcc36c5dd094f7dff3d0083362701b8ad489b825a93dab3e51d7a0b59f2"),
+    std::make_pair(360000, "da08157c018429bf717989ec653151652fb95d3107b287e016c8b9483e9f86f7")
 };
-
 
 /** A mapping of transaction types, versions and the blocks at which they are enabled.
  */

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -12,6 +12,7 @@
 
 #include "script/standard.h"
 
+#include <openssl/sha.h>
 #include <stdint.h>
 
 namespace mastercore

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -205,8 +205,7 @@ bool VerifyCheckpoint(int block)
     for (unsigned int i = 0; i < sizeof(checkpoints)/sizeof(checkpoints[0]); i++) {
         if (block != checkpoints[i].first) continue;
         // only verify if there is a checkpoint to verify against
-        uint256 consensusHash;
-        consensusHash = GetConsensusHash();
+        uint256 consensusHash = GetConsensusHash();
         if (consensusHash.GetHex() != checkpoints[i].second) return false;
     }
 

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -16,6 +16,13 @@
 
 namespace mastercore
 {
+/** Checkpoints - block and consensus hash.
+ */
+static const std::pair<int, std::string> checkpoints[] = {
+    std::make_pair(250000, "dummy")
+};
+
+
 /** A mapping of transaction types, versions and the blocks at which they are enabled.
  */
 static const int txRestrictionsRules[][3] = {
@@ -169,6 +176,24 @@ uint256 GetConsensusHash()
     uint256 consensusHash;
     SHA256_Final((unsigned char*)&consensusHash, &shaCtx);
     return consensusHash;
+}
+
+/** Compares a supplied block and consensus hash against a hardcoded list of checkpoints */
+bool VerifyCheckpoint(int block)
+{
+    // checkpoints are only verified for mainnet
+    if (isNonMainNet()) return true;
+
+    for (unsigned int i = 0; i < sizeof(checkpoints)/sizeof(checkpoints[0]); i++) {
+        if (block != checkpoints[i].first) continue;
+        // only verify if there is a checkpoint to verify against
+        uint256 consensusHash;
+        consensusHash = GetConsensusHash();
+        if (consensusHash.GetHex() != checkpoints[i].second) return false;
+    }
+
+    // either checkpoint matched or we don't have a checkpoint for this block
+    return true;
 }
 
 } // namespace mastercore

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -16,21 +16,41 @@
 
 namespace mastercore
 {
-/** Checkpoints - block and consensus hash.
+
+struct ConsensusCheckpoint
+{
+    int blockHeight;
+    uint256 blockHash;
+    uint256 consensusHash;
+};
+
+/** Checkpoints - block, block hash and consensus hash.
  */
-static const std::pair<int, std::string> checkpoints[] = {
-    std::make_pair(250000, "f8ca97346756bbe3b530d052c884b2f54c14edc1498ba2176214857dee13f3ca"),
-    std::make_pair(260000, "e8b5445bbfc915e59164a6c22e4d84b23539569ee3c95b49eefaeaca86ea98a0"),
-    std::make_pair(270000, "4eb6f75c961308c18dad1e2677170465f30d367489e61cb2510e400dc3d21117"),
-    std::make_pair(280000, "5896745cfde2423d1c896865b49953cac76d87f8d29c619793698d06c14f11d6"),
-    std::make_pair(290000, "28f4c64fa05adee082c7fb10f3b768747fef28bff1e29f22482ed17e9dfe130c"),
-    std::make_pair(300000, "51b429776f26ee4b9ebf2de669c7c01f420004ce29d4df92a2e3d7b0248cbe8e"),
-    std::make_pair(310000, "f8ab77846e859ccc5094f4944e0b6fbf7f1e1435578fd3debffc0e0db4afda58"),
-    std::make_pair(320000, "ac76516b2be5fd6391ac1511c409e19eab0c5b55754883a72d2473457af9299e"),
-    std::make_pair(330000, "158c9640fd4376569e439f7c6f4b7ac17e14dffc9f9b99a7e6b38b57c7ff5ece"),
-    std::make_pair(340000, "85655b4e01fa328f5d1c955d00f27989e644a38931280d1448b83c98f78d3a25"),
-    std::make_pair(350000, "c562ebcc36c5dd094f7dff3d0083362701b8ad489b825a93dab3e51d7a0b59f2"),
-    std::make_pair(360000, "da08157c018429bf717989ec653151652fb95d3107b287e016c8b9483e9f86f7")
+static const ConsensusCheckpoint vCheckpoints[] = {
+    { 250000, uint256("000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"),
+              uint256("f8ca97346756bbe3b530d052c884b2f54c14edc1498ba2176214857dee13f3ca") },
+    { 260000, uint256("000000000000001fb91fbcebaaba0e2d926f04908d798a8b598c3bd962951080"),
+              uint256("e8b5445bbfc915e59164a6c22e4d84b23539569ee3c95b49eefaeaca86ea98a0") },
+    { 270000, uint256("0000000000000002a775aec59dc6a9e4bb1c025cf1b8c2195dd9dc3998c827c5"),
+              uint256("4eb6f75c961308c18dad1e2677170465f30d367489e61cb2510e400dc3d21117") },
+    { 280000, uint256("0000000000000001c091ada69f444dc0282ecaabe4808ddbb2532e5555db0c03"),
+              uint256("5896745cfde2423d1c896865b49953cac76d87f8d29c619793698d06c14f11d6") },
+    { 290000, uint256("0000000000000000fa0b2badd05db0178623ebf8dd081fe7eb874c26e27d0b3b"),
+              uint256("28f4c64fa05adee082c7fb10f3b768747fef28bff1e29f22482ed17e9dfe130c") },
+    { 300000, uint256("000000000000000082ccf8f1557c5d40b21edabb18d2d691cfbf87118bac7254"),
+              uint256("51b429776f26ee4b9ebf2de669c7c01f420004ce29d4df92a2e3d7b0248cbe8e") },
+    { 310000, uint256("0000000000000000125a28cc9e9209ddb75718f599a8039f6c9e7d9f1fb021e0"),
+              uint256("f8ab77846e859ccc5094f4944e0b6fbf7f1e1435578fd3debffc0e0db4afda58") },
+    { 320000, uint256("000000000000000015aab005b28a326ade60f07515c33517ea5cb598f28fb7ea"),
+              uint256("ac76516b2be5fd6391ac1511c409e19eab0c5b55754883a72d2473457af9299e") },
+    { 330000, uint256("00000000000000000faabab19f17c0178c754dbed023e6c871dcaf74159c5f02"),
+              uint256("158c9640fd4376569e439f7c6f4b7ac17e14dffc9f9b99a7e6b38b57c7ff5ece") },
+    { 340000, uint256("00000000000000000d9b2508615d569e18f00c034d71474fc44a43af8d4a5003"),
+              uint256("85655b4e01fa328f5d1c955d00f27989e644a38931280d1448b83c98f78d3a25") },
+    { 350000, uint256("0000000000000000053cf64f0400bb38e0c4b3872c38795ddde27acb40a112bb"),
+              uint256("c562ebcc36c5dd094f7dff3d0083362701b8ad489b825a93dab3e51d7a0b59f2") },
+    { 360000, uint256("00000000000000000ca6e07cf681390ff888b7f96790286a440da0f2b87c8ea6"),
+              uint256("da08157c018429bf717989ec653151652fb95d3107b287e016c8b9483e9f86f7") },
 };
 
 /** A mapping of transaction types, versions and the blocks at which they are enabled.
@@ -202,17 +222,20 @@ uint256 GetConsensusHash()
     return consensusHash;
 }
 
-/** Compares a supplied block and consensus hash against a hardcoded list of checkpoints */
-bool VerifyCheckpoint(int block)
+/** Compares a supplied block, block hash and consensus hash against a hardcoded list of checkpoints */
+bool VerifyCheckpoint(int block, uint256 blockHash)
 {
     // checkpoints are only verified for mainnet
     if (isNonMainNet()) return true;
 
-    for (unsigned int i = 0; i < sizeof(checkpoints)/sizeof(checkpoints[0]); i++) {
-        if (block != checkpoints[i].first) continue;
+    for (unsigned int i = 0; i < sizeof(vCheckpoints)/sizeof(vCheckpoints[0]); i++) {
+        if (block != vCheckpoints[i].blockHeight) continue;
+
+        if (blockHash != vCheckpoints[i].blockHash) return false;
+
         // only verify if there is a checkpoint to verify against
         uint256 consensusHash = GetConsensusHash();
-        if (consensusHash.GetHex() != checkpoints[i].second) return false;
+        if (consensusHash != vCheckpoints[i].consensusHash) return false;
     }
 
     // either checkpoint matched or we don't have a checkpoint for this block

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -152,7 +152,6 @@ uint256 GetConsensusHash()
     SHA256_CTX shaCtx;
     SHA256_Init(&shaCtx);
 
-    // obtain a lock while we interrogate the tally map
     LOCK(cs_tally);
 
     // loop through the tally map, updating the sha context with the data from each balance & type
@@ -171,11 +170,20 @@ uint256 GetConsensusHash()
 
             note: pending tally is ignored
             */
+
+            int64_t balance = tally.getMoney(propertyId, BALANCE);
+            int64_t sellOfferReserve = tally.getMoney(propertyId, SELLOFFER_RESERVE);
+            int64_t acceptReserve = tally.getMoney(propertyId, ACCEPT_RESERVE);
+            int64_t metaDExReserve = tally.getMoney(propertyId, METADEX_RESERVE);
+
+            // skip this entry if all balances are empty
+            if (!balance && !sellOfferReserve && !acceptReserve && !metaDExReserve) continue;
+
             const std::string& dataStr = address + "|" + FormatIndivisibleMP(propertyId) + "|" +
-                                         FormatIndivisibleMP(tally.getMoney(propertyId, BALANCE)) + "|" +
-                                         FormatIndivisibleMP(tally.getMoney(propertyId, SELLOFFER_RESERVE)) + "|" +
-                                         FormatIndivisibleMP(tally.getMoney(propertyId, ACCEPT_RESERVE)) + "|" +
-                                         FormatIndivisibleMP(tally.getMoney(propertyId, METADEX_RESERVE));
+                                         FormatIndivisibleMP(balance) + "|" +
+                                         FormatIndivisibleMP(sellOfferReserve) + "|" +
+                                         FormatIndivisibleMP(acceptReserve) + "|" +
+                                         FormatIndivisibleMP(metaDExReserve);
 
             // update the sha context with the data string
             SHA256_Update(&shaCtx, dataStr.c_str(), dataStr.length());

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -1,6 +1,9 @@
 #ifndef OMNICORE_RULES_H
 #define OMNICORE_RULES_H
 
+class uint256;
+
+#include <openssl/sha.h>
 #include <stdint.h>
 
 namespace mastercore
@@ -40,6 +43,8 @@ bool IsAllowedInputType(int whichType, int nBlock);
 bool IsAllowedOutputType(int whichType, int nBlock);
 /** Checks, if the transaction type and version is supported and enabled. */
 bool IsTransactionTypeAllowed(int txBlock, uint32_t txProperty, uint16_t txType, uint16_t version, bool bAllowNullProperty = false);
+/** Obtains a hash of all balances to use for consensus verification & checkpointing. */
+uint256 GetConsensusHash();
 }
 
 #endif // OMNICORE_RULES_H

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -45,6 +45,8 @@ bool IsAllowedOutputType(int whichType, int nBlock);
 bool IsTransactionTypeAllowed(int txBlock, uint32_t txProperty, uint16_t txType, uint16_t version, bool bAllowNullProperty = false);
 /** Obtains a hash of all balances to use for consensus verification & checkpointing. */
 uint256 GetConsensusHash();
+/** Compares a supplied block and consensus hash against a hardcoded list of checkpoints */
+bool VerifyCheckpoint(int block);
 }
 
 #endif // OMNICORE_RULES_H

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -3,7 +3,6 @@
 
 class uint256;
 
-#include <openssl/sha.h>
 #include <stdint.h>
 
 namespace mastercore

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -45,8 +45,8 @@ bool IsAllowedOutputType(int whichType, int nBlock);
 bool IsTransactionTypeAllowed(int txBlock, uint32_t txProperty, uint16_t txType, uint16_t version, bool bAllowNullProperty = false);
 /** Obtains a hash of all balances to use for consensus verification & checkpointing. */
 uint256 GetConsensusHash();
-/** Compares a supplied block and consensus hash against a hardcoded list of checkpoints */
-bool VerifyCheckpoint(int block);
+/** Compares a supplied block, block hash and consensus hash against a hardcoded list of checkpoints */
+bool VerifyCheckpoint(int block, uint256 blockHash);
 }
 
 #endif // OMNICORE_RULES_H

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -371,6 +371,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_getallbalancesforaddress",   &omni_getallbalancesforaddress,   false,      true,       true },
     { "omni layer (data retrieval)",         "omni_gettradehistoryforaddress",  &omni_gettradehistoryforaddress,  false,      true,       true },
     { "omni layer (data retrieval)",         "omni_gettradehistoryforpair",     &omni_gettradehistoryforpair,     false,      true,       true },
+    { "omni layer (data retrieval)",         "omni_getcurrentconsensushash",    &omni_getcurrentconsensushash,    false,      true,       false },
 
     /* Omni Core configuration calls */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -245,6 +245,7 @@ extern json_spirit::Value omni_listblocktransactions(const json_spirit::Array& p
 extern json_spirit::Value omni_getallbalancesforaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_gettradehistoryforaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_gettradehistoryforpair(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getcurrentconsensushash(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Consensus testing currently relies on looping through every property and checking the balance for every address.  This PR serves to distill that process down into a single hash, which can be used for consensus testing but also be used as a form of checkpointing (by verifying that all balances for all properties are as expected at a given block).  

This PR also implements a checkpointing system, and hardcoded checkpoints for every 10,000 blocks.  Strictly speaking only the most recent checkpoint is needed and earlier checkpoints may be removed later, however in the early stages of this PR and while it's being tested it is useful to have earlier checkpoints listed as this allows checkpoint verification functions to be tested earlier in the parsing process.

The RPC call ```omni_getcurrentconsensushash``` may be used to obtain the hash for the current block.

Feedback would be most welcomed :)
