### PR TITLE
Improve wallet handling and support --disable-wallet builds

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -27,7 +27,8 @@ OMNICORE_H = \
   omnicore/utils.h \
   omnicore/utilsbitcoin.h \
   omnicore/version.h \
-  omnicore/walletcache.h
+  omnicore/walletcache.h \
+  omnicore/wallettxs.h
 
 OMNICORE_CPP = \
   omnicore/convert.cpp \
@@ -57,7 +58,8 @@ OMNICORE_CPP = \
   omnicore/utils.cpp \
   omnicore/utilsbitcoin.cpp \
   omnicore/version.cpp \
-  omnicore/walletcache.cpp
+  omnicore/walletcache.cpp \
+  omnicore/wallettxs.cpp
 
 libbitcoin_server_a_SOURCES += \
   $(OMNICORE_CPP) \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -329,7 +329,9 @@ BITCOIN_QT_CPP = \
   qt/splashscreen.cpp \
   qt/trafficgraphwidget.cpp \
   qt/utilitydialog.cpp \
-  qt/winshutdownmonitor.cpp
+  qt/winshutdownmonitor.cpp \
+  qt/omnicore_init.cpp \
+  qt/omnicore_qtutils.cpp
 
 if ENABLE_WALLET
 BITCOIN_QT_CPP += \
@@ -365,11 +367,9 @@ BITCOIN_QT_CPP += \
   qt/lookuptxdialog.cpp \
   qt/txhistorydialog.cpp \
   qt/balancesdialog.cpp \
-  qt/omnicore_init.cpp \
   qt/metadexdialog.cpp \
   qt/metadexcanceldialog.cpp \
-  qt/tradehistorydialog.cpp \
-  qt/omnicore_qtutils.cpp
+  qt/tradehistorydialog.cpp
 endif
 
 RES_IMAGES = \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1109,18 +1109,6 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     // ********************************************************* Step 7.5: load omni core
 
-#ifndef ENABLE_WALLET
-    bool fDisableWallet = true;
-#endif
-
-    if (fDisableWallet) {
-        return InitError(_(
-                "Disabled wallet detected.\n\n"
-                "Omni Core requires an enabled wallet. Please start your client "
-                "without the \"-disablewallet\" option to enable the wallet."
-            ));
-    }
-
     if (!fTxIndex) {
         // ask the user if they would like us to modify their config file for them
         std::string msg = _("Disabled transaction index detected.\n\n"

--- a/src/omnicore/fetchwallettx.cpp
+++ b/src/omnicore/fetchwallettx.cpp
@@ -1,32 +1,65 @@
-// The fetch functions provide a sorted list of transaction hashes ordered by block, position in block and position in wallet including STO receipts
+/**
+ * @file fetchwallettx.cpp
+ *
+ * The fetch functions provide a sorted list of transaction hashes ordered by block,
+ * position in block and position in wallet including STO receipts.
+ */
+
 #include "omnicore/fetchwallettx.h"
 
+#include "omnicore/log.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/pending.h"
 #include "omnicore/utilsbitcoin.h"
 
 #include "init.h"
-#include "wallet.h"
+#include "main.h"
 #include "sync.h"
-
-#include <stdint.h>
-
-#include <set>
-#include <map>
-#include <string>
+#include "tinyformat.h"
+#include "txdb.h"
+#ifdef ENABLE_WALLET
+#include "wallet.h"
+#endif
 
 #include <boost/algorithm/string.hpp>
 
-using namespace mastercore;
+#include <stdint.h>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mastercore
+{
+/**
+ * Gets the byte offset of a transaction from the transaction index.
+ */
+unsigned int GetTransactionByteOffset(const uint256& txid)
+{
+    LOCK(cs_main);
+
+    CDiskTxPos position;
+    if (pblocktree->ReadTxIndex(txid, position)) {
+        return position.nTxOffset;
+    }
+
+    return 0;
+}
 
 /**
-  * Returns an ordered list of Omni transactions including STO receipts that are relevant to the wallet
-  * Ignores order in the wallet (which can be skewed by watch addresses) and utilizes block height and position within block
-  */
-std::map<std::string,uint256> FetchWalletOmniTransactions(int count, int startBlock, int endBlock)
+ * Returns an ordered list of Omni transactions including STO receipts that are relevant to the wallet.
+ *
+ * Ignores order in the wallet (which can be skewed by watch addresses) and utilizes block height and position within block.
+ */
+std::map<std::string, uint256> FetchWalletOmniTransactions(unsigned int count, int startBlock, int endBlock)
 {
-    // Iterate backwards through wallet transactions until we have count items to return:
-    std::map<std::string,uint256> mapResponse;
+    std::map<std::string, uint256> mapResponse;
+#ifdef ENABLE_WALLET
+    if (pwalletMain == NULL) {
+        return mapResponse;
+    }
     std::set<uint256> seenHashes;
     std::list<CAccountingEntry> acentries;
     CWallet::TxItems txOrdered;
@@ -34,17 +67,18 @@ std::map<std::string,uint256> FetchWalletOmniTransactions(int count, int startBl
         LOCK(pwalletMain->cs_wallet);
         txOrdered = pwalletMain->OrderedTxItems(acentries, "*");
     }
+    // Iterate backwards through wallet transactions until we have count items to return:
     for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it) {
-        CWalletTx *const pwtx = (*it).second.first;
-        if (pwtx == 0) continue;
-        uint256 txHash = pwtx->GetHash();
+        const CWalletTx* pwtx = it->second.first;
+        if (pwtx == NULL) continue;
+        const uint256& txHash = pwtx->GetHash();
         {
             LOCK(cs_tally);
             if (!p_txlistdb->exists(txHash)) continue;
         }
-        uint256 blockHash = pwtx->hashBlock;
+        const uint256& blockHash = pwtx->hashBlock;
         if ((0 == blockHash) || (NULL == GetBlockIndex(blockHash))) continue;
-        CBlockIndex* pBlockIndex = GetBlockIndex(blockHash);
+        const CBlockIndex* pBlockIndex = GetBlockIndex(blockHash);
         if (NULL == pBlockIndex) continue;
         int blockHeight = pBlockIndex->nHeight;
         if (blockHeight < startBlock || blockHeight > endBlock) continue;
@@ -52,7 +86,7 @@ std::map<std::string,uint256> FetchWalletOmniTransactions(int count, int startBl
         std::string sortKey = strprintf("%06d%010d", blockHeight, blockPosition);
         mapResponse.insert(std::make_pair(sortKey, txHash));
         seenHashes.insert(txHash);
-        if ((int)mapResponse.size() >= count) break;
+        if (mapResponse.size() >= count) break;
     }
 
     // Insert STO receipts - receiving an STO has no inbound transaction to the wallet, so we will insert these manually into the response
@@ -82,8 +116,10 @@ std::map<std::string,uint256> FetchWalletOmniTransactions(int count, int startBl
     }
 
     // Insert pending transactions (sets block as 999999 and position as wallet position)
-    for (PendingMap::iterator it = my_pending.begin(); it != my_pending.end(); ++it) {
-        uint256 txHash = it->first;
+    // TODO: resolve potential deadlock caused by cs_wallet, cs_pending
+    // LOCK(cs_pending);
+    for (PendingMap::const_iterator it = my_pending.begin(); it != my_pending.end(); ++it) {
+        const uint256& txHash = it->first;
         int blockHeight = 999999;
         if (blockHeight < startBlock || blockHeight > endBlock) continue;
         int blockPosition = 0;
@@ -91,25 +127,16 @@ std::map<std::string,uint256> FetchWalletOmniTransactions(int count, int startBl
             LOCK(pwalletMain->cs_wallet);
             std::map<uint256, CWalletTx>::const_iterator walletIt = pwalletMain->mapWallet.find(txHash);
             if (walletIt != pwalletMain->mapWallet.end()) {
-                const CWalletTx* pendingWTx = &(*walletIt).second;
-                blockPosition = pendingWTx->nOrderPos;
+                const CWalletTx& wtx = walletIt->second;
+                blockPosition = wtx.nOrderPos;
             }
         }
         std::string sortKey = strprintf("%06d%010d", blockHeight, blockPosition);
         mapResponse.insert(std::make_pair(sortKey, txHash));
     }
-
+#endif
     return mapResponse;
 }
 
-/** Gets the byte offset of a transaction from the tx index
-  */
-uint64_t GetTransactionByteOffset(const uint256& txid)
-{
-    LOCK(cs_main);
-    CDiskTxPos position;
-    if (pblocktree->ReadTxIndex(txid, position)) {
-        return position.nTxOffset;
-    }
-    return 0;
-}
+
+} // namespace mastercore

--- a/src/omnicore/fetchwallettx.h
+++ b/src/omnicore/fetchwallettx.h
@@ -3,21 +3,16 @@
 
 class uint256;
 
-//#include "util.h"
-#include "txdb.h"
-
-#include <stdint.h>
 #include <map>
 #include <string>
 
-/** Gets the byte offset of a transaction from the tx index
-  */
-uint64_t GetTransactionByteOffset(const uint256& txid);
+namespace mastercore
+{
+/** Gets the byte offset of a transaction from the transaction index. */
+unsigned int GetTransactionByteOffset(const uint256& txid);
 
-/**
-  * Returns an ordered list of Omni transactions that are relevant to the wallet
-  * Ignores order in the wallet (which can be skewed by watch addresses) and utilizes block height and position within block
-  */
-std::map<std::string,uint256> FetchWalletOmniTransactions(int count, int startBlock = 0, int endBlock = 999999);
+/** Returns an ordered list of Omni transactions that are relevant to the wallet. */
+std::map<std::string, uint256> FetchWalletOmniTransactions(unsigned int count, int startBlock = 0, int endBlock = 999999);
+}
 
 #endif // OMNICORE_FETCHWALLETTX_H

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2803,8 +2803,13 @@ CWallet *wallet = pwalletMain;
   return string();
 }
 
-// This function determines whether it is valid to use a Class C transaction for a given payload size
-static bool UseEncodingClassC(size_t nDataSize)
+/**
+ * Determines, whether it is valid to use a Class C transaction for a given payload size.
+ *
+ * @param nDataSize The length of the payload
+ * @return True, if Class C is enabled and the payload is small enough
+ */
+bool mastercore::UseEncodingClassC(size_t nDataSize)
 {
     size_t nTotalSize = nDataSize + GetOmMarker().size(); // Marker "omni"
     bool fDataEnabled = GetBoolArg("-datacarrier", true);
@@ -2813,30 +2818,6 @@ static bool UseEncodingClassC(size_t nDataSize)
         fDataEnabled = false;
     }
     return nTotalSize <= nMaxDatacarrierBytes && fDataEnabled;
-}
-
-bool feeCheck(const string &address, size_t nDataSize)
-{
-    // check the supplied address against selectCoins to determine if sufficient fees for send
-    CCoinControl coinControl;
-    int64_t inputTotal = SelectCoins(address, coinControl, 0);
-    bool ClassC = UseEncodingClassC(nDataSize);
-    int64_t minFee = 0;
-
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    // TODO: THIS NEEDS WORK - CALCULATIONS ARE UNSUITABLE CURRENTLY
-    if (ClassC) {
-        // estimated minimum fee calculation for Class C with payload of nDataSize
-        // minFee = 3 * minRelayTxFee.GetFee(200) + CWallet::minTxFee.GetFee(200000);
-        minFee = 10000; // simply warn when below 10,000 satoshi for now
-    } else {
-        // estimated minimum fee calculation for Class B with payload of nDataSize
-        // minFee = 3 * minRelayTxFee.GetFee(200) + CWallet::minTxFee.GetFee(200000);
-        minFee = 10000; // simply warn when below 10,000 satoshi for now
-    }
-
-    return inputTotal >= minFee;
 }
 
 // This function requests the wallet create an Omni transaction using the supplied parameters and payload

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2867,21 +2867,12 @@ int mastercore::ClassAgnosticWalletTXBuilder(const std::string& senderAddress, c
     // Encode the data outputs
     switch(omniTxClass) {
         case OMNI_CLASS_B: { // declaring vars in a switch here so use an expicit code block
-            CBitcoinAddress address;
             CPubKey redeemingPubKey;
-            if (!redemptionAddress.empty()) { address.SetString(redemptionAddress); } else { address.SetString(senderAddress); }
-            if (wallet && address.IsValid()) { // validate the redemption address
-                if (address.IsScript()) {
-                    PrintToLog("%s() ERROR: Redemption Address must be specified !\n", __FUNCTION__);
-                    return MP_REDEMP_ILLEGAL;
-                } else {
-                    CKeyID keyID;
-                    if (!address.GetKeyID(keyID)) return MP_REDEMP_BAD_KEYID;
-                    if (!wallet->GetPubKey(keyID, redeemingPubKey)) return MP_REDEMP_FETCH_ERR_PUBKEY;
-                    if (!redeemingPubKey.IsFullyValid()) return MP_REDEMP_INVALID_PUBKEY;
-                }
-            } else return MP_REDEMP_BAD_VALIDATION;
-            if(!OmniCore_Encode_ClassB(senderAddress,redeemingPubKey,data,vecSend)) { return MP_ENCODING_ERROR; }
+            const std::string& sAddress = redemptionAddress.empty() ? senderAddress : redemptionAddress;
+            if (!AddressToPubKey(sAddress, redeemingPubKey)) {
+                return MP_REDEMP_BAD_VALIDATION;
+            }
+            if (!OmniCore_Encode_ClassB(senderAddress,redeemingPubKey,data,vecSend)) { return MP_ENCODING_ERROR; }
         break; }
         case OMNI_CLASS_C:
             if(!OmniCore_Encode_ClassC(data,vecSend)) { return MP_ENCODING_ERROR; }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2775,15 +2775,6 @@ bool mastercore_handler_tx(const CTransaction& tx, int nBlock, unsigned int idx,
     return fFoundTx;
 }
 
-// IsMine wrapper to determine whether the address is in our local wallet
-int IsMyAddress(const std::string &address)
-{
-    if (!pwalletMain) return ISMINE_NO;
-    const CBitcoinAddress& omniAddress = address;
-    CTxDestination omniDest = omniAddress.Get();
-    return IsMine(*pwalletMain, omniDest);
-}
-
 /**
  * Determines, whether it is valid to use a Class C transaction for a given payload size.
  *

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2784,25 +2784,6 @@ int IsMyAddress(const std::string &address)
     return IsMine(*pwalletMain, omniDest);
 }
 
-// gets a label for a Bitcoin address from the wallet, mainly to the UI (used in demo)
-string getLabel(const string &address)
-{
-CWallet *wallet = pwalletMain;
-
-  if (wallet)
-   {
-        LOCK(wallet->cs_wallet);
-        CBitcoinAddress address_parsed(address);
-        std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(address_parsed.Get());
-        if (mi != wallet->mapAddressBook.end())
-        {
-            return (mi->second.name);
-        }
-    }
-
-  return string();
-}
-
 /**
  * Determines, whether it is valid to use a Class C transaction for a given payload size.
  *

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -249,7 +249,6 @@ extern std::set<uint32_t> global_wallet_property_list;
 
 int64_t getMPbalance(const std::string& address, uint32_t propertyId, TallyType ttype);
 int64_t getUserAvailableMPbalance(const std::string& address, uint32_t propertyId);
-int IsMyAddress(const std::string& address);
 
 /** Global handler to initialize Omni Core. */
 int mastercore_init();

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -126,10 +126,10 @@ enum FILETYPES {
 #define OMNI_PROPERTY_TMSC  2
 
 // forward declarations
-std::string FormatDivisibleMP(int64_t n, bool fSign = false);
-std::string FormatDivisibleShortMP(int64_t);
-std::string FormatMP(uint32_t, int64_t n, bool fSign = false);
-std::string FormatShortMP(uint32_t, int64_t);
+std::string FormatDivisibleMP(int64_t amount, bool fSign = false);
+std::string FormatDivisibleShortMP(int64_t amount);
+std::string FormatMP(uint32_t propertyId, int64_t amount, bool fSign = false);
+std::string FormatShortMP(uint32_t propertyId, int64_t amount);
 std::string FormatByType(int64_t amount, uint16_t propertyType);
 
 /** Returns the Exodus address. */

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -126,12 +126,11 @@ enum FILETYPES {
 #define OMNI_PROPERTY_TMSC  2
 
 // forward declarations
-std::string FormatDivisibleMP(int64_t amount, bool fSign = false);
-std::string FormatDivisibleShortMP(int64_t amount);
-std::string FormatMP(uint32_t propertyId, int64_t amount, bool fSign = false);
-std::string FormatShortMP(uint32_t propertyId, int64_t amount);
+std::string FormatDivisibleMP(int64_t n, bool fSign = false);
+std::string FormatDivisibleShortMP(int64_t);
+std::string FormatMP(uint32_t, int64_t n, bool fSign = false);
+std::string FormatShortMP(uint32_t, int64_t);
 std::string FormatByType(int64_t amount, uint16_t propertyType);
-bool feeCheck(const std::string& address, size_t nDataSize);
 
 /** Returns the Exodus address. */
 const CBitcoinAddress ExodusAddress();
@@ -304,6 +303,9 @@ std::string strTransactionType(uint16_t txType);
 
 /** Returns the encoding class, used to embed a payload. */
 int GetEncodingClass(const CTransaction& tx, int nBlock);
+
+/** Determines, whether it is valid to use a Class C transaction for a given payload size. */
+bool UseEncodingClassC(size_t nDataSize);
 
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -251,8 +251,6 @@ int64_t getMPbalance(const std::string& address, uint32_t propertyId, TallyType 
 int64_t getUserAvailableMPbalance(const std::string& address, uint32_t propertyId);
 int IsMyAddress(const std::string& address);
 
-std::string getLabel(const std::string& address);
-
 /** Global handler to initialize Omni Core. */
 int mastercore_init();
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1,4 +1,8 @@
-// RPC calls
+/**
+ * @file rpc.cpp
+ *
+ * This file contains RPC calls for data retrieval.
+ */
 
 #include "omnicore/rpc.h"
 
@@ -30,7 +34,9 @@
 #include "tinyformat.h"
 #include "uint256.h"
 #include "utilstrencodings.h"
+#ifdef ENABLE_WALLET
 #include "wallet.h"
+#endif
 
 #include "json/json_spirit_value.h"
 
@@ -272,6 +278,7 @@ Value mscrpc(const Array& params, bool fHelp)
             PrintToConsole("Unlocking cs_main now\n");
             break;
         }
+#ifdef ENABLE_WALLET
         case 11:
         {
             PrintToConsole("Locking pwalletMain->cs_wallet for %d milliseconds..\n", extra2);
@@ -280,6 +287,7 @@ Value mscrpc(const Array& params, bool fHelp)
             PrintToConsole("Unlocking pwalletMain->cs_wallet now\n");
             break;
         }
+#endif
         default:
             break;
     }

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -16,6 +16,7 @@
 #include "omnicore/tx.h"
 #include "omnicore/pending.h"
 #include "omnicore/utilsbitcoin.h"
+#include "omnicore/wallettxs.h"
 
 // Boost includes
 #include <boost/lexical_cast.hpp>

--- a/src/omnicore/walletcache.cpp
+++ b/src/omnicore/walletcache.cpp
@@ -4,6 +4,7 @@
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/tally.h"
+#include "omnicore/wallettxs.h"
 
 #include "init.h"
 #include "sync.h"

--- a/src/omnicore/walletcache.cpp
+++ b/src/omnicore/walletcache.cpp
@@ -1,4 +1,10 @@
-// Provides a cache of wallet balances and functionality for determining whether Omni state changes affected anything in the wallet
+/**
+ * @file walletcache.cpp
+ *
+ * Provides a cache of wallet balances and functionality for determining whether
+ * Omni state changes affected anything in the wallet.
+ */
+
 #include "omnicore/walletcache.h"
 
 #include "omnicore/log.h"
@@ -9,7 +15,9 @@
 #include "init.h"
 #include "sync.h"
 #include "uint256.h"
+#ifdef ENABLE_WALLET
 #include "wallet.h"
+#endif
 
 #include <stdint.h>
 #include <algorithm>
@@ -20,8 +28,8 @@
 #include <utility>
 #include <vector>
 
-using namespace mastercore;
-
+namespace mastercore
+{
 //! Global vector of Omni transactions in the wallet
 std::vector<uint256> walletTXIDCache;
 
@@ -29,7 +37,7 @@ std::vector<uint256> walletTXIDCache;
 static std::map<std::string, CMPTally> walletBalancesCache;
 
 /**
- * Adds a txid to the wallet txid cache, performing duplicate detection
+ * Adds a txid to the wallet txid cache, performing duplicate detection.
  */
 void WalletTXIDCacheAdd(const uint256& hash)
 {
@@ -42,12 +50,12 @@ void WalletTXIDCacheAdd(const uint256& hash)
 }
 
 /**
- * Performs initial population of the wallet txid cache
+ * Performs initial population of the wallet txid cache.
  */
 void WalletTXIDCacheInit()
 {
     if (msc_debug_walletcache) PrintToLog("WALLETTXIDCACHE: WalletTXIDCacheInit requested\n");
-
+#ifdef ENABLE_WALLET
     LOCK2(cs_tally, pwalletMain->cs_wallet);
 
     std::list<CAccountingEntry> acentries;
@@ -55,8 +63,8 @@ void WalletTXIDCacheInit()
 
     // Iterate through the wallet, checking if each transaction is Omni (via levelDB)
     for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it) {
-        CWalletTx *const pwtx = (*it).second.first;
-        if (pwtx != 0) {
+        const CWalletTx* pwtx = it->second.first;
+        if (pwtx != NULL) {
             // get the hash of the transaction and check leveldb to see if this is an Omni tx, if so add to cache
             const uint256& hash = pwtx->GetHash();
             if (p_txlistdb->exists(hash)) {
@@ -65,11 +73,13 @@ void WalletTXIDCacheInit()
             }
         }
     }
+#endif
 }
 
 /**
- * Updates the cache with the latest state, returning true if changes were made to wallet addresses (including watch only)
- * Also prepares a list of addresses that were changed (for future usage)
+ * Updates the cache with the latest state, returning true if changes were made to wallet addresses (including watch only).
+ *
+ * Also prepares a list of addresses that were changed (for future usage).
  */
 int WalletCacheUpdate()
 {
@@ -125,3 +135,5 @@ int WalletCacheUpdate()
     return numChanges;
 }
 
+
+} // namespace mastercore

--- a/src/omnicore/walletcache.h
+++ b/src/omnicore/walletcache.h
@@ -5,6 +5,8 @@ class uint256;
 
 #include <vector>
 
+namespace mastercore
+{
 //! Global vector of Omni transactions in the wallet
 extern std::vector<uint256> walletTXIDCache;
 
@@ -16,6 +18,6 @@ void WalletTXIDCacheInit();
 
 /** Updates the cache and returns whether any wallet addresses were changed */
 int WalletCacheUpdate();
-
+}
 
 #endif // OMNICORE_WALLETCACHE_H

--- a/src/omnicore/wallettxs.cpp
+++ b/src/omnicore/wallettxs.cpp
@@ -106,6 +106,26 @@ bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest)
 }
 
 /**
+ * Retrieves the label, used by the UI, for an address from the wallet.
+ */
+std::string GetAddressLabel(const std::string& address)
+{
+    std::string addressLabel;
+#ifdef ENABLE_WALLET
+    if (pwalletMain) {
+        LOCK(pwalletMain->cs_wallet);
+
+        CBitcoinAddress addressParsed(address);
+        std::map<CTxDestination, CAddressBookData>::const_iterator mi = pwalletMain->mapAddressBook.find(addressParsed.Get());
+        if (mi != pwalletMain->mapAddressBook.end()) {
+            addressLabel = mi->second.name;
+        }
+    }
+#endif
+    return addressLabel;
+}
+
+/**
  * Selects spendable outputs to create a transaction.
  */
 int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional)

--- a/src/omnicore/wallettxs.cpp
+++ b/src/omnicore/wallettxs.cpp
@@ -59,6 +59,33 @@ bool AddressToPubKey(const std::string& key, CPubKey& pubKey)
 }
 
 /**
+ * Checks, whether enough spendable outputs are available to pay for transaction fees.
+ */
+bool CheckFee(const std::string& fromAddress, size_t nDataSize)
+{
+    int64_t minFee = 0;
+    int64_t inputTotal = 0;
+#ifdef ENABLE_WALLET
+    bool fUseClassC = UseEncodingClassC(nDataSize);
+
+    CCoinControl coinControl;
+    inputTotal = SelectCoins(fromAddress, coinControl, 0);
+
+    // TODO: THIS NEEDS WORK - CALCULATIONS ARE UNSUITABLE CURRENTLY
+    if (fUseClassC) {
+        // estimated minimum fee calculation for Class C with payload of nDataSize
+        // minFee = 3 * minRelayTxFee.GetFee(200) + CWallet::minTxFee.GetFee(200000);
+        minFee = 10000; // simply warn when below 10,000 satoshi for now
+    } else {
+        // estimated minimum fee calculation for Class B with payload of nDataSize
+        // minFee = 3 * minRelayTxFee.GetFee(200) + CWallet::minTxFee.GetFee(200000);
+        minFee = 10000; // simply warn when below 10,000 satoshi for now
+    }
+#endif
+    return inputTotal >= minFee;
+}
+
+/**
  * Checks, whether the output qualifies as input for a transaction.
  */
 bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest)

--- a/src/omnicore/wallettxs.cpp
+++ b/src/omnicore/wallettxs.cpp
@@ -1,0 +1,114 @@
+#include "omnicore/wallettxs.h"
+
+#include "omnicore/log.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/rules.h"
+#include "omnicore/script.h"
+#include "omnicore/utilsbitcoin.h"
+
+#include "amount.h"
+#include "base58.h"
+#include "coincontrol.h"
+#include "init.h"
+#include "main.h"
+#include "script/standard.h"
+#include "sync.h"
+#include "uint256.h"
+#include "wallet.h"
+
+#include <stdint.h>
+#include <map>
+#include <string>
+
+namespace mastercore
+{
+/**
+ * Checks, whether the output qualifies as input for a transaction.
+ */
+bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest)
+{
+    txnouttype whichType;
+
+    if (!GetOutputType(txOut.scriptPubKey, whichType)) {
+        return false;
+    }
+    if (!IsAllowedInputType(whichType, nHeight)) {
+        return false;
+    }
+    if (!ExtractDestination(txOut.scriptPubKey, dest)) {
+        return false;
+    }
+
+    return true;
+}
+/**
+ * Selects spendable outputs to create a transaction.
+ */
+int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional)
+{
+    // total output funds collected
+    int64_t nTotal = 0;
+
+#ifdef ENABLE_WALLET
+    if (NULL == pwalletMain) {
+        return 0;
+    }
+
+    // assume 20 KB max. transaction size at 0.0001 per kilobyte
+    int64_t nMax = (COIN * (20 * (0.0001)));
+
+    // if referenceamount is set it is needed to be accounted for here too
+    if (0 < additional) nMax += additional;
+
+    int nHeight = GetHeight();
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    // iterate over the wallet
+    for (std::map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
+        const uint256& txid = it->first;
+        const CWalletTx& wtx = it->second;
+
+        if (!wtx.IsTrusted()) {
+            continue;
+        }
+        if (!wtx.GetAvailableCredit()) {
+            continue;
+        }
+
+        for (unsigned int n = 0; n < wtx.vout.size(); n++) {
+            const CTxOut& txOut = wtx.vout[n];
+
+            CTxDestination dest;
+            if (!CheckInput(txOut, nHeight, dest)) {
+                continue;
+            }
+            if (!IsMine(*pwalletMain, dest)) {
+                continue;
+            }
+            if (pwalletMain->IsSpent(txid, n)) {
+                continue;
+            }
+
+            std::string sAddress = CBitcoinAddress(dest).ToString();
+            if (msc_debug_tokens)
+                PrintToLog("%s(): sender: %s, outpoint: %s:%d, value: %d\n", __func__, sAddress, txid.GetHex(), n, txOut.nValue);
+
+            // only use funds from the sender's address
+            if (fromAddress == sAddress) {
+                COutPoint outpoint(txid, n);
+                coinControl.Select(outpoint);
+
+                nTotal += txOut.nValue;
+                if (nMax <= nTotal) break;
+            }
+        }
+
+        if (nMax <= nTotal) break;
+    }
+#endif
+
+    return nTotal;
+}
+
+
+} // namespace mastercore

--- a/src/omnicore/wallettxs.cpp
+++ b/src/omnicore/wallettxs.cpp
@@ -16,7 +16,10 @@
 #include "sync.h"
 #include "uint256.h"
 #include "utilstrencodings.h"
+#ifdef ENABLE_WALLET
 #include "wallet.h"
+#include "wallet_ismine.h"
+#endif
 
 #include <stdint.h>
 #include <map>
@@ -123,6 +126,24 @@ std::string GetAddressLabel(const std::string& address)
     }
 #endif
     return addressLabel;
+}
+
+/**
+ * IsMine wrapper to determine whether the address is in the wallet.
+ */
+int IsMyAddress(const std::string& address)
+{
+#ifdef ENABLE_WALLET
+    if (pwalletMain) {
+        // TODO: resolve deadlock caused cs_tally, cs_wallet
+        // LOCK(pwalletMain->cs_wallet);
+        CBitcoinAddress parsedAddress(address);
+        isminetype isMine = IsMine(*pwalletMain, parsedAddress.Get());
+
+        return static_cast<int>(isMine);
+    }
+#endif
+    return 0;
 }
 
 /**

--- a/src/omnicore/wallettxs.h
+++ b/src/omnicore/wallettxs.h
@@ -20,6 +20,9 @@ bool CheckFee(const std::string& fromAddress, size_t nDataSize);
 /** Checks, whether the output qualifies as input for a transaction. */
 bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest);
 
+/** Retrieves the label, used by the UI, for an address from the wallet. */
+std::string GetAddressLabel(const std::string& address);
+
 /** Selects spendable outputs to create a transaction. */
 int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional = 0);
 }

--- a/src/omnicore/wallettxs.h
+++ b/src/omnicore/wallettxs.h
@@ -1,0 +1,20 @@
+#ifndef OMNICORE_WALLETTXS_H
+#define OMNICORE_WALLETTXS_H
+
+class CCoinControl;
+
+#include "script/standard.h"
+
+#include <stdint.h>
+#include <string>
+
+namespace mastercore
+{
+/** Checks, whether the output qualifies as input for a transaction. */
+bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest);
+
+/** Selects spendable outputs to create a transaction. */
+int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional = 0);
+}
+
+#endif // OMNICORE_WALLETTXS_H

--- a/src/omnicore/wallettxs.h
+++ b/src/omnicore/wallettxs.h
@@ -14,6 +14,9 @@ namespace mastercore
 /** Retrieves a public key from the wallet, or converts a hex-string to a public key. */
 bool AddressToPubKey(const std::string& key, CPubKey& pubKey);
 
+/** Checks, whether enough spendable outputs are available to pay for transaction fees. */
+bool CheckFee(const std::string& fromAddress, size_t nDataSize);
+
 /** Checks, whether the output qualifies as input for a transaction. */
 bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest);
 

--- a/src/omnicore/wallettxs.h
+++ b/src/omnicore/wallettxs.h
@@ -23,6 +23,9 @@ bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest);
 /** Retrieves the label, used by the UI, for an address from the wallet. */
 std::string GetAddressLabel(const std::string& address);
 
+/** IsMine wrapper to determine whether the address is in the wallet. */
+int IsMyAddress(const std::string& address);
+
 /** Selects spendable outputs to create a transaction. */
 int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional = 0);
 }

--- a/src/omnicore/wallettxs.h
+++ b/src/omnicore/wallettxs.h
@@ -2,6 +2,7 @@
 #define OMNICORE_WALLETTXS_H
 
 class CCoinControl;
+class CPubKey;
 
 #include "script/standard.h"
 
@@ -10,6 +11,9 @@ class CCoinControl;
 
 namespace mastercore
 {
+/** Retrieves a public key from the wallet, or converts a hex-string to a public key. */
+bool AddressToPubKey(const std::string& key, CPubKey& pubKey);
+
 /** Checks, whether the output qualifies as input for a transaction. */
 bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest);
 

--- a/src/qt/balancesdialog.cpp
+++ b/src/qt/balancesdialog.cpp
@@ -10,6 +10,7 @@
 #include "omnicore/omnicore.h"
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
+#include "omnicore/wallettxs.h"
 
 #include "amount.h"
 #include "sync.h"
@@ -244,9 +245,9 @@ void BalancesDialog::PopulateBalances(unsigned int propertyId)
 
             // add the row
             if (!watchAddress) {
-                AddRow(getLabel(my_it->first), address, reservedStr, availableStr);
+                AddRow(GetAddressLabel(my_it->first), address, reservedStr, availableStr);
             } else {
-                AddRow(getLabel(my_it->first), address + " (watch-only)", reservedStr, availableStr);
+                AddRow(GetAddressLabel(my_it->first), address + " (watch-only)", reservedStr, availableStr);
             }
         }
     }

--- a/src/qt/lookupaddressdialog.cpp
+++ b/src/qt/lookupaddressdialog.cpp
@@ -9,6 +9,7 @@
 
 #include "omnicore/omnicore.h"
 #include "omnicore/sp.h"
+#include "omnicore/wallettxs.h"
 
 #include "base58.h"
 

--- a/src/qt/metadexcanceldialog.cpp
+++ b/src/qt/metadexcanceldialog.cpp
@@ -18,6 +18,7 @@
 #include "omnicore/sp.h"
 #include "omnicore/pending.h"
 #include "omnicore/utilsbitcoin.h"
+#include "omnicore/wallettxs.h"
 
 #include <stdint.h>
 #include <map>

--- a/src/qt/metadexdialog.cpp
+++ b/src/qt/metadexdialog.cpp
@@ -20,6 +20,7 @@
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
 #include "omnicore/utilsbitcoin.h"
+#include "omnicore/wallettxs.h"
 
 #include "amount.h"
 #include "sync.h"
@@ -407,7 +408,7 @@ void MetaDExDialog::UpdateSellAddressBalance()
         if (isPropertyDivisible(propertyId)) { sellBalStr = FormatDivisibleMP(balanceAvailable); } else { sellBalStr = FormatIndivisibleMP(balanceAvailable); }
         ui->yourSellBalanceLabel->setText(QString::fromStdString("Your balance: " + sellBalStr + " SPT"));
         // warning label will be lit if insufficient fees for MetaDEx payload (28 bytes)
-        if (feeCheck(currentSetSellAddress.toStdString(), 28)) {
+        if (CheckFee(currentSetSellAddress.toStdString(), 28)) {
             ui->sellAddressFeeWarningLabel->setVisible(false);
         } else {
             ui->sellAddressFeeWarningLabel->setText("WARNING: The address is low on BTC for transaction fees.");
@@ -429,7 +430,7 @@ void MetaDExDialog::UpdateBuyAddressBalance()
         int64_t balanceAvailable = getUserAvailableMPbalance(currentSetBuyAddress.toStdString(), propertyId);
         ui->yourBuyBalanceLabel->setText(QString::fromStdString("Your balance: " + FormatDivisibleMP(balanceAvailable) + getTokenLabel(propertyId)));
         // warning label will be lit if insufficient fees for MetaDEx payload (28 bytes)
-        if (feeCheck(currentSetBuyAddress.toStdString(), 28)) {
+        if (CheckFee(currentSetBuyAddress.toStdString(), 28)) {
             ui->buyAddressFeeWarningLabel->setVisible(false);
         } else {
             ui->buyAddressFeeWarningLabel->setText("WARNING: The address is low on BTC for transaction fees.");

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -20,6 +20,7 @@
 #include "omnicore/tx.h"
 #include "omnicore/pending.h"
 #include "omnicore/utilsbitcoin.h"
+#include "omnicore/wallettxs.h"
 
 #include "main.h"
 #include "sync.h"

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -97,12 +97,12 @@ void SendMPDialog::setWalletModel(WalletModel *model)
 
 void SendMPDialog::updatePropSelector()
 {
+    LOCK(cs_tally);
+
     uint32_t nextPropIdMainEco = GetNextPropertyId(true);  // these allow us to end the for loop at the highest existing
     uint32_t nextPropIdTestEco = GetNextPropertyId(false); // property ID rather than a fixed value like 100000 (optimization)
     QString spId = ui->propertyComboBox->itemData(ui->propertyComboBox->currentIndex()).toString();
     ui->propertyComboBox->clear();
-
-    LOCK(cs_tally);
 
     for (unsigned int propertyId = 1; propertyId < nextPropIdMainEco; propertyId++) {
         if ((global_balance_money[propertyId] > 0) || (global_balance_reserved[propertyId] > 0)) {

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -18,6 +18,7 @@
 #include "omnicore/sp.h"
 #include "omnicore/tally.h"
 #include "omnicore/utilsbitcoin.h"
+#include "omnicore/wallettxs.h"
 
 #include "amount.h"
 #include "base58.h"
@@ -157,7 +158,7 @@ void SendMPDialog::updateFrom()
             ui->balanceLabel->setText(QString::fromStdString("Address Balance: " + FormatMP(propertyId, getUserAvailableMPbalance(currentSetFromAddress, propertyId)) + getTokenLabel(propertyId)));
         }
         // warning label will be lit if insufficient fees for simple send (16 byte payload)
-        if (feeCheck(currentSetFromAddress, 16)) {
+        if (CheckFee(currentSetFromAddress, 16)) {
             ui->feeWarningLabel->setVisible(false);
         } else {
             ui->feeWarningLabel->setText("WARNING: The sending address is low on BTC for transaction fees. Please topup the BTC balance for the sending address to send Omni Layer transactions.");

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -25,7 +25,7 @@
 #include "main.h"
 #include "sync.h"
 #include "uint256.h"
-#include "wallet.h"
+#include "wallet_ismine.h"
 
 #include <stdint.h>
 #include <map>

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -161,7 +161,7 @@ void TradeHistoryDialog::UpdateTradeHistoryTable(bool forceUpdate)
     if (forceUpdate || newTXCount > 0) {
         ui->tradeHistoryTable->setSortingEnabled(false); // disable sorting while we update the table
         QAbstractItemModel* tradeHistoryAbstractModel = ui->tradeHistoryTable->model();
-        int chainHeight = chainActive.Height();
+        int chainHeight = GetHeight();
 
         // Loop through tradeHistoryMap and search tradeHistoryTable for the transaction, adding it if not already there
         for (TradeHistoryMap::iterator it = tradeHistoryMap.begin(); it != tradeHistoryMap.end(); ++it) {
@@ -247,12 +247,11 @@ void TradeHistoryDialog::UpdateTradeHistoryTable(bool forceUpdate)
 // Used to cache trades so we don't need to reparse all our transactions on every update
 int TradeHistoryDialog::PopulateTradeHistoryMap()
 {
-    // Attempt to obtain locks
-    CWallet *wallet = pwalletMain;
-    if (NULL == wallet) return -1;
+    // TODO: locks may not be needed here -- looks like wallet lock can be removed
+    if (NULL == pwalletMain) return -1;
     TRY_LOCK(cs_main,lckMain);
     if (!lckMain) return -1;
-    TRY_LOCK(wallet->cs_wallet, lckWallet);
+    TRY_LOCK(pwalletMain->cs_wallet, lckWallet);
     if (!lckWallet) return -1;
 
     int64_t nProcessed = 0; // number of new entries, forms return code

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -181,12 +181,12 @@ void TXHistoryDialog::setWalletModel(WalletModel *model)
 
 int TXHistoryDialog::PopulateHistoryMap()
 {
-    CWallet *wallet = pwalletMain;
-    if (NULL == wallet) return 0;
+    // TODO: locks may not be needed here -- looks like wallet lock can be removed
+    if (NULL == pwalletMain) return 0;
     // try and fix intermittent freeze on startup and while running by only updating if we can get required locks
     TRY_LOCK(cs_main,lckMain);
     if (!lckMain) return 0;
-    TRY_LOCK(wallet->cs_wallet, lckWallet);
+    TRY_LOCK(pwalletMain->cs_wallet, lckWallet);
     if (!lckWallet) return 0;
 
     int64_t nProcessed = 0; // counter for how many transactions we've added to history this time
@@ -195,7 +195,6 @@ int TXHistoryDialog::PopulateHistoryMap()
     std::map<std::string,uint256> walletTransactions = FetchWalletOmniTransactions(GetArg("-omniuiwalletscope", 1000));
 
     // reverse iterate over (now ordered) transactions and populate history map for each one
-    Array response;
     for (std::map<std::string,uint256>::reverse_iterator it = walletTransactions.rbegin(); it != walletTransactions.rend(); it++) {
         uint256 txHash = it->second;
 
@@ -227,7 +226,6 @@ int TXHistoryDialog::PopulateHistoryMap()
         uint256 blockHash = 0;
         if (!GetTransaction(txHash, wtx, blockHash, true)) continue;
         if ((0 == blockHash) || (NULL == GetBlockIndex(blockHash))) {
-
             // this transaction is unconfirmed, should be one of our pending transactions
             LOCK(cs_pending);
             PendingMap::iterator pending_it = my_pending.find(txHash);
@@ -269,12 +267,15 @@ int TXHistoryDialog::PopulateHistoryMap()
             uint64_t tmpPropertyId = 0;
             bool bIsBuy = false;
             int numberOfPurchases = 0;
-            LOCK(cs_tally);
-            p_txlistdb->getPurchaseDetails(txHash, 1, &tmpBuyer, &tmpSeller, &tmpVout, &tmpPropertyId, &tmpNValue);
+            {
+                LOCK(cs_tally);
+                p_txlistdb->getPurchaseDetails(txHash, 1, &tmpBuyer, &tmpSeller, &tmpVout, &tmpPropertyId, &tmpNValue);
+            }
             bIsBuy = IsMyAddress(tmpBuyer);
             numberOfPurchases = p_txlistdb->getNumberOfPurchases(txHash);
             if (0 >= numberOfPurchases) continue;
             for (int purchaseNumber = 1; purchaseNumber <= numberOfPurchases; purchaseNumber++) {
+                LOCK(cs_tally);
                 p_txlistdb->getPurchaseDetails(txHash, purchaseNumber, &tmpBuyer, &tmpSeller, &tmpVout, &tmpPropertyId, &tmpNValue);
                 total += tmpNValue;
             }
@@ -340,7 +341,7 @@ int TXHistoryDialog::PopulateHistoryMap()
 
 void TXHistoryDialog::UpdateConfirmations()
 {
-    int chainHeight = chainActive.Height(); // get the chain height
+    int chainHeight = GetHeight(); // get the chain height
     int rowCount = ui->txHistoryTable->rowCount();
     for (int row = 0; row < rowCount; row++) {
         int confirmations = 0;
@@ -400,6 +401,7 @@ void TXHistoryDialog::UpdateHistory()
                 QDateTime txTime;
                 QTableWidgetItem *dateCell = new QTableWidgetItem;
                 if (htxo.blockHeight>0) {
+                    LOCK(cs_main);
                     CBlockIndex* pBlkIdx = chainActive[htxo.blockHeight];
                     if (NULL != pBlkIdx) txTime.setTime_t(pBlkIdx->GetBlockTime());
                     dateCell->setData(Qt::DisplayRole, txTime);

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -20,6 +20,7 @@
 #include "omnicore/tx.h"
 #include "omnicore/utilsbitcoin.h"
 #include "omnicore/walletcache.h"
+#include "omnicore/wallettxs.h"
 
 #include "init.h"
 #include "main.h"

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -356,7 +356,6 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_getallbalancesforid",        &omni_getallbalancesforid,        false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getbalance",                 &omni_getbalance,                 false,      true,       false },
     { "omni layer (data retrieval)",         "omni_gettransaction",             &omni_gettransaction,             false,      true,       false },
-    { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
     { "omni layer (data retrieval)",         "omni_getproperty",                &omni_getproperty,                false,      true,       false },
     { "omni layer (data retrieval)",         "omni_listproperties",             &omni_listproperties,             false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getcrowdsale",               &omni_getcrowdsale,               false,      true,       false },
@@ -371,6 +370,8 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_gettradehistoryforaddress",  &omni_gettradehistoryforaddress,  false,      true,       false },
     { "omni layer (data retrieval)",         "omni_gettradehistoryforpair",     &omni_gettradehistoryforpair,     false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getcurrentconsensushash",    &omni_getcurrentconsensushash,    false,      true,       false },
+#ifdef ENABLE_WALLET
+    { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
 
     /* Omni Core configuration calls */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
@@ -397,32 +398,35 @@ static const CRPCCommand vRPCCommands[] =
 
     /* Omni Core hidden calls - development usage (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
-    { "hidden",                              "mscrpc",                          &mscrpc,                          true,       true,       false },
     { "hidden",                              "omni_sendactivation",             &omni_sendactivation,             false,      true,       true },
     { "hidden",                              "omni_sendalert",                  &omni_sendalert,                  true,       true,       true },
+#endif
+    { "hidden",                              "mscrpc",                          &mscrpc,                          true,       true,       false },
 
     /* Omni Core hidden calls - aliased calls for backwards compatibiltiy - to be depreciated (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
-    { "hidden",                              "trade_MP",                        &trade_MP,                        false,      true,       true }, // depreciated - to be removed? we haven't released with this call
     { "hidden",                              "getinfo_MP",                      &omni_getinfo,                    true,       true,       false },
-    { "hidden",                              "getallbalancesforid_MP",          &omni_getallbalancesforid,        false,      true,       false },
     { "hidden",                              "getbalance_MP",                   &omni_getbalance,                 false,      true,       false },
-    { "hidden",                              "send_MP",                         &omni_send,                       false,      true,       true },
-    { "hidden",                              "gettransaction_MP",               &omni_gettransaction,             false,      true,       false },
-    { "hidden",                              "listtransactions_MP",             &omni_listtransactions,           false,      true,       true },
+    { "hidden",                              "getallbalancesforaddress_MP",     &omni_getallbalancesforaddress,   false,      true,       false },
+    { "hidden",                              "getallbalancesforid_MP",          &omni_getallbalancesforid,        false,      true,       false },
     { "hidden",                              "getproperty_MP",                  &omni_getproperty,                false,      true,       false },
     { "hidden",                              "listproperties_MP",               &omni_listproperties,             false,      true,       false },
     { "hidden",                              "getcrowdsale_MP",                 &omni_getcrowdsale,               false,      true,       false },
     { "hidden",                              "getgrants_MP",                    &omni_getgrants,                  false,      true,       false },
     { "hidden",                              "getactivedexsells_MP",            &omni_getactivedexsells,          false,      true,       false },
     { "hidden",                              "getactivecrowdsales_MP",          &omni_getactivecrowdsales,        false,      true,       false },
-    { "hidden",                              "getorderbook_MP",                 &omni_getorderbook,               false,      true,       false },
-    { "hidden",                              "sendtoowners_MP",                 &omni_sendsto,                    false,      true,       true },
-    { "hidden",                              "sendrawtx_MP",                    &omni_sendrawtx,                  false,      true,       true },
     { "hidden",                              "getsto_MP",                       &omni_getsto,                     false,      true,       false },
+    { "hidden",                              "getorderbook_MP",                 &omni_getorderbook,               false,      true,       false },
     { "hidden",                              "gettrade_MP",                     &omni_gettrade,                   false,      true,       false },
+    { "hidden",                              "gettransaction_MP",               &omni_gettransaction,             false,      true,       false },
     { "hidden",                              "listblocktransactions_MP",        &omni_listblocktransactions,      false,      true,       false },
-    { "hidden",                              "getallbalancesforaddress_MP",     &omni_getallbalancesforaddress,   false,      true,       false },
+#ifdef ENABLE_WALLET
+    { "hidden",                              "listtransactions_MP",             &omni_listtransactions,           false,      true,       true },
+    { "hidden",                              "sendrawtx_MP",                    &omni_sendrawtx,                  false,      true,       true },
+    { "hidden",                              "send_MP",                         &omni_send,                       false,      true,       true },
+    { "hidden",                              "sendtoowners_MP",                 &omni_sendsto,                    false,      true,       true },
+    { "hidden",                              "trade_MP",                        &trade_MP,                        false,      true,       true }, // depreciated - to be removed? we haven't released with this call
+#endif
 };
 
 CRPCTable::CRPCTable()

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -350,27 +350,26 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "walletpassphrase",       &walletpassphrase,       true,      false,      true },
 #endif // ENABLE_WALLET
 
-#ifdef ENABLE_WALLET
     /* Omni Core data retrieval calls */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
-    { "omni layer (data retrieval)",         "omni_getinfo",                    &omni_getinfo,                    true,       true,       true },
-    { "omni layer (data retrieval)",         "omni_getallbalancesforid",        &omni_getallbalancesforid,        false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getbalance",                 &omni_getbalance,                 false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_gettransaction",             &omni_gettransaction,             false,      true,       true },
+    { "omni layer (data retrieval)",         "omni_getinfo",                    &omni_getinfo,                    true,       true,       false },
+    { "omni layer (data retrieval)",         "omni_getallbalancesforid",        &omni_getallbalancesforid,        false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getbalance",                 &omni_getbalance,                 false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_gettransaction",             &omni_gettransaction,             false,      true,       false },
     { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getproperty",                &omni_getproperty,                false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_listproperties",             &omni_listproperties,             false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getcrowdsale",               &omni_getcrowdsale,               false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getgrants",                  &omni_getgrants,                  false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getactivedexsells",          &omni_getactivedexsells,          false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getactivecrowdsales",        &omni_getactivecrowdsales,        false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getorderbook",               &omni_getorderbook,               false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_gettrade",                   &omni_gettrade,                   false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getsto",                     &omni_getsto,                     false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_listblocktransactions",      &omni_listblocktransactions,      false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_getallbalancesforaddress",   &omni_getallbalancesforaddress,   false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_gettradehistoryforaddress",  &omni_gettradehistoryforaddress,  false,      true,       true },
-    { "omni layer (data retrieval)",         "omni_gettradehistoryforpair",     &omni_gettradehistoryforpair,     false,      true,       true },
+    { "omni layer (data retrieval)",         "omni_getproperty",                &omni_getproperty,                false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_listproperties",             &omni_listproperties,             false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getcrowdsale",               &omni_getcrowdsale,               false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getgrants",                  &omni_getgrants,                  false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getactivedexsells",          &omni_getactivedexsells,          false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getactivecrowdsales",        &omni_getactivecrowdsales,        false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getorderbook",               &omni_getorderbook,               false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_gettrade",                   &omni_gettrade,                   false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getsto",                     &omni_getsto,                     false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_listblocktransactions",      &omni_listblocktransactions,      false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getallbalancesforaddress",   &omni_getallbalancesforaddress,   false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_gettradehistoryforaddress",  &omni_gettradehistoryforaddress,  false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_gettradehistoryforpair",     &omni_gettradehistoryforpair,     false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getcurrentconsensushash",    &omni_getcurrentconsensushash,    false,      true,       false },
 
     /* Omni Core configuration calls */
@@ -398,33 +397,32 @@ static const CRPCCommand vRPCCommands[] =
 
     /* Omni Core hidden calls - development usage (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
-    { "hidden",                              "mscrpc",                          &mscrpc,                          true,       true,       true },
+    { "hidden",                              "mscrpc",                          &mscrpc,                          true,       true,       false },
     { "hidden",                              "omni_sendactivation",             &omni_sendactivation,             false,      true,       true },
     { "hidden",                              "omni_sendalert",                  &omni_sendalert,                  true,       true,       true },
 
     /* Omni Core hidden calls - aliased calls for backwards compatibiltiy - to be depreciated (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
     { "hidden",                              "trade_MP",                        &trade_MP,                        false,      true,       true }, // depreciated - to be removed? we haven't released with this call
-    { "hidden",                              "getinfo_MP",                      &omni_getinfo,                    true,       true,       true },
-    { "hidden",                              "getallbalancesforid_MP",          &omni_getallbalancesforid,        false,      true,       true },
-    { "hidden",                              "getbalance_MP",                   &omni_getbalance,                 false,      true,       true },
+    { "hidden",                              "getinfo_MP",                      &omni_getinfo,                    true,       true,       false },
+    { "hidden",                              "getallbalancesforid_MP",          &omni_getallbalancesforid,        false,      true,       false },
+    { "hidden",                              "getbalance_MP",                   &omni_getbalance,                 false,      true,       false },
     { "hidden",                              "send_MP",                         &omni_send,                       false,      true,       true },
-    { "hidden",                              "gettransaction_MP",               &omni_gettransaction,             false,      true,       true },
+    { "hidden",                              "gettransaction_MP",               &omni_gettransaction,             false,      true,       false },
     { "hidden",                              "listtransactions_MP",             &omni_listtransactions,           false,      true,       true },
-    { "hidden",                              "getproperty_MP",                  &omni_getproperty,                false,      true,       true },
-    { "hidden",                              "listproperties_MP",               &omni_listproperties,             false,      true,       true },
-    { "hidden",                              "getcrowdsale_MP",                 &omni_getcrowdsale,               false,      true,       true },
-    { "hidden",                              "getgrants_MP",                    &omni_getgrants,                  false,      true,       true },
-    { "hidden",                              "getactivedexsells_MP",            &omni_getactivedexsells,          false,      true,       true },
-    { "hidden",                              "getactivecrowdsales_MP",          &omni_getactivecrowdsales,        false,      true,       true },
-    { "hidden",                              "getorderbook_MP",                 &omni_getorderbook,               false,      true,       true },
+    { "hidden",                              "getproperty_MP",                  &omni_getproperty,                false,      true,       false },
+    { "hidden",                              "listproperties_MP",               &omni_listproperties,             false,      true,       false },
+    { "hidden",                              "getcrowdsale_MP",                 &omni_getcrowdsale,               false,      true,       false },
+    { "hidden",                              "getgrants_MP",                    &omni_getgrants,                  false,      true,       false },
+    { "hidden",                              "getactivedexsells_MP",            &omni_getactivedexsells,          false,      true,       false },
+    { "hidden",                              "getactivecrowdsales_MP",          &omni_getactivecrowdsales,        false,      true,       false },
+    { "hidden",                              "getorderbook_MP",                 &omni_getorderbook,               false,      true,       false },
     { "hidden",                              "sendtoowners_MP",                 &omni_sendsto,                    false,      true,       true },
     { "hidden",                              "sendrawtx_MP",                    &omni_sendrawtx,                  false,      true,       true },
-    { "hidden",                              "getsto_MP",                       &omni_getsto,                     false,      true,       true },
-    { "hidden",                              "gettrade_MP",                     &omni_gettrade,                   false,      true,       true },
-    { "hidden",                              "listblocktransactions_MP",        &omni_listblocktransactions,      false,      true,       true },
-    { "hidden",                              "getallbalancesforaddress_MP",     &omni_getallbalancesforaddress,   false,      true,       true },
-#endif // ENABLE_WALLET [required by Omni Core for now]
+    { "hidden",                              "getsto_MP",                       &omni_getsto,                     false,      true,       false },
+    { "hidden",                              "gettrade_MP",                     &omni_gettrade,                   false,      true,       false },
+    { "hidden",                              "listblocktransactions_MP",        &omni_listblocktransactions,      false,      true,       false },
+    { "hidden",                              "getallbalancesforaddress_MP",     &omni_getallbalancesforaddress,   false,      true,       false },
 };
 
 CRPCTable::CRPCTable()


### PR DESCRIPTION
Nearly all interactions with the wallet were moved into `wallettxs.cpp`.

A few helpers were added, and a few functions renamed:

- AddressToPubKey()
- CheckFee()
- CheckInput() *(might as well be placed somewhere else)*
- GetAddressLabel()
- IsMyAddress()
- SelectCoins()

Furthermore, all parts which access the wallet, and are not exclusively build with enabled wallet (such as the send dialogs), are wrapped with `#ifdef ENABLE_WALLET`.

Besides an arguably better organization and structure, a nice side effect is that builds without wallet (`./configure --disable-wallet`) are supported and work very well, which resolves #62.