### PR TITLE
Prepare deactivation of "grant tokens" side effects

### DIFF
--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -23,20 +23,6 @@
 
 namespace mastercore
 {
-/** Features, activated by message
- */
-enum FeatureId
-{
-    //! Feature identifier to enable Class C transaction parsing and processing
-    OMNICORE_FEATURE_CLASS_C = 1,
-    //! Feature identifier to enable the distributed token exchange
-    OMNICORE_FEATURE_METADEX = 2,
-    //! Feature identifier to enable betting transactions
-    OMNICORE_FEATURE_BETTING = 3,
-    //! Feature identifier to disable crowdsale participations when "granting tokens"
-    OMNICORE_FEATURE_GRANTEFFECTS = 4
-};
-
 /**
  * Returns a mapping of transaction types, and the blocks at which they are enabled.
  */
@@ -337,25 +323,25 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, int transactionBlo
 
     // check feature is recognized and activation is successful
     switch (featureId) {
-        case OMNICORE_FEATURE_CLASS_C:
+        case FEATURE_CLASS_C:
             MutableConsensusParams().NULLDATA_BLOCK = activationBlock;
             PrintToLog("Feature activation of ID %d succeeded. "
                        "Class C transaction encoding is going to be enabled at block %d.\n",
                        featureId, params.NULLDATA_BLOCK);
             return true;
-        case OMNICORE_FEATURE_METADEX:
+        case FEATURE_METADEX:
             MutableConsensusParams().MSC_METADEX_BLOCK = activationBlock;
             PrintToLog("Feature activation of ID %d succeeded. "
                        "The distributed token exchange is going to be enabled at block %d.\n",
                        featureId, params.MSC_METADEX_BLOCK);
             return true;
-        case OMNICORE_FEATURE_BETTING:
+        case FEATURE_BETTING:
             MutableConsensusParams().MSC_BET_BLOCK = activationBlock;
             PrintToLog("Feature activation of ID %d succeeded. "
                        "Bet transactions are going to be enabled at block %d.\n",
                        featureId, params.MSC_BET_BLOCK);
             return true;
-        case OMNICORE_FEATURE_GRANTEFFECTS:
+        case FEATURE_GRANTEFFECTS:
             MutableConsensusParams().GRANTEFFECTS_FEATURE_BLOCK = activationBlock;
             PrintToLog("Feature activation of ID %d succeeded. "
                        "The potential side effect of crowdsale participations, when "
@@ -366,6 +352,34 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, int transactionBlo
 
     PrintToLog("Feature activation of id %d refused due to unknown feature ID\n", featureId);
     return false;
+}
+
+/**
+ * Checks, whether a feature is activated at the given block.
+ */
+bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
+{
+    const CConsensusParams& params = ConsensusParams();
+    int activationBlock = std::numeric_limits<int>::max();
+
+    switch (featureId) {
+        case FEATURE_CLASS_C:
+            activationBlock = params.NULLDATA_BLOCK;
+            break;
+        case FEATURE_METADEX:
+            activationBlock = params.MSC_METADEX_BLOCK;
+            break;
+        case FEATURE_BETTING:
+            activationBlock = params.MSC_BET_BLOCK;
+            break;
+        case FEATURE_GRANTEFFECTS:
+            activationBlock = params.GRANTEFFECTS_FEATURE_BLOCK;
+            break;
+        default:
+            return false;
+    }
+
+    return (transactionBlock >= activationBlock);
 }
 
 /**

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -27,9 +27,14 @@ namespace mastercore
  */
 enum FeatureId
 {
+    //! Feature identifier to enable Class C transaction parsing and processing
     OMNICORE_FEATURE_CLASS_C = 1,
+    //! Feature identifier to enable the distributed token exchange
     OMNICORE_FEATURE_METADEX = 2,
-    OMNICORE_FEATURE_BETTING = 3
+    //! Feature identifier to enable betting transactions
+    OMNICORE_FEATURE_BETTING = 3,
+    //! Feature identifier to disable crowdsale participations when "granting tokens"
+    OMNICORE_FEATURE_GRANTEFFECTS = 4
 };
 
 /**
@@ -152,6 +157,8 @@ CMainConsensusParams::CMainConsensusParams()
     MSC_STO_BLOCK = 342650;
     MSC_METADEX_BLOCK = 999999;
     MSC_BET_BLOCK = 999999;
+    // Other feature activations:
+    GRANTEFFECTS_FEATURE_BLOCK = 999999;
 }
 
 /**
@@ -182,6 +189,8 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     MSC_STO_BLOCK = 0;
     MSC_METADEX_BLOCK = 0;
     MSC_BET_BLOCK = 999999;
+    // Other feature activations:
+    GRANTEFFECTS_FEATURE_BLOCK = 999999;
 }
 
 /**
@@ -212,6 +221,8 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     MSC_STO_BLOCK = 0;
     MSC_METADEX_BLOCK = 0;
     MSC_BET_BLOCK = 999999;
+    // Other feature activations:
+    GRANTEFFECTS_FEATURE_BLOCK = 999999;
 }
 
 //! Consensus parameters for mainnet
@@ -328,15 +339,28 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, int transactionBlo
     switch (featureId) {
         case OMNICORE_FEATURE_CLASS_C:
             MutableConsensusParams().NULLDATA_BLOCK = activationBlock;
-            PrintToLog("Feature activation of ID %d succeeded, OP_RETURN block is now %d\n", featureId, params.NULLDATA_BLOCK);
+            PrintToLog("Feature activation of ID %d succeeded. "
+                       "Class C transaction encoding is going to be enabled at block %d.\n",
+                       featureId, params.NULLDATA_BLOCK);
             return true;
         case OMNICORE_FEATURE_METADEX:
             MutableConsensusParams().MSC_METADEX_BLOCK = activationBlock;
-            PrintToLog("Feature activation of ID %d succeeded, MSC_METADEX_BLOCK is now %d\n", featureId, params.MSC_METADEX_BLOCK);
+            PrintToLog("Feature activation of ID %d succeeded. "
+                       "The distributed token exchange is going to be enabled at block %d.\n",
+                       featureId, params.MSC_METADEX_BLOCK);
             return true;
         case OMNICORE_FEATURE_BETTING:
             MutableConsensusParams().MSC_BET_BLOCK = activationBlock;
-            PrintToLog("Feature activation of ID %d succeeded, MSC_BET_BLOCK is now %d\n", featureId, params.MSC_BET_BLOCK);
+            PrintToLog("Feature activation of ID %d succeeded. "
+                       "Bet transactions are going to be enabled at block %d.\n",
+                       featureId, params.MSC_BET_BLOCK);
+            return true;
+        case OMNICORE_FEATURE_GRANTEFFECTS:
+            MutableConsensusParams().GRANTEFFECTS_FEATURE_BLOCK = activationBlock;
+            PrintToLog("Feature activation of ID %d succeeded. "
+                       "The potential side effect of crowdsale participations, when "
+                       "granting tokens, is going to be disabled at block %d.\n",
+                       featureId, params.GRANTEFFECTS_FEATURE_BLOCK);
             return true;
     }
 

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -14,6 +14,15 @@ const int MONEYMAN_REGTEST_BLOCK = 101;
 //! Block to enable the Exodus fundraiser address on testnet
 const int MONEYMAN_TESTNET_BLOCK = 270775;
 
+//! Feature identifier to enable Class C transaction parsing and processing
+const uint16_t FEATURE_CLASS_C = 1;
+//! Feature identifier to enable the distributed token exchange
+const uint16_t FEATURE_METADEX = 2;
+//! Feature identifier to enable betting transactions
+const uint16_t FEATURE_BETTING = 3;
+//! Feature identifier to disable crowdsale participations when "granting tokens"
+const uint16_t FEATURE_GRANTEFFECTS = 4;
+
 /** A structure to represent transaction restrictions.
  */
 struct TransactionRestriction
@@ -150,6 +159,8 @@ CConsensusParams& MutableConsensusParams();
 
 /** Activates a feature at a specific block height. */
 bool ActivateFeature(uint16_t featureId, int activationBlock, int transactionBlock);
+/** Checks, whether a feature is activated at the given block. */
+bool IsFeatureActivated(uint16_t featureId, int transactionBlock);
 
 /** Checks, if the script type is allowed as input. */
 bool IsAllowedInputType(int whichType, int nBlock);

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -88,6 +88,9 @@ public:
     //! Block to enable betting transactions
     int MSC_BET_BLOCK;
 
+    //! Block to deactivate crowdsale participations when "granting tokens"
+    int GRANTEFFECTS_FEATURE_BLOCK;
+
     /** Returns a mapping of transaction types, and the blocks at which they are enabled. */
     virtual std::vector<TransactionRestriction> GetRestrictions() const;
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1635,8 +1635,14 @@ int CMPTransaction::logicMath_GrantTokens()
     // Move the tokens
     assert(update_tally_map(receiver, property, nValue, BALANCE));
 
-    // Is there an active crowdsale running from this recepient?
-    logicHelper_CrowdsaleParticipation();
+    /**
+     * As long as the feature to disable the side effects of "granting tokens"
+     * is not activated, "granting tokens" can trigger crowdsale participations.
+     */
+    if (!IsFeatureActivated(FEATURE_GRANTEFFECTS, block)) {
+        // Is there an active crowdsale running from this recepient?
+        logicHelper_CrowdsaleParticipation();
+    }
 
     return 0;
 }


### PR DESCRIPTION
The transaction type "grant tokens" may trigger crowdsale participations as secondary effect.

This behavior may not be desired in the future, and to open the possibility to disable this side effect without rolling out another major version, a "feature switch" was added around the call that initiates the crowdsale participation.

If this feature is activated, then "grant tokens" will no longer trigger crowdsale participations, but if not, and until then, nothing changes.

This PR resolves #157.