### PR TITLE
Don't spam log about non-sequential seqence numbers

### DIFF
--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -33,7 +33,8 @@ bool msc_debug_script             = 0;
 bool msc_debug_dex                = 1;
 bool msc_debug_send               = 1;
 bool msc_debug_tokens             = 0;
-bool msc_debug_spec               = 1;
+//! Print information about payloads with non-sequential sequence number
+bool msc_debug_spec               = 0;
 bool msc_debug_exo                = 0;
 bool msc_debug_tally              = 1;
 bool msc_debug_sp                 = 1;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -507,7 +507,7 @@ int TXExodusFundraiser(const CTransaction& tx, const std::string& sender, int64_
         }
 
         int64_t amountGenerated = round(params.exodusReward * amountInvested * bonus);
-        if (msc_debug_exo) PrintToLog("Exodus Fundraiser tx detected, tx %s generated %s\n", tx.GetHash().ToString(), FormatDivisibleMP(amountGenerated));
+        PrintToLog("Exodus Fundraiser tx detected, tx %s generated %s\n", tx.GetHash().ToString(), FormatDivisibleMP(amountGenerated));
 
         // TODO: return result, grant somewhere else
         update_tally_map(sender, OMNI_PROPERTY_MSC, amountGenerated, BALANCE);


### PR DESCRIPTION
The message:

> Error: non-sequential seqnum ! expected=2, got=1

It is very misleading, and serves at best for very low level debug purposes. It was enabled by default, but is now disabled.

Furthermore Exodus purchases are logged, even without explicit Exodus debug logging.