### PR TITLE
Add hidden RPC command to activate features

### DIFF
--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -379,6 +379,26 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosyste
     return payload;
 }
 
+std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock)
+{
+    std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 65535;
+    uint16_t messageType = 65534;
+
+    mastercore::swapByteOrder16(messageVer);
+    mastercore::swapByteOrder16(messageType);
+    mastercore::swapByteOrder16(featureId);
+    mastercore::swapByteOrder32(activationBlock);
+
+    PUSH_BACK_BYTES(payload, messageVer);
+    PUSH_BACK_BYTES(payload, messageType);
+    PUSH_BACK_BYTES(payload, featureId);
+    PUSH_BACK_BYTES(payload, activationBlock);
+
+    return payload;
+}
+
 std::vector<unsigned char> CreatePayload_OmniCoreAlert(int32_t alertType, uint64_t expiryValue, uint32_t typeCheck, uint32_t verCheck, const std::string& alertMessage)
 {
     std::vector<unsigned char> payload;

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -24,6 +24,7 @@ std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale
 std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired);
 std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdForSale, uint32_t propertyIdDesired);
 std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem);
+std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock);
 std::vector<unsigned char> CreatePayload_OmniCoreAlert(int32_t alertType, uint64_t expiryValue, uint32_t typeCheck, uint32_t verCheck, const std::string& alertMessage);
 
 

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -361,6 +361,16 @@ BOOST_AUTO_TEST_CASE(payload_change_property_manager)
     BOOST_CHECK_EQUAL(HexStr(vch), "000000460000000d");
 }
 
+BOOST_AUTO_TEST_CASE(payload_feature_activation)
+{
+    // Omni Core feature activation [type 65534, version 65535]
+    std::vector<unsigned char> vch = CreatePayload_ActivateFeature(
+        static_cast<uint16_t>(1),        // feature identifier: 1 (OP_RETURN)
+        static_cast<uint32_t>(370000));  // activation block
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "fffffffe00010005a550");
+}
+
 BOOST_AUTO_TEST_CASE(payload_omnicore_alert)
 {
     // Omni Core client notification [type 65535, version 65535]

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -162,6 +162,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendgrant", 2 },
     { "omni_sendrevoke", 1 },
     { "omni_sendchangeissuer", 2 },
+    { "omni_sendactivation", 1 },
+    { "omni_sendactivation", 2 },
     { "omni_sendalert", 1 },
     { "omni_sendalert", 2 },
     { "omni_sendalert", 3 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -399,6 +399,7 @@ static const CRPCCommand vRPCCommands[] =
     /* Omni Core hidden calls - development usage (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
     { "hidden",                              "mscrpc",                          &mscrpc,                          true,       true,       true },
+    { "hidden",                              "omni_sendactivation",             &omni_sendactivation,             false,      true,       true },
     { "hidden",                              "omni_sendalert",                  &omni_sendalert,                  true,       true,       true },
 
     /* Omni Core hidden calls - aliased calls for backwards compatibiltiy - to be depreciated (not shown in help) */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -270,6 +270,7 @@ extern json_spirit::Value omni_sendchangeissuer(const json_spirit::Array& params
 
 /* Omni Core hidden calls - development usage (not shown in help) */
 extern json_spirit::Value mscrpc(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_sendactivation(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_sendalert(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core hidden calls - aliased calls for backwards compatibiltiy - to be depreciated (not shown in help) */


### PR DESCRIPTION
Description:

  > Activate a protocol feature.

  > Note: Omni Core ignores activations from unauthorized sources.

Arguments:

>  1. fromaddress          (string, required) the address to send from
>  2. featureid            (number, required) the identifier of the feature to activate
>  3. block                (number, required) the activation block

Feature activations (and alerts) can be tested by whitelisting sources with `-omnialertallowsender=address|any`, for example in regtest mode or on testnet.