### PR TITLE
Mostly cosmetic overhaul of traditional DEx logic

### DIFF
--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -1,4 +1,8 @@
-// DEx & MetaDEx
+/**
+ * @file dex.cpp
+ *
+ * This file contains DEx logic.
+ */
 
 #include "omnicore/dex.h"
 
@@ -25,370 +29,366 @@
 #include <utility>
 #include <vector>
 
-using boost::algorithm::token_compress_on;
-
-using std::string;
-
 using namespace mastercore;
 
-
-// check to see if such a sell offer exists
-bool mastercore::DEx_offerExists(const string &seller_addr, unsigned int prop)
+/**
+ * TODO: update key generation
+ * Checks, if such a sell offer exists.
+ */
+bool mastercore::DEx_offerExists(const std::string& seller_addr, uint32_t prop)
 {
-//  if (msc_debug_dex) file_log("%s()\n", __FUNCTION__);
-const string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
-OfferMap::iterator my_it = my_offers.find(combo);
+    if (msc_debug_dex) PrintToLog("%s()\n", __func__);
 
-  return !(my_it == my_offers.end());
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+    OfferMap::iterator my_it = my_offers.find(combo);
+
+    return !(my_it == my_offers.end());
 }
 
-// getOffer may replace DEx_offerExists() in the near future
-// TODO: locks are needed around map's insert & erase
-CMPOffer *mastercore::DEx_getOffer(const string &seller_addr, unsigned int prop)
+/**
+ * TODO: update key generation
+ */
+CMPOffer* mastercore::DEx_getOffer(const std::string& seller_addr, uint32_t prop)
 {
-  if (msc_debug_dex) PrintToLog("%s(%s, %u)\n", __FUNCTION__, seller_addr, prop);
-const string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
-OfferMap::iterator my_it = my_offers.find(combo);
+    if (msc_debug_dex) PrintToLog("%s(%s, %d)\n", __func__, seller_addr, prop);
 
-  if (my_it != my_offers.end()) return &(my_it->second);
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+    OfferMap::iterator it = my_offers.find(combo);
 
-  return (CMPOffer *) NULL;
+    if (it != my_offers.end()) return &(it->second);
+
+    return NULL;
 }
 
-// TODO: locks are needed around map's insert & erase
-CMPAccept *mastercore::DEx_getAccept(const string &seller_addr, unsigned int prop, const string &buyer_addr)
+CMPAccept* mastercore::DEx_getAccept(const std::string& seller_addr, uint32_t prop, const std::string& buyer_addr)
 {
-  if (msc_debug_dex) PrintToLog("%s(%s, %u, %s)\n", __FUNCTION__, seller_addr, prop, buyer_addr);
-const string combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller_addr, buyer_addr);
-AcceptMap::iterator my_it = my_accepts.find(combo);
+    if (msc_debug_dex) PrintToLog("%s(%s, %d, %s)\n", __func__, seller_addr, prop, buyer_addr);
 
-  if (my_it != my_accepts.end()) return &(my_it->second);
+    const std::string combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller_addr, buyer_addr);
+    AcceptMap::iterator it = my_accepts.find(combo);
 
-  return (CMPAccept *) NULL;
+    if (it != my_accepts.end()) return &(it->second);
+
+    return NULL;
 }
 
-// returns 0 if everything is OK
-int mastercore::DEx_offerCreate(string seller_addr, unsigned int prop, uint64_t nValue, int block, uint64_t amount_des, uint64_t fee, unsigned char btl, const uint256 &txid, uint64_t *nAmended)
+/**
+ * TODO: change nAmended: uint64_t -> int64_t
+ * @return 0 if everything is OK
+ */
+int mastercore::DEx_offerCreate(const std::string& seller_addr, uint32_t prop, int64_t nValue, int block, int64_t amount_des, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended)
 {
-int rc = DEX_ERROR_SELLOFFER;
+    int rc = DEX_ERROR_SELLOFFER;
 
-  // sanity check our params are OK
-  if ((!btl) || (!amount_des)) return (DEX_ERROR_SELLOFFER -101); // time limit or amount desired empty
+    // sanity check our params are OK
+    if ((!btl) || (!amount_des)) return (DEX_ERROR_SELLOFFER -101); // time limit or amount desired empty
 
-  if (DEx_getOffer(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -10);  // offer already exists
+    if (DEx_getOffer(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -10); // offer already exists
 
-  const string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
 
-  if (msc_debug_dex)
-   PrintToLog("%s(%s|%s), nValue=%lu)\n", __FUNCTION__, seller_addr, combo, nValue);
+    if (msc_debug_dex) PrintToLog("%s(%s|%s), nValue=%d)\n", __func__, seller_addr, combo, nValue);
 
-  const uint64_t balanceReallyAvailable = getMPbalance(seller_addr, prop, BALANCE);
+    const int64_t balanceReallyAvailable = getMPbalance(seller_addr, prop, BALANCE);
 
-  // if offering more than available -- put everything up on sale
-  if (nValue > balanceReallyAvailable)
-  {
-  double BTC;
+    // -------------------------------------------------------------------------
+    // TODO: no floating numbers
 
-    // AND we must also re-adjust the BTC desired in this case...
-    BTC = amount_des * balanceReallyAvailable;
-    BTC /= (double)nValue;
-    amount_des = rounduint64(BTC);
+    // if offering more than available -- put everything up on sale
+    if (nValue > balanceReallyAvailable) {
+        PrintToLog("%s: adjusting order: %s offers %s, but has only %s SP %d (%s)\n", __func__,
+                        seller_addr, FormatDivisibleMP(nValue),
+                        FormatDivisibleMP(balanceReallyAvailable),
+                        prop, strMPProperty(prop));
 
-    nValue = balanceReallyAvailable;
+        double BTC;
 
-    if (nAmended) *nAmended = nValue;
-  }
+        // AND we must also re-adjust the BTC desired in this case...
+        BTC = amount_des * balanceReallyAvailable;
+        BTC /= (double) nValue;
+        amount_des = rounduint64(BTC);
 
-  if (update_tally_map(seller_addr, prop, - nValue, BALANCE)) // subtract from what's available
-  {
-    update_tally_map(seller_addr, prop, nValue, SELLOFFER_RESERVE); // put in reserve
+        nValue = balanceReallyAvailable;
 
-    my_offers.insert(std::make_pair(combo, CMPOffer(block, nValue, prop, amount_des, fee, btl, txid)));
+        if (nAmended) *nAmended = nValue;
+    }
+
+    // -------------------------------------------------------------------------
+
+    if (nValue > 0) {
+        assert(update_tally_map(seller_addr, prop, -nValue, BALANCE));
+        assert(update_tally_map(seller_addr, prop, nValue, SELLOFFER_RESERVE));
+
+        my_offers.insert(std::make_pair(combo, CMPOffer(block, nValue, prop, amount_des, fee, btl, txid)));
+
+        rc = 0;
+    }
+
+    return rc;
+}
+
+/**
+ * @return 0 if everything is OK
+ */
+int mastercore::DEx_offerDestroy(const std::string& seller_addr, uint32_t prop)
+{
+    const int64_t amount = getMPbalance(seller_addr, prop, SELLOFFER_RESERVE);
+
+    if (!DEx_offerExists(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -11); // offer does not exist
+
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+
+    OfferMap::iterator my_it = my_offers.find(combo);
+
+    if (amount > 0) {
+        assert(update_tally_map(seller_addr, prop, -amount, SELLOFFER_RESERVE));
+        assert(update_tally_map(seller_addr, prop, amount, BALANCE)); // give back to the seller from SellOffer-Reserve
+    }
+
+    // delete the offer
+    my_offers.erase(my_it);
+
+    if (msc_debug_dex) PrintToLog("%s(%s|%s)\n", __func__, seller_addr, combo);
+
+    return 0;
+}
+
+/**
+ * @return 0 if everything is OK
+ */
+int mastercore::DEx_offerUpdate(const std::string& seller_addr, uint32_t prop, int64_t nValue, int block, int64_t desired, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended)
+{
+    if (msc_debug_dex) PrintToLog("%s(%s, %d)\n", __func__, seller_addr, prop);
+
+    int rc = DEX_ERROR_SELLOFFER;
+
+    if (!DEx_offerExists(seller_addr, prop)) {
+        return (DEX_ERROR_SELLOFFER -12); // offer does not exist
+    }
+
+    rc = DEx_offerDestroy(seller_addr, prop);
+
+    if (!rc) {
+        rc = DEx_offerCreate(seller_addr, prop, nValue, block, desired, fee, btl, txid, nAmended);
+    }
+
+    return rc;
+}
+
+/**
+ * TODO: change nAmended: uint64_t -> int64_t
+ * @return 0 if everything is OK
+ */
+int mastercore::DEx_acceptCreate(const std::string& buyer, const std::string& seller, uint32_t prop, int64_t nValue, int block, int64_t fee_paid, uint64_t* nAmended)
+{
+    int rc = DEX_ERROR_ACCEPT -10;
+    OfferMap::iterator my_it;
+    const std::string selloffer_combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller);
+    const std::string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer);
+    int64_t nActualAmount = getMPbalance(seller, prop, SELLOFFER_RESERVE);
+
+    my_it = my_offers.find(selloffer_combo);
+
+    if (my_it == my_offers.end()) return DEX_ERROR_ACCEPT -15;
+
+    CMPOffer& offer = my_it->second;
+
+    if (msc_debug_dex) PrintToLog("%s(offer: %s)\n", __func__, offer.getHash().GetHex());
+
+    // here we ensure the correct BTC fee was paid in this acceptance message, per spec
+    if (fee_paid < offer.getMinFee()) {
+        PrintToLog("ERROR: fee too small -- the ACCEPT is rejected! (%d is smaller than %d)\n", fee_paid, offer.getMinFee());
+        return DEX_ERROR_ACCEPT -105;
+    }
+
+    PrintToLog("%s(%s) OFFER FOUND\n", __func__, selloffer_combo);
+
+    // the older accept is the valid one: do not accept any new ones!
+    if (DEx_getAccept(seller, prop, buyer)) {
+        PrintToLog("%s() ERROR: an accept from this same seller for this same offer is already open !!!!!\n", __func__);
+        return DEX_ERROR_ACCEPT -205;
+    }
+
+    if (nActualAmount > nValue) {
+        nActualAmount = nValue;
+
+        if (nAmended) *nAmended = nActualAmount;
+    }
+
+    // TODO: think if we want to save nValue -- as the amount coming off the wire into the object or not
+    if (nActualAmount > 0) {
+        assert(update_tally_map(seller, prop, -nActualAmount, SELLOFFER_RESERVE));
+        assert(update_tally_map(seller, prop, nActualAmount, ACCEPT_RESERVE));
+
+        CMPAccept acceptOffer(nActualAmount, block, offer.getBlockTimeLimit(), offer.getProperty(), offer.getOfferAmountOriginal(), offer.getBTCDesiredOriginal(), offer.getHash());
+        my_accepts.insert(std::make_pair(accept_combo, acceptOffer));
+
+        rc = 0;
+    }
+
+    return rc;
+}
+
+/**
+ * Finalizes an accepted offer.
+ *
+ * This function is called by handler_block() for each accepted offer that has
+ * expired. This function is also called when the purchase has been completed,
+ * and the buyer bought everything he was allocated).
+ *
+ * @return 0 if everything is OK
+ */
+int mastercore::DEx_acceptDestroy(const std::string& buyer, const std::string& seller, uint32_t prop, bool bForceErase)
+{
+    int rc = DEX_ERROR_ACCEPT -20;
+    CMPOffer* p_offer = DEx_getOffer(seller, prop);
+    CMPAccept* p_accept = DEx_getAccept(seller, prop, buyer);
+    bool bReturnToMoney; // return to BALANCE of the seller, otherwise return to SELLOFFER_RESERVE
+    const std::string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer);
+
+    if (!p_accept) return rc; // sanity check
+
+    const int64_t nActualAmount = p_accept->getAcceptAmountRemaining();
+
+    // if the offer is gone ACCEPT_RESERVE should go back to BALANCE
+    if (!p_offer) {
+        bReturnToMoney = true;
+    } else {
+        PrintToLog("%s() HASHES: offer=%s, accept=%s\n", __func__, p_offer->getHash().GetHex(), p_accept->getHash().GetHex());
+
+        // offer exists, determine whether it's the original offer or some random new one
+        if (p_offer->getHash() == p_accept->getHash()) {
+            // same offer, return to SELLOFFER_RESERVE
+            bReturnToMoney = false;
+        } else {
+            // old offer is gone !
+            bReturnToMoney = true;
+        }
+    }
+
+    if (nActualAmount > 0) {
+        if (bReturnToMoney) {
+            assert(update_tally_map(seller, prop, -nActualAmount, ACCEPT_RESERVE));
+            assert(update_tally_map(seller, prop, nActualAmount, BALANCE));
+        } else {
+            assert(update_tally_map(seller, prop, -nActualAmount, ACCEPT_RESERVE));
+            assert(update_tally_map(seller, prop, nActualAmount, SELLOFFER_RESERVE));
+        }
+    }
+
+    // can only erase when is NOT called from an iterator loop
+    if (bForceErase) {
+        AcceptMap::iterator my_it = my_accepts.find(accept_combo);
+
+        if (my_accepts.end() != my_it) my_accepts.erase(my_it);
+    }
 
     rc = 0;
-  }
-
-  return rc;
+    return rc;
 }
 
-// returns 0 if everything is OK
-int mastercore::DEx_offerDestroy(const string &seller_addr, unsigned int prop)
+/**
+ * Handles incoming BTC payment for the offer.
+ * TODO: change nAmended: uint64_t -> int64_t
+ */
+int mastercore::DEx_payment(const uint256& txid, unsigned int vout, const std::string& seller, const std::string& buyer, int64_t BTC_paid, int blockNow, uint64_t* nAmended)
 {
-const uint64_t amount = getMPbalance(seller_addr, prop, SELLOFFER_RESERVE);
+    int rc = DEX_ERROR_PAYMENT;
 
-  if (!DEx_offerExists(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -11); // offer does not exist
+    uint32_t prop = OMNI_PROPERTY_MSC; // test for MSC accept first
+    CMPAccept* p_accept = DEx_getAccept(seller, prop, buyer);
 
-  const string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
-
-  OfferMap::iterator my_it;
-
-  my_it = my_offers.find(combo);
-
-  if (amount)
-  {
-    update_tally_map(seller_addr, prop, amount, BALANCE);   // give back to the seller from SellOffer-Reserve
-    update_tally_map(seller_addr, prop, - amount, SELLOFFER_RESERVE);
-  }
-
-  // delete the offer
-  my_offers.erase(my_it);
-
-  if (msc_debug_dex)
-   PrintToLog("%s(%s|%s)\n", __FUNCTION__, seller_addr, combo);
-
-  return 0;
-}
-
-// returns 0 if everything is OK
-int mastercore::DEx_offerUpdate(const string &seller_addr, unsigned int prop, uint64_t nValue, int block, uint64_t desired, uint64_t fee, unsigned char btl, const uint256 &txid, uint64_t *nAmended)
-{
-int rc = DEX_ERROR_SELLOFFER;
-
-  PrintToLog("%s(%s, %d)\n", __FUNCTION__, seller_addr, prop);
-
-  if (!DEx_offerExists(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -12); // offer does not exist
-
-  rc = DEx_offerDestroy(seller_addr, prop);
-
-  if (!rc)
-  {
-    rc = DEx_offerCreate(seller_addr, prop, nValue, block, desired, fee, btl, txid, nAmended);
-  }
-
-  return rc;
-}
-
-// returns 0 if everything is OK
-int mastercore::DEx_acceptCreate(const string &buyer, const string &seller, int prop, uint64_t nValue, int block, uint64_t fee_paid, uint64_t *nAmended)
-{
-int rc = DEX_ERROR_ACCEPT - 10;
-OfferMap::iterator my_it;
-const string selloffer_combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller);
-const string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer);
-uint64_t nActualAmount = getMPbalance(seller, prop, SELLOFFER_RESERVE);
-
-  my_it = my_offers.find(selloffer_combo);
-
-  if (my_it == my_offers.end()) return DEX_ERROR_ACCEPT -15;
-
-  CMPOffer &offer = my_it->second;
-
-  if (msc_debug_dex) PrintToLog("%s(offer: %s)\n", __FUNCTION__, offer.getHash().GetHex());
-
-  // here we ensure the correct BTC fee was paid in this acceptance message, per spec
-  if (fee_paid < offer.getMinFee())
-  {
-    PrintToLog("ERROR: fee too small -- the ACCEPT is rejected! (%lu is smaller than %lu)\n", fee_paid, offer.getMinFee());
-    return DEX_ERROR_ACCEPT -105;
-  }
-
-  PrintToLog("%s(%s) OFFER FOUND\n", __FUNCTION__, selloffer_combo);
-
-  // the older accept is the valid one: do not accept any new ones!
-  if (DEx_getAccept(seller, prop, buyer))
-  {
-    PrintToLog("%s() ERROR: an accept from this same seller for this same offer is already open !!!!!\n", __FUNCTION__);
-    return DEX_ERROR_ACCEPT -205;
-  }
-
-  if (nActualAmount > nValue)
-  {
-    nActualAmount = nValue;
-
-    if (nAmended) *nAmended = nActualAmount;
-  }
-
-  // TODO: think if we want to save nValue -- as the amount coming off the wire into the object or not
-  if (update_tally_map(seller, prop, - nActualAmount, SELLOFFER_RESERVE))
-  {
-    if (update_tally_map(seller, prop, nActualAmount, ACCEPT_RESERVE))
-    {
-      // insert into the map !
-      my_accepts.insert(std::make_pair(accept_combo, CMPAccept(nActualAmount, block,
-       offer.getBlockTimeLimit(), offer.getProperty(), offer.getOfferAmountOriginal(), offer.getBTCDesiredOriginal(), offer.getHash() )));
-
-      rc = 0;
+    if (!p_accept) {
+        prop = OMNI_PROPERTY_TMSC; // test for TMSC accept second
+        p_accept = DEx_getAccept(seller, prop, buyer);
     }
-  }
 
-  return rc;
-}
+    if (msc_debug_dex) PrintToLog("%s(%s, %s)\n", __func__, seller, buyer);
 
-// this function is called by handler_block() for each Accept that has expired
-// this function is also called when the purchase has been completed (the buyer bought everything he was allocated)
-//
-// returns 0 if everything is OK
-int mastercore::DEx_acceptDestroy(const string &buyer, const string &seller, int prop, bool bForceErase)
-{
-int rc = DEX_ERROR_ACCEPT - 20;
-CMPOffer *p_offer = DEx_getOffer(seller, prop);
-CMPAccept *p_accept = DEx_getAccept(seller, prop, buyer);
-bool bReturnToMoney; // return to BALANCE of the seller, otherwise return to SELLOFFER_RESERVE
-const string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer);
+    if (!p_accept) return (DEX_ERROR_PAYMENT -1); // there must be an active Accept for this payment
 
-  if (!p_accept) return rc; // sanity check
+    // -------------------------------------------------------------------------
+    // TODO: no floating numbers
 
-  const uint64_t nActualAmount = p_accept->getAcceptAmountRemaining();
+    const double BTC_desired_original = p_accept->getBTCDesiredOriginal();
+    const double offer_amount_original = p_accept->getOfferAmountOriginal();
 
-  // if the offer is gone ACCEPT_RESERVE should go back to BALANCE
-  if (!p_offer)
-  {
-    bReturnToMoney = true;
-  }
-  else
-  {
-    PrintToLog("%s() HASHES: offer=%s, accept=%s\n", __FUNCTION__, p_offer->getHash().GetHex(), p_accept->getHash().GetHex());
+    if (0 == (double) BTC_desired_original) return (DEX_ERROR_PAYMENT -2); // divide by 0 protection
 
-    // offer exists, determine whether it's the original offer or some random new one
-    if (p_offer->getHash() == p_accept->getHash())
-    {
-      // same offer, return to SELLOFFER_RESERVE
-      bReturnToMoney = false;
+    double perc_X = (double) BTC_paid / BTC_desired_original;
+    double Purchased = offer_amount_original * perc_X;
+
+    int64_t units_purchased = rounduint64(Purchased);
+
+    // -------------------------------------------------------------------------
+
+    const int64_t nActualAmount = p_accept->getAcceptAmountRemaining(); // actual amount desired, in the Accept
+
+    if (msc_debug_dex)
+        PrintToLog("BTC_desired= %30.20lf , offer_amount=%30.20lf , perc_X= %30.20lf , Purchased= %30.20lf , units_purchased= %lu\n",
+            BTC_desired_original, offer_amount_original, perc_X, Purchased, units_purchased);
+
+    // if units_purchased is greater than what's in the Accept, the buyer gets only what's in the Accept
+    if (nActualAmount < units_purchased) {
+        units_purchased = nActualAmount;
+
+        if (nAmended) *nAmended = units_purchased;
     }
-    else
-    {
-      // old offer is gone !
-      bReturnToMoney = true;
+
+    if (units_purchased > 0) {
+        assert(update_tally_map(seller, prop, -units_purchased, ACCEPT_RESERVE));
+        assert(update_tally_map(buyer, prop, units_purchased, BALANCE));
+
+        bool bValid = true;
+        p_txlistdb->recordPaymentTX(txid, bValid, blockNow, vout, prop, units_purchased, buyer, seller);
+
+        rc = 0;
+        PrintToLog("#######################################################\n");
     }
-  }
 
-  if (bReturnToMoney)
-  {
-    if (update_tally_map(seller, prop, - nActualAmount, ACCEPT_RESERVE))
-    {
-      update_tally_map(seller, prop, nActualAmount, BALANCE);
-      rc = 0;
+    // reduce the amount of units still desired by the buyer and if 0 must destroy the Accept
+    if (p_accept->reduceAcceptAmountRemaining_andIsZero(units_purchased)) {
+        const int64_t selloffer_reserve = getMPbalance(seller, prop, SELLOFFER_RESERVE);
+        const int64_t accept_reserve = getMPbalance(seller, prop, ACCEPT_RESERVE);
+
+        DEx_acceptDestroy(buyer, seller, prop, true);
+
+        // delete the Offer object if there is nothing in its Reserves -- everything got puchased and paid for
+        if ((0 == selloffer_reserve) && (0 == accept_reserve)) {
+            DEx_offerDestroy(seller, prop);
+        }
     }
-  }
-  else
-  {
-    // return to SELLOFFER_RESERVE
-    if (update_tally_map(seller, prop, - nActualAmount, ACCEPT_RESERVE))
-    {
-      update_tally_map(seller, prop, nActualAmount, SELLOFFER_RESERVE);
-      rc = 0;
-    }
-  }
 
-  // can only erase when is NOT called from an iterator loop
-  if (bForceErase)
-  {
-  const AcceptMap::iterator my_it = my_accepts.find(accept_combo);
-
-    if (my_accepts.end() !=my_it) my_accepts.erase(my_it);
-  }
-
-  return rc;
-}
-
-// incoming BTC payment for the offer
-// TODO: verify proper partial payment handling
-int mastercore::DEx_payment(uint256 txid, unsigned int vout, string seller, string buyer, uint64_t BTC_paid, int blockNow, uint64_t *nAmended)
-{
-//  if (msc_debug_dex) file_log("%s()\n", __FUNCTION__);
-int rc = DEX_ERROR_PAYMENT;
-CMPAccept *p_accept;
-int prop;
-
-prop = OMNI_PROPERTY_MSC; //test for MSC accept first
-p_accept = DEx_getAccept(seller, prop, buyer);
-
-  if (!p_accept) 
-  {
-    prop = OMNI_PROPERTY_TMSC; //test for TMSC accept second
-    p_accept = DEx_getAccept(seller, prop, buyer); 
-  }
-
-  if (msc_debug_dex) PrintToLog("%s(%s, %s)\n", __FUNCTION__, seller, buyer);
-
-  if (!p_accept) return (DEX_ERROR_PAYMENT -1);  // there must be an active Accept for this payment
-
-  const double BTC_desired_original = p_accept->getBTCDesiredOriginal();
-  const double offer_amount_original = p_accept->getOfferAmountOriginal();
-
-  if (0==(double)BTC_desired_original) return (DEX_ERROR_PAYMENT -2);  // divide by 0 protection
-
-  double perc_X = (double)BTC_paid/BTC_desired_original;
-  double Purchased = offer_amount_original * perc_X;
-
-  uint64_t units_purchased = rounduint64(Purchased);
-
-  const uint64_t nActualAmount = p_accept->getAcceptAmountRemaining();  // actual amount desired, in the Accept
-
-  if (msc_debug_dex)
-   PrintToLog("BTC_desired= %30.20lf , offer_amount=%30.20lf , perc_X= %30.20lf , Purchased= %30.20lf , units_purchased= %lu\n",
-   BTC_desired_original, offer_amount_original, perc_X, Purchased, units_purchased);
-
-  // if units_purchased is greater than what's in the Accept, the buyer gets only what's in the Accept
-  if (nActualAmount < units_purchased)
-  {
-    units_purchased = nActualAmount;
-
-    if (nAmended) *nAmended = units_purchased;
-  }
-
-  if (update_tally_map(seller, prop, - units_purchased, ACCEPT_RESERVE))
-  {
-      update_tally_map(buyer, prop, units_purchased, BALANCE);
-      rc = 0;
-      bool bValid = true;
-      p_txlistdb->recordPaymentTX(txid, bValid, blockNow, vout, prop, units_purchased, buyer, seller);
-
-      PrintToLog("#######################################################\n");
-  }
-
-  // reduce the amount of units still desired by the buyer and if 0 must destroy the Accept
-  if (p_accept->reduceAcceptAmountRemaining_andIsZero(units_purchased))
-  {
-  const uint64_t selloffer_reserve = getMPbalance(seller, prop, SELLOFFER_RESERVE);
-  const uint64_t accept_reserve = getMPbalance(seller, prop, ACCEPT_RESERVE);
-
-    DEx_acceptDestroy(buyer, seller, prop, true);
-
-    // delete the Offer object if there is nothing in its Reserves -- everything got puchased and paid for
-    if ((0 == selloffer_reserve) && (0 == accept_reserve))
-    {
-      DEx_offerDestroy(seller, prop);
-    }
-  }
-
-  return rc;
+    return rc;
 }
 
 unsigned int eraseExpiredAccepts(int blockNow)
 {
-unsigned int how_many_erased = 0;
-AcceptMap::iterator my_it = my_accepts.begin();
+    unsigned int how_many_erased = 0;
+    AcceptMap::iterator my_it = my_accepts.begin();
 
-  while (my_accepts.end() != my_it)
-  {
-    // my_it->first = key
-    // my_it->second = value
+    while (my_accepts.end() != my_it) {
+        CMPAccept& mpaccept = my_it->second;
 
-    CMPAccept &mpaccept = my_it->second;
+        if ((blockNow - mpaccept.getAcceptBlock()) >= static_cast<int>(mpaccept.getBlockTimeLimit())) {
+            PrintToLog("%s() FOUND EXPIRED ACCEPT, erasing: blockNow=%d, offer block=%d, blocktimelimit= %d\n",
+                    __func__, blockNow, mpaccept.getAcceptBlock(), mpaccept.getBlockTimeLimit());
 
-    if ((blockNow - mpaccept.block) >= (int) mpaccept.getBlockTimeLimit())
-    {
-      PrintToLog("%s() FOUND EXPIRED ACCEPT, erasing: blockNow=%d, offer block=%d, blocktimelimit= %d\n",
-       __FUNCTION__, blockNow, mpaccept.block, mpaccept.getBlockTimeLimit());
+            // extract the seller, buyer and property from the key
+            std::vector<std::string> vstr;
+            boost::split(vstr, my_it->first, boost::is_any_of("-+"), boost::token_compress_on);
+            std::string seller = vstr[0];
+            uint32_t property = atoi(vstr[1]);
+            std::string buyer = vstr[2];
 
-      // extract the seller, buyer & property from the Key
-      std::vector<std::string> vstr;
-      boost::split(vstr, my_it->first, boost::is_any_of("-+"), token_compress_on);
-      string seller = vstr[0];
-      int property = atoi(vstr[1]);
-      string buyer = vstr[2];
+            DEx_acceptDestroy(buyer, seller, property);
 
-      DEx_acceptDestroy(buyer, seller, property);
+            my_accepts.erase(my_it++);
 
-      my_accepts.erase(my_it++);
-
-      ++how_many_erased;
+            ++how_many_erased;
+        } else my_it++;
     }
-    else my_it++;
 
-  }
-
-  return how_many_erased;
+    return how_many_erased;
 }
 

--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -29,13 +29,13 @@
 #include <utility>
 #include <vector>
 
-using namespace mastercore;
-
+namespace mastercore
+{
 /**
  * TODO: update key generation
  * Checks, if such a sell offer exists.
  */
-bool mastercore::DEx_offerExists(const std::string& seller_addr, uint32_t prop)
+bool DEx_offerExists(const std::string& seller_addr, uint32_t prop)
 {
     if (msc_debug_dex) PrintToLog("%s()\n", __func__);
 
@@ -48,7 +48,7 @@ bool mastercore::DEx_offerExists(const std::string& seller_addr, uint32_t prop)
 /**
  * TODO: update key generation
  */
-CMPOffer* mastercore::DEx_getOffer(const std::string& seller_addr, uint32_t prop)
+CMPOffer* DEx_getOffer(const std::string& seller_addr, uint32_t prop)
 {
     if (msc_debug_dex) PrintToLog("%s(%s, %d)\n", __func__, seller_addr, prop);
 
@@ -60,7 +60,7 @@ CMPOffer* mastercore::DEx_getOffer(const std::string& seller_addr, uint32_t prop
     return NULL;
 }
 
-CMPAccept* mastercore::DEx_getAccept(const std::string& seller_addr, uint32_t prop, const std::string& buyer_addr)
+CMPAccept* DEx_getAccept(const std::string& seller_addr, uint32_t prop, const std::string& buyer_addr)
 {
     if (msc_debug_dex) PrintToLog("%s(%s, %d, %s)\n", __func__, seller_addr, prop, buyer_addr);
 
@@ -76,7 +76,7 @@ CMPAccept* mastercore::DEx_getAccept(const std::string& seller_addr, uint32_t pr
  * TODO: change nAmended: uint64_t -> int64_t
  * @return 0 if everything is OK
  */
-int mastercore::DEx_offerCreate(const std::string& seller_addr, uint32_t prop, int64_t nValue, int block, int64_t amount_des, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended)
+int DEx_offerCreate(const std::string& seller_addr, uint32_t prop, int64_t nValue, int block, int64_t amount_des, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended)
 {
     int rc = DEX_ERROR_SELLOFFER;
 
@@ -130,7 +130,7 @@ int mastercore::DEx_offerCreate(const std::string& seller_addr, uint32_t prop, i
 /**
  * @return 0 if everything is OK
  */
-int mastercore::DEx_offerDestroy(const std::string& seller_addr, uint32_t prop)
+int DEx_offerDestroy(const std::string& seller_addr, uint32_t prop)
 {
     const int64_t amount = getMPbalance(seller_addr, prop, SELLOFFER_RESERVE);
 
@@ -156,7 +156,7 @@ int mastercore::DEx_offerDestroy(const std::string& seller_addr, uint32_t prop)
 /**
  * @return 0 if everything is OK
  */
-int mastercore::DEx_offerUpdate(const std::string& seller_addr, uint32_t prop, int64_t nValue, int block, int64_t desired, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended)
+int DEx_offerUpdate(const std::string& seller_addr, uint32_t prop, int64_t nValue, int block, int64_t desired, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended)
 {
     if (msc_debug_dex) PrintToLog("%s(%s, %d)\n", __func__, seller_addr, prop);
 
@@ -179,7 +179,7 @@ int mastercore::DEx_offerUpdate(const std::string& seller_addr, uint32_t prop, i
  * TODO: change nAmended: uint64_t -> int64_t
  * @return 0 if everything is OK
  */
-int mastercore::DEx_acceptCreate(const std::string& buyer, const std::string& seller, uint32_t prop, int64_t nValue, int block, int64_t fee_paid, uint64_t* nAmended)
+int DEx_acceptCreate(const std::string& buyer, const std::string& seller, uint32_t prop, int64_t nValue, int block, int64_t fee_paid, uint64_t* nAmended)
 {
     int rc = DEX_ERROR_ACCEPT -10;
     OfferMap::iterator my_it;
@@ -238,7 +238,7 @@ int mastercore::DEx_acceptCreate(const std::string& buyer, const std::string& se
  *
  * @return 0 if everything is OK
  */
-int mastercore::DEx_acceptDestroy(const std::string& buyer, const std::string& seller, uint32_t prop, bool bForceErase)
+int DEx_acceptDestroy(const std::string& buyer, const std::string& seller, uint32_t prop, bool bForceErase)
 {
     int rc = DEX_ERROR_ACCEPT -20;
     CMPOffer* p_offer = DEx_getOffer(seller, prop);
@@ -291,7 +291,7 @@ int mastercore::DEx_acceptDestroy(const std::string& buyer, const std::string& s
  * Handles incoming BTC payment for the offer.
  * TODO: change nAmended: uint64_t -> int64_t
  */
-int mastercore::DEx_payment(const uint256& txid, unsigned int vout, const std::string& seller, const std::string& buyer, int64_t BTC_paid, int blockNow, uint64_t* nAmended)
+int DEx_payment(const uint256& txid, unsigned int vout, const std::string& seller, const std::string& buyer, int64_t BTC_paid, int blockNow, uint64_t* nAmended)
 {
     int rc = DEX_ERROR_PAYMENT;
 
@@ -392,3 +392,5 @@ unsigned int eraseExpiredAccepts(int blockNow)
     return how_many_erased;
 }
 
+
+} // namespace mastercore

--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -32,27 +32,26 @@
 namespace mastercore
 {
 /**
- * TODO: update key generation
  * Checks, if such a sell offer exists.
  */
 bool DEx_offerExists(const std::string& seller_addr, uint32_t prop)
 {
     if (msc_debug_dex) PrintToLog("%s()\n", __func__);
 
-    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr, prop);
     OfferMap::iterator my_it = my_offers.find(combo);
 
     return !(my_it == my_offers.end());
 }
 
 /**
- * TODO: update key generation
+ * @return The DEx sell offer, or NULL, if no match was found
  */
 CMPOffer* DEx_getOffer(const std::string& seller_addr, uint32_t prop)
 {
     if (msc_debug_dex) PrintToLog("%s(%s, %d)\n", __func__, seller_addr, prop);
 
-    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr, prop);
     OfferMap::iterator it = my_offers.find(combo);
 
     if (it != my_offers.end()) return &(it->second);
@@ -64,7 +63,7 @@ CMPAccept* DEx_getAccept(const std::string& seller_addr, uint32_t prop, const st
 {
     if (msc_debug_dex) PrintToLog("%s(%s, %d, %s)\n", __func__, seller_addr, prop, buyer_addr);
 
-    const std::string combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller_addr, buyer_addr);
+    const std::string combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller_addr, buyer_addr, prop);
     AcceptMap::iterator it = my_accepts.find(combo);
 
     if (it != my_accepts.end()) return &(it->second);
@@ -85,7 +84,7 @@ int DEx_offerCreate(const std::string& seller_addr, uint32_t prop, int64_t nValu
 
     if (DEx_getOffer(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -10); // offer already exists
 
-    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr, prop);
 
     if (msc_debug_dex) PrintToLog("%s(%s|%s), nValue=%d)\n", __func__, seller_addr, combo, nValue);
 
@@ -136,7 +135,7 @@ int DEx_offerDestroy(const std::string& seller_addr, uint32_t prop)
 
     if (!DEx_offerExists(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -11); // offer does not exist
 
-    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr, prop);
 
     OfferMap::iterator my_it = my_offers.find(combo);
 
@@ -183,8 +182,8 @@ int DEx_acceptCreate(const std::string& buyer, const std::string& seller, uint32
 {
     int rc = DEX_ERROR_ACCEPT -10;
     OfferMap::iterator my_it;
-    const std::string selloffer_combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller);
-    const std::string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer);
+    const std::string selloffer_combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller, prop);
+    const std::string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer, prop);
     int64_t nActualAmount = getMPbalance(seller, prop, SELLOFFER_RESERVE);
 
     my_it = my_offers.find(selloffer_combo);
@@ -244,7 +243,7 @@ int DEx_acceptDestroy(const std::string& buyer, const std::string& seller, uint3
     CMPOffer* p_offer = DEx_getOffer(seller, prop);
     CMPAccept* p_accept = DEx_getAccept(seller, prop, buyer);
     bool bReturnToMoney; // return to BALANCE of the seller, otherwise return to SELLOFFER_RESERVE
-    const std::string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer);
+    const std::string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer, prop);
 
     if (!p_accept) return rc; // sanity check
 

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -16,12 +16,26 @@
 #include <map>
 #include <string>
 
-// this is the internal format for the offer primary key
-// TODO: replace by a class method
-#define STR_SELLOFFER_ADDR_PROP_COMBO(x) (x + "-" + strprintf("%d", prop))
-#define STR_ACCEPT_ADDR_PROP_ADDR_COMBO(_seller , _buyer) (_seller + "-" + strprintf("%d", prop) + "+" + _buyer)
-#define STR_PAYMENT_SUBKEY_TXID_PAYMENT_COMBO(txidStr) (txidStr + "-" + strprintf("%d", paymentNumber))
-#define STR_REF_SUBKEY_TXID_REF_COMBO(txidStr) (txidStr + strprintf("%d", refNumber))
+/** Lookup key to find DEx offers. */
+inline std::string STR_SELLOFFER_ADDR_PROP_COMBO(const std::string& address, uint32_t propertyId)
+{
+    return strprintf("%s-%d", address, propertyId);
+}
+/** Lookup key to find DEx accepts. */
+inline std::string STR_ACCEPT_ADDR_PROP_ADDR_COMBO(const std::string& seller, const std::string& buyer, uint32_t propertyId)
+{
+    return strprintf("%s-%d+%s", seller, propertyId, buyer);
+}
+/** Lookup key to find DEx payments. */
+inline std::string STR_PAYMENT_SUBKEY_TXID_PAYMENT_COMBO(const std::string& txidStr, unsigned int paymentNumber)
+{
+    return strprintf("%s-%d", txidStr, paymentNumber);
+}
+/** Lookup key to find MetaDEx sub-records. TODO: not here! */
+inline std::string STR_REF_SUBKEY_TXID_REF_COMBO(const std::string& txidStr, unsigned int refNumber)
+{
+    return strprintf("%s%d", txidStr, refNumber);
+}
 
 /** A single outstanding offer, from one seller of one property.
  *

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -200,8 +200,6 @@ public:
     }
 };
 
-unsigned int eraseExpiredAccepts(int blockNow);
-
 namespace mastercore
 {
 typedef std::map<std::string, CMPOffer> OfferMap;
@@ -219,6 +217,8 @@ int DEx_offerUpdate(const std::string& seller_addr, uint32_t property, int64_t n
 int DEx_acceptCreate(const std::string& buyer, const std::string& seller, uint32_t property, int64_t nValue, int block, int64_t fee_paid, uint64_t* nAmended = NULL);
 int DEx_acceptDestroy(const std::string& buyer, const std::string& seller, uint32_t property, bool fForceErase = false);
 int DEx_payment(const uint256& txid, unsigned int vout, const std::string& seller, const std::string& buyer, int64_t BTC_paid, int blockNow, uint64_t* nAmended = NULL);
+
+unsigned int eraseExpiredAccepts(int blockNow);
 }
 
 

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -130,24 +130,25 @@ private:
     int block;
 
 public:
+    // TODO: it may not intuitive that this is *not* the hash of the accept order
     uint256 getHash() const { return offer_txid; }
 
     int64_t getOfferAmountOriginal() { return offer_amount_original; }
     int64_t getBTCDesiredOriginal() { return BTC_desired_original; }
 
-    uint8_t getBlockTimeLimit() { return blocktimelimit; }
+    uint8_t getBlockTimeLimit() const { return blocktimelimit; }
     uint32_t getProperty() const { return property; }
 
     int getAcceptBlock() const { return block; }
 
-    CMPAccept(int64_t amountOffered, int blockIn, uint8_t paymentWindow, uint32_t propertyId,
+    CMPAccept(int64_t amountAccepted, int blockIn, uint8_t paymentWindow, uint32_t propertyId,
               int64_t offerAmountOriginal, int64_t amountDesired, const uint256& txid)
-      : accept_amount_remaining(amountOffered), blocktimelimit(paymentWindow),
+      : accept_amount_remaining(amountAccepted), blocktimelimit(paymentWindow),
         property(propertyId), offer_amount_original(offerAmountOriginal),
         BTC_desired_original(amountDesired), offer_txid(txid), block(blockIn)
     {
         accept_amount_original = accept_amount_remaining;
-        PrintToLog("%s(%d): %s\n", __func__, amountOffered, txid.GetHex());
+        PrintToLog("%s(%d): %s\n", __func__, amountAccepted, txid.GetHex());
     }
 
     CMPAccept(int64_t acceptAmountOriginal, int64_t acceptAmountRemaining, int blockIn,
@@ -222,17 +223,18 @@ typedef std::map<std::string, CMPAccept> AcceptMap;
 extern OfferMap my_offers;
 extern AcceptMap my_accepts;
 
-bool DEx_offerExists(const std::string& seller_addr, uint32_t property);
-CMPOffer* DEx_getOffer(const std::string& seller_addr, uint32_t property);
-CMPAccept* DEx_getAccept(const std::string& seller_addr, uint32_t property, const std::string& buyer_addr);
-int DEx_offerCreate(const std::string& seller_addr, uint32_t property, int64_t nValue, int block, int64_t amount_desired, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended = NULL);
-int DEx_offerDestroy(const std::string& seller_addr, uint32_t property);
-int DEx_offerUpdate(const std::string& seller_addr, uint32_t property, int64_t nValue, int block, int64_t desired, int64_t fee, uint8_t btl, const uint256& txid, uint64_t* nAmended = NULL);
-int DEx_acceptCreate(const std::string& buyer, const std::string& seller, uint32_t property, int64_t nValue, int block, int64_t fee_paid, uint64_t* nAmended = NULL);
-int DEx_acceptDestroy(const std::string& buyer, const std::string& seller, uint32_t property, bool fForceErase = false);
-int DEx_payment(const uint256& txid, unsigned int vout, const std::string& seller, const std::string& buyer, int64_t BTC_paid, int blockNow, uint64_t* nAmended = NULL);
+bool DEx_offerExists(const std::string& addressSeller, uint32_t propertyId);
+CMPOffer* DEx_getOffer(const std::string& addressSeller, uint32_t propertyId);
+bool DEx_acceptExists(const std::string& addressSeller, uint32_t propertyId, const std::string& addressBuyer);
+CMPAccept* DEx_getAccept(const std::string& addressSeller, uint32_t propertyId, const std::string& addressBuyer);
+int DEx_offerCreate(const std::string& addressSeller, uint32_t propertyId, int64_t amountOffered, int block, int64_t amountDesired, int64_t minAcceptFee, uint8_t paymentWindow, const uint256& txid, uint64_t* nAmended = NULL);
+int DEx_offerDestroy(const std::string& addressSeller, uint32_t propertyId);
+int DEx_offerUpdate(const std::string& addressSeller, uint32_t propertyId, int64_t amountOffered, int block, int64_t amountDesired, int64_t minAcceptFee, uint8_t paymentWindow, const uint256& txid, uint64_t* nAmended = NULL);
+int DEx_acceptCreate(const std::string& addressBuyer, const std::string& addressSeller, uint32_t propertyId, int64_t amountAccepted, int block, int64_t feePaid, uint64_t* nAmended = NULL);
+int DEx_acceptDestroy(const std::string& addressBuyer, const std::string& addressSeller, uint32_t propertyid, bool fForceErase = false);
+int DEx_payment(const uint256& txid, unsigned int vout, const std::string& addressSeller, const std::string& addressBuyer, int64_t amountPaid, int block, uint64_t* nAmended = NULL);
 
-unsigned int eraseExpiredAccepts(int blockNow);
+unsigned int eraseExpiredAccepts(int block);
 }
 
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1862,7 +1862,7 @@ int input_mp_offers_string(const std::string& s)
     // TODO: should this be here? There are usually no sanity checks..
     if (OMNI_PROPERTY_BTC != prop_desired) return -1;
 
-    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(sellerAddr);
+    const std::string combo = STR_SELLOFFER_ADDR_PROP_COMBO(sellerAddr, prop);
     CMPOffer newOffer(offerBlock, amountOriginal, prop, btcDesired, minFee, blocktimelimit, txid);
 
     if (!my_offers.insert(std::make_pair(combo, newOffer)).second) return -1;
@@ -1897,7 +1897,7 @@ int input_mp_accepts_string(const string &s)
   btcDesired = boost::lexical_cast<uint64_t>(vstr[i++]);
   txidStr = vstr[i++];
 
-  const string combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(sellerAddr, buyerAddr);
+  const string combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(sellerAddr, buyerAddr, prop);
   CMPAccept newAccept(amountOriginal, amountRemaining, nBlock, blocktimelimit, prop, offerOriginal, btcDesired, uint256(txidStr));
   if (my_accepts.insert(std::make_pair(combo, newAccept)).second) {
     return 0;
@@ -3242,7 +3242,7 @@ void CMPTxList::recordMetaDExCancelTX(const uint256 &txidMaster, const uint256 &
 
        // Step 4 - Write sub-record with cancel details
        const string txidStr = txidMaster.ToString() + "-C";
-       const string subKey = STR_REF_SUBKEY_TXID_REF_COMBO(txidStr);
+       const string subKey = STR_REF_SUBKEY_TXID_REF_COMBO(txidStr, refNumber);
        const string subValue = strprintf("%s:%d:%lu", txidSub.ToString(), propertyId, nValue);
        Status subStatus;
        PrintToLog("METADEXCANCELDEBUG : Writing sub-record %s with value %s\n", subKey, subValue);
@@ -3302,7 +3302,7 @@ void CMPTxList::recordPaymentTX(const uint256 &txid, bool fValid, int nBlock, un
 
        // Step 4 - Write sub-record with payment details
        const string txidStr = txid.ToString();
-       const string subKey = STR_PAYMENT_SUBKEY_TXID_PAYMENT_COMBO(txidStr);
+       const string subKey = STR_PAYMENT_SUBKEY_TXID_PAYMENT_COMBO(txidStr, paymentNumber);
        const string subValue = strprintf("%d:%s:%s:%d:%lu", vout, buyer, seller, propertyId, nValue);
        Status subStatus;
        PrintToLog("DEXPAYDEBUG : Writing sub-record %s with value %s\n", subKey, subValue);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -81,6 +81,7 @@ using leveldb::Iterator;
 using leveldb::Slice;
 using leveldb::Status;
 
+using std::endl;
 using std::make_pair;
 using std::map;
 using std::ofstream;


### PR DESCRIPTION
This PR is mostly cosmetic, and tackles the following points:

- Auto format code
- Add Doxygen compatible documentation
- Update argument names
- Replace \__FUNCTION__ with \__func__
- Specify namespaces explicitly
- Make tally updates only when they are expected to succeed
- Use assertions for all tally updates
- Replace boost::format with tinyformat (strprintf)
- Use correct, fixed size integers
- Refine log entires
- Wrap DEx related code with namespace
- Replace #defines for lookup keys with inline strings
- Extract calculation for DEx payments
- Extract calculation for DEx offer adjustment
- Add DEx_acceptExists() to check, if an accept order exists

Sorry for the huge line change; when stepping through commit by commit it should hopefully be possible to compare nearby lines.