### PR TITLE
Seperate logic from plain transaction parsing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2060,7 +2060,7 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
 
         //! Omni Core: new confirmed transaction notification
         LogPrint("handler", "Omni Core handler: new confirmed transaction [height: %d, idx: %u]\n", GetHeight(), nTxIdx);
-        if (0 == mastercore_handler_tx(tx, GetHeight(), nTxIdx++, pindexNew)) ++nNumMetaTxs;
+        if (mastercore_handler_tx(tx, GetHeight(), nTxIdx++, pindexNew)) ++nNumMetaTxs;
     }
 
     //! Omni Core: end of block connect notification

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -24,6 +24,8 @@ static const long LOG_SHRINKSIZE  = 50000000; // 50 MB
 // Debug flags
 bool msc_debug_parser_data        = 0;
 bool msc_debug_parser_readonly    = 0;
+//! Print information to potential DEx payments and outputs
+bool msc_debug_parser_dex         = 1;
 bool msc_debug_parser             = 0;
 bool msc_debug_verbose            = 0;
 bool msc_debug_verbose2           = 0;
@@ -227,6 +229,7 @@ void InitDebugLogLevels()
     for (std::vector<std::string>::const_iterator it = debugLevels.begin(); it != debugLevels.end(); ++it) {
         if (*it == "parser_data") msc_debug_parser_data = true;
         if (*it == "parser_readonly") msc_debug_parser_readonly = true;
+        if (*it == "parser_dex") msc_debug_parser_dex = true;
         if (*it == "parser") msc_debug_parser = true;
         if (*it == "verbose") msc_debug_verbose = true;
         if (*it == "verbose2") msc_debug_verbose2 = true;
@@ -259,6 +262,7 @@ void InitDebugLogLevels()
             if (*it == "all") allDebugState = true;
             msc_debug_parser_data = allDebugState;
             msc_debug_parser_readonly = allDebugState;
+            msc_debug_parser_dex = allDebugState;
             msc_debug_parser = allDebugState;
             msc_debug_verbose = allDebugState;
             msc_debug_verbose2 = allDebugState;

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -21,6 +21,7 @@ void ShrinkDebugLog();
 // Debug flags
 extern bool msc_debug_parser_data;
 extern bool msc_debug_parser_readonly;
+extern bool msc_debug_parser_dex;
 extern bool msc_debug_parser;
 extern bool msc_debug_verbose;
 extern bool msc_debug_verbose2;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -998,7 +998,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         if (strDataAddress.empty()) // an empty Data Address here means it is not Class A valid and should be defaulted to a BTC payment
         {
             // this must be the BTC payment - validate (?)
-            if (!bRPConly || msc_debug_parser_readonly) {
+            if ((!bRPConly || msc_debug_parser_readonly) && msc_debug_parser_dex) {
                 PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
                 PrintToLog("!! this may be the BTC payment for an offer !!\n");
             }
@@ -1015,7 +1015,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                         const std::string strAddress = CBitcoinAddress(dest).ToString();
 
                         if (exodus_address == strAddress) continue;
-                        if (!bRPConly || msc_debug_parser_readonly) {
+                        if ((!bRPConly || msc_debug_parser_readonly) && msc_debug_parser_dex) {
                             PrintToLog("payment #%d %s %11.8lf\n", count, strAddress, (double) wtx.vout[i].nValue / (double) COIN);
                         }
 
@@ -1395,8 +1395,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             packet_size = PACKET_SIZE_CLASS_A;
             memcpy(single_pkt, &ParseHex(strScriptData)[0], packet_size);
         } else {
-            // TODO: move/remove the following log output ?
-            if (!bRPConly || msc_debug_parser_readonly) {
+            if ((!bRPConly || msc_debug_parser_readonly) && msc_debug_parser_dex) {
                 PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
                 PrintToLog("!! this may be the BTC payment for an offer !!\n");
             }
@@ -1632,7 +1631,7 @@ static bool HandleDExPayments(const CTransaction& tx, int nBlock, const std::str
                 continue;
             }
             std::string strAddress = address.ToString();
-            PrintToLog("payment #%d %s %s\n", count, strAddress, FormatIndivisibleMP(tx.vout[n].nValue));
+            if (msc_debug_parser_dex) PrintToLog("payment #%d %s %s\n", count, strAddress, FormatIndivisibleMP(tx.vout[n].nValue));
 
             // check everything and pay BTC for the property we are buying here...
             if (0 == DEx_payment(tx.GetHash(), n, strAddress, strSender, tx.vout[n].nValue, nBlock)) ++count;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1162,7 +1162,8 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
 /** Determines, whether to fall back to legacy transaction parsing/processing. */
 static bool useLegacyProcessing(int nBlock)
 {
-    return (!IsAllowedOutputType(TX_NULL_DATA, nBlock));
+    static bool fDisableLegacy = GetBoolArg("-omnidisablelegacy", false);
+    return (!IsAllowedOutputType(TX_NULL_DATA, nBlock) && !fDisableLegacy);
 }
 
 } // namespace legacy

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -491,7 +491,12 @@ void CheckWalletUpdate(bool forceUpdate)
     uiInterface.OmniBalanceChanged();
 }
 
-int TXExodusFundraiser(const CTransaction& tx, const std::string& sender, int64_t amountInvested, int nBlock, unsigned int nTime)
+/**
+ * Executes Exodus crowdsale purchases.
+ *
+ * @return True, if it was a valid purchase
+ */
+static bool TXExodusFundraiser(const CTransaction& tx, const std::string& sender, int64_t amountInvested, int nBlock, unsigned int nTime)
 {
     const int secondsPerWeek = 60 * 60 * 24 * 7;
     const CConsensusParams& params = ConsensusParams();
@@ -501,21 +506,18 @@ int TXExodusFundraiser(const CTransaction& tx, const std::string& sender, int64_
         double bonusPercentage = params.exodusBonusPerWeek * deadlineTimeleft / secondsPerWeek;
         double bonus = 1.0 + std::max(bonusPercentage, 0.0);
 
-        if (isNonMainNet()) {
-            // TODO: seems useless, if limited to non-mainnet; should be removed
-            if (sender == exodus_address) return 1; // sending from Exodus should not be fundraising anything
-        }
-
         int64_t amountGenerated = round(params.exodusReward * amountInvested * bonus);
-        PrintToLog("Exodus Fundraiser tx detected, tx %s generated %s\n", tx.GetHash().ToString(), FormatDivisibleMP(amountGenerated));
+        if (amountGenerated > 0) {
+            PrintToLog("Exodus Fundraiser tx detected, tx %s generated %s\n", tx.GetHash().ToString(), FormatDivisibleMP(amountGenerated));
 
-        // TODO: return result, grant somewhere else
-        update_tally_map(sender, OMNI_PROPERTY_MSC, amountGenerated, BALANCE);
-        update_tally_map(sender, OMNI_PROPERTY_TMSC, amountGenerated, BALANCE);
+            assert(update_tally_map(sender, OMNI_PROPERTY_MSC, amountGenerated, BALANCE));
+            assert(update_tally_map(sender, OMNI_PROPERTY_TMSC, amountGenerated, BALANCE));
 
-        return 0;
+            return true;
+        }
     }
-    return -1;
+
+    return false;
 }
 
 /**
@@ -1151,9 +1153,16 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
 
     if (msc_debug_verbose) PrintToLog("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt, false));
 
-    mp_tx.Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *) &single_pkt, packet_size, fMultisig, (inAll - outAll));
+    int encodingClass = fMultisig ? OMNI_CLASS_B : OMNI_CLASS_A;
+    mp_tx.Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *) &single_pkt, packet_size, encodingClass, (inAll - outAll));
 
     return 0;
+}
+
+/** Determines, whether to fall back to legacy transaction parsing/processing. */
+static bool useLegacyProcessing(int nBlock)
+{
+    return (!IsAllowedOutputType(TX_NULL_DATA, nBlock));
 }
 
 } // namespace legacy
@@ -1169,7 +1178,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
     assert(bRPConly == mp_tx.isRpcOnly());
 
     // Fallback to legacy parsing, if OP_RETURN isn't enabled:
-    if (!IsAllowedOutputType(TX_NULL_DATA, nBlock)) {
+    if (legacy::useLegacyProcessing(nBlock)) {
         return legacy::parseTransaction(bRPConly, wtx, nBlock, idx, mp_tx, nTime);
     }
 
@@ -1274,23 +1283,6 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
     } else {
         PrintToLog("The sender is still EMPTY !!! txid: %s\n", wtx.GetHash().GetHex());
         return -5;
-    }
-
-    if (!bRPConly) {
-        // ### CHECK FOR ANY REQUIRED EXODUS CROWDSALE PAYMENTS ###
-        int64_t BTC_amount = 0;
-        for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
-            CTxDestination dest;
-            if (ExtractDestination(wtx.vout[n].scriptPubKey, dest)) {
-                if (CBitcoinAddress(dest) == ExodusCrowdsaleAddress(nBlock)) {
-                    BTC_amount = wtx.vout[n].nValue;
-                    break; // TODO: maybe sum all values
-                }
-            }
-        }
-        if (0 < BTC_amount) {
-            TXExodusFundraiser(wtx, strSender, BTC_amount, nBlock, nTime);
-        }
     }
 
     // ### DATA POPULATION ### - save output addresses, values and scripts
@@ -1402,30 +1394,11 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             packet_size = PACKET_SIZE_CLASS_A;
             memcpy(single_pkt, &ParseHex(strScriptData)[0], packet_size);
         } else {
-            // ### BTC PAYMENT FOR DEX HANDLING ###
+            // TODO: move/remove the following log output ?
             if (!bRPConly || msc_debug_parser_readonly) {
                 PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
                 PrintToLog("!! this may be the BTC payment for an offer !!\n");
             }
-            // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
-            int count = 0;
-            for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
-                CTxDestination dest;
-                if (ExtractDestination(wtx.vout[n].scriptPubKey, dest)) {
-                    CBitcoinAddress address(dest);
-                    if (address == ExodusAddress()) {
-                        continue;
-                    }
-                    std::string strAddress = address.ToString();
-                    if (!bRPConly || msc_debug_parser_readonly) {
-                        PrintToLog("payment #%d %s %s\n", count, strAddress, FormatIndivisibleMP(wtx.vout[n].nValue));
-                    }
-                    // check everything & pay BTC for the property we are buying here...
-                    if (bRPConly) count = 55555;  // no real way to validate a payment during simple RPC call
-                    else if (0 == DEx_payment(wtx.GetHash(), n, strAddress, strSender, wtx.vout[n].nValue, nBlock)) ++count;
-                }
-            }
-            return count ? count : -5678; // return count -- the actual number of payments within this TX or error if none were made
         }
     }
     // ### CLASS B / CLASS C PARSING ###
@@ -1540,9 +1513,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                 }
             }
             packet_size = mdata_count * (PACKET_SIZE - 1);
-            if (sizeof(single_pkt) < packet_size) {
-                return -111;
-            }
+            assert(packet_size <= sizeof(single_pkt));
 
             // ### FINALIZE CLASS B ###
             for (unsigned int m = 0; m < mdata_count; ++m) { // now decode mastercoin packets
@@ -1621,7 +1592,13 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
 
     // ### SET MP TX INFO ###
     if (msc_debug_verbose) PrintToLog("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt));
-    mp_tx.Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, omniClass-1, (inAll-outAll));
+    mp_tx.Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, omniClass, (inAll-outAll));
+
+    // TODO: the following is a bit aweful
+    // Provide a hint for DEx payments
+    if (omniClass == OMNI_CLASS_A && packet_size == 0) {
+        return 1;
+    }
 
     return 0;
 }
@@ -1632,6 +1609,65 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
 int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction& mptx, unsigned int nTime)
 {
     return parseTransaction(true, tx, nBlock, idx, mptx, nTime);
+}
+
+/**
+ * Handles potential DEx payments.
+ *
+ * Note: must *not* be called outside of the transaction handler, and it does not
+ * check, if a transaction marker exists.
+ *
+ * @return True, if valid
+ */
+static bool HandleDExPayments(const CTransaction& tx, int nBlock, const std::string& strSender)
+{
+    int count = 0;
+
+    for (unsigned int n = 0; n < tx.vout.size(); ++n) {
+        CTxDestination dest;
+        if (ExtractDestination(tx.vout[n].scriptPubKey, dest)) {
+            CBitcoinAddress address(dest);
+            if (address == ExodusAddress()) {
+                continue;
+            }
+            std::string strAddress = address.ToString();
+            PrintToLog("payment #%d %s %s\n", count, strAddress, FormatIndivisibleMP(tx.vout[n].nValue));
+
+            // check everything and pay BTC for the property we are buying here...
+            if (0 == DEx_payment(tx.GetHash(), n, strAddress, strSender, tx.vout[n].nValue, nBlock)) ++count;
+        }
+    }
+
+    return (count > 0);
+}
+
+/**
+ * Handles potential Exodus crowdsale purchases.
+ *
+ * Note: must *not* be called outside of the transaction handler, and it does not
+ * check, if a transaction marker exists.
+ *
+ * @return True, if it was a valid purchase
+ */
+static bool HandleExodusPurchase(const CTransaction& tx, int nBlock, const std::string& strSender, unsigned int nTime)
+{
+    int64_t amountInvested = 0;
+
+    for (unsigned int n = 0; n < tx.vout.size(); ++n) {
+        CTxDestination dest;
+        if (ExtractDestination(tx.vout[n].scriptPubKey, dest)) {
+            if (CBitcoinAddress(dest) == ExodusCrowdsaleAddress(nBlock)) {
+                amountInvested = tx.vout[n].nValue;
+                break; // TODO: maybe sum all values
+            }
+        }
+    }
+
+    if (0 < amountInvested) {
+        return TXExodusFundraiser(tx, strSender, amountInvested, nBlock, nTime);
+    }
+
+    return false;
 }
 
 /**
@@ -1774,7 +1810,7 @@ static int msc_initial_scan(int nFirstBlock)
             if (!ReadBlockFromDisk(block, pblockindex)) break;
 
             BOOST_FOREACH(const CTransaction&tx, block.vtx) {
-                if (0 == mastercore_handler_tx(tx, nBlock, nTxNum, pblockindex)) nFound++;
+                if (mastercore_handler_tx(tx, nBlock, nTxNum, pblockindex)) ++nFound;
                 ++nTxNum;
             }
         }
@@ -2664,8 +2700,12 @@ int mastercore_shutdown()
     return 0;
 }
 
-// this is called for every new transaction that comes in (actually in block parsing loop)
-int mastercore_handler_tx(const CTransaction &tx, int nBlock, unsigned int idx, CBlockIndex const * pBlockIndex)
+/**
+ * This handler is called for every new transaction that comes in (actually in block parsing loop).
+ *
+ * @return True, if the transaction was an Exodus purchase, DEx payment or a valid Omni transaction
+ */
+bool mastercore_handler_tx(const CTransaction& tx, int nBlock, unsigned int idx, const CBlockIndex* pBlockIndex)
 {
     LOCK(cs_tally);
 
@@ -2679,28 +2719,50 @@ int mastercore_handler_tx(const CTransaction &tx, int nBlock, unsigned int idx, 
     // NOTE2: Plus I wanna clear the amount before that TX is parsed by our protocol, in case we ever consider pending amounts in internal calculations.
     PendingDelete(tx.GetHash());
 
-    // save the augmented offer or accept amount into the database as well (expecting them to be numerically lower than that in the blockchain)
-    int interp_ret = -555555, pop_ret;
-
-    if (nBlock < nWaterlineBlock) return -1; // we do not care about parsing blocks prior to our waterline (empty blockchain defense)
+    // we do not care about parsing blocks prior to our waterline (empty blockchain defense)
+    if (nBlock < nWaterlineBlock) return false;
+    int64_t nBlockTime = pBlockIndex->GetBlockTime();
 
     CMPTransaction mp_obj;
     mp_obj.unlockLogic();
 
-    pop_ret = parseTransaction(false, tx, nBlock, idx, mp_obj, pBlockIndex->GetBlockTime());
-    if (0 == pop_ret) {
-        // true MP transaction, validity (such as insufficient funds, or offer not found) is determined elsewhere
+    bool fFoundTx = false;
+    int pop_ret = parseTransaction(false, tx, nBlock, idx, mp_obj, nBlockTime);
 
-        interp_ret = mp_obj.interpretPacket();
-        if (interp_ret) PrintToLog("!!! interpretPacket() returned %d !!!\n", interp_ret);
+    if (!legacy::useLegacyProcessing(nBlock))
+    {
+        /**
+         * Legacy transaction parsing also triggers Exodus purchases and DEx payments,
+         * so we need an extra path here.
+         */
 
-        // of course only MP-related TXs get recorded
-        bool bValid = (0 <= interp_ret);
+        if (pop_ret >= 0) {
+            assert(mp_obj.getEncodingClass() != NO_MARKER);
+            assert(mp_obj.getSender().empty() == false);
 
-        p_txlistdb->recordTX(tx.GetHash(), bValid, nBlock, mp_obj.getType(), mp_obj.getNewAmount());
+            fFoundTx |= HandleExodusPurchase(tx, nBlock, mp_obj.getSender(), nBlockTime);
+        }
+
+        if (pop_ret > 0) {
+            assert(mp_obj.getEncodingClass() == OMNI_CLASS_A);
+            assert(mp_obj.getPayload().empty() == true);
+
+            fFoundTx |= HandleDExPayments(tx, nBlock, mp_obj.getSender());
+        }
     }
 
-    return interp_ret;
+    if (0 == pop_ret) {
+        int interp_ret = mp_obj.interpretPacket();
+        if (interp_ret) PrintToLog("!!! interpretPacket() returned %d !!!\n", interp_ret);
+
+        // only valid transactions get recorded
+        bool bValid = (0 <= interp_ret);
+        p_txlistdb->recordTX(tx.GetHash(), bValid, nBlock, mp_obj.getType(), mp_obj.getNewAmount());
+
+        fFoundTx |= (interp_ret == 0);
+    }
+
+    return fFoundTx;
 }
 
 // IsMine wrapper to determine whether the address is in our local wallet

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -266,7 +266,7 @@ int mastercore_handler_disc_begin(int nBlockNow, CBlockIndex const * pBlockIndex
 int mastercore_handler_disc_end(int nBlockNow, CBlockIndex const * pBlockIndex);
 int mastercore_handler_block_begin(int nBlockNow, CBlockIndex const * pBlockIndex);
 int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex, unsigned int);
-int mastercore_handler_tx(const CTransaction &tx, int nBlock, unsigned int idx, CBlockIndex const *pBlockIndex );
+bool mastercore_handler_tx(const CTransaction& tx, int nBlock, unsigned int idx, const CBlockIndex* pBlockIndex);
 int mastercore_save_state( CBlockIndex const *pBlockIndex );
 
 namespace mastercore

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -66,16 +66,20 @@ std::string mastercore::c_strMasterProtocolTXType(uint16_t txType)
 }
 
 /** Helper to convert class number to string. */
-static std::string intToClass(int multi)
+static std::string intToClass(int encodingClass)
 {
-    switch (multi) {
-        case 1:
+    switch (encodingClass) {
+        case OMNI_CLASS_A:
+            return "A";
+        case OMNI_CLASS_B:
             return "B";
-        case 2:
+        case OMNI_CLASS_C:
             return "C";
     }
-    return "A";
+
+    return "-";
 }
+
 /** Checks whether a pointer to the payload is past it's last position. */
 bool CMPTransaction::isOverrun(const char* p)
 {
@@ -166,7 +170,7 @@ bool CMPTransaction::interpret_TransactionType()
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t------------------------------\n");
-        PrintToLog("\t         version: %d, class %s\n", txVersion, intToClass(multi));
+        PrintToLog("\t         version: %d, class %s\n", txVersion, intToClass(encodingClass));
         PrintToLog("\t            type: %d (%s)\n", txType, c_strMasterProtocolTXType(txType));
     }
 

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -36,7 +36,7 @@ private:
 
     int pkt_size;
     unsigned char pkt[1 + MAX_PACKETS * PACKET_SIZE];
-    int multi;  // Class A = 0, Class B = 1, Class C = 2
+    int encodingClass;  // No Marker = 0, Class A = 1, Class B = 2, Class C = 3
 
     std::string sender;
     std::string receiver;
@@ -174,6 +174,7 @@ public:
     std::string getSPName() const { return name; }
     std::string getAlertString() const { return alertString; }
     bool isRpcOnly() const { return rpcOnly; }
+    int getEncodingClass() const { return encodingClass; }
 
     /** Creates a new CMPTransaction object. */
     CMPTransaction()
@@ -191,7 +192,7 @@ public:
         tx_fee_paid = 0;
         pkt_size = 0;
         memset(&pkt, 0, sizeof(pkt));
-        multi = 0;
+        encodingClass = 0;
         sender.clear();
         receiver.clear();
         type = 0;
@@ -232,7 +233,7 @@ public:
 
     /** Sets the given values. */
     void Set(const std::string& s, const std::string& r, uint64_t n, const uint256& t,
-        int b, unsigned int idx, unsigned char *p, unsigned int size, int fMultisig, uint64_t txf)
+        int b, unsigned int idx, unsigned char *p, unsigned int size, int encodingClassIn, uint64_t txf)
     {
         sender = s;
         receiver = r;
@@ -242,7 +243,7 @@ public:
         pkt_size = size < sizeof (pkt) ? size : sizeof (pkt);
         nValue = n;
         nNewValue = n;
-        multi = fMultisig;
+        encodingClass = encodingClassIn;
         tx_fee_paid = txf;
         memcpy(&pkt, p, pkt_size);
     }


### PR DESCRIPTION
To turn `parseTransaction()` into a side effect free function, the DEx payment and Exodus purchase logic was extracted, and moved into new functions, which are called directly from the transaction handler.

The legacy parsing is mostly untouched, and the new logic functions are only executed, if the non-legacy parsing function is used.

`parseTransaction()` returns a negative error code, `1` (potential DEx payment), or `0`, if it's an Omni transaction with payload. This should not have an impact, given that it's usually used with checks such as `< 0`, `== 0`, `>= 0`, or `> 0`.

Because the result of the transaction handler is either valid, or invalid, a boolean is returned instead of a number.

These changes pave the way for further restructuring, and finer control over the state, as well as better signal handling, and it resolves #143.