### PR TITLE
Fix/add missing fields for transaction retrieval via RPC

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -219,6 +219,15 @@ std::string FormatMP(uint32_t property, int64_t n, bool fSign)
     }
 }
 
+std::string FormatByType(int64_t amount, uint16_t propertyType)
+{
+    if (propertyType & MSC_PROPERTY_TYPE_INDIVISIBLE) {
+        return FormatIndivisibleMP(amount);
+    } else {
+        return FormatDivisibleMP(amount);
+    }
+}
+
 OfferMap mastercore::my_offers;
 AcceptMap mastercore::my_accepts;
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -126,10 +126,11 @@ enum FILETYPES {
 #define OMNI_PROPERTY_TMSC  2
 
 // forward declarations
-std::string FormatDivisibleMP(int64_t n, bool fSign = false);
-std::string FormatDivisibleShortMP(int64_t);
-std::string FormatMP(uint32_t, int64_t n, bool fSign = false);
-std::string FormatShortMP(uint32_t, int64_t);
+std::string FormatDivisibleMP(int64_t amount, bool fSign = false);
+std::string FormatDivisibleShortMP(int64_t amount);
+std::string FormatMP(uint32_t propertyId, int64_t amount, bool fSign = false);
+std::string FormatShortMP(uint32_t propertyId, int64_t amount);
+std::string FormatByType(int64_t amount, uint16_t propertyType);
 bool feeCheck(const std::string& address, size_t nDataSize);
 
 /** Returns the Exodus address. */
@@ -299,7 +300,7 @@ CMPTally* getTally(const std::string& address);
 
 int64_t getTotalTokens(uint32_t propertyId, int64_t* n_owners_total = NULL);
 
-std::string c_strMasterProtocolTXType(uint16_t txType);
+std::string strTransactionType(uint16_t txType);
 
 /** Returns the encoding class, used to embed a payload. */
 int GetEncodingClass(const CTransaction& tx, int nBlock);

--- a/src/omnicore/pending.cpp
+++ b/src/omnicore/pending.cpp
@@ -62,10 +62,12 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, const st
         case MSC_TYPE_TRADE_OFFER:
             amountStr = FormatDivisibleMP(amount); // both amount for sale (either TMSC or MSC) and BTC desired are always divisible
             amountDStr = FormatDivisibleMP(amountDesired);
-            txobj.push_back(Pair("amountoffered", amountStr));
-            txobj.push_back(Pair("propertyidoffered", (uint64_t)propertyId));
-            txobj.push_back(Pair("btcamountdesired", amountDStr));
-            txobj.push_back(Pair("action", action));
+            txobj.push_back(Pair("propertyid", (uint64_t)propertyId));
+            txobj.push_back(Pair("amount", amountStr));
+            if (action == 1) txobj.push_back(Pair("action", "new"));
+            if (action == 2) txobj.push_back(Pair("action", "update"));
+            if (action == 3) txobj.push_back(Pair("action", "cancel"));
+            txobj.push_back(Pair("bitcoindesired", amountDStr));
         break;
         case MSC_TYPE_METADEX_TRADE:
         case MSC_TYPE_METADEX_CANCEL_PRICE:
@@ -73,12 +75,12 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, const st
             divisibleDesired = isPropertyDivisible(propertyIdDesired);
             if (divisible) { amountStr = FormatDivisibleMP(amount); } else { amountStr = FormatIndivisibleMP(amount); }
             if (divisibleDesired) { amountDStr = FormatDivisibleMP(amountDesired); } else { amountDStr = FormatIndivisibleMP(amountDesired); }
-            txobj.push_back(Pair("amountoffered", amountStr));
-            txobj.push_back(Pair("propertyidoffered", (uint64_t)propertyId));
-            txobj.push_back(Pair("propertyidofferedisdivisible", divisible));
-            txobj.push_back(Pair("amountdesired", amountDStr));
+            txobj.push_back(Pair("propertyidforsale", (uint64_t)propertyId));
+            txobj.push_back(Pair("propertyidforsaleisdivisible", divisible));
+            txobj.push_back(Pair("amountforsale", amountStr));
             txobj.push_back(Pair("propertyiddesired", (uint64_t)propertyIdDesired));
             txobj.push_back(Pair("propertyiddesiredisdivisible", divisibleDesired));
+            txobj.push_back(Pair("amountdesired", amountDStr));
             if ((propertyId == OMNI_PROPERTY_MSC) || (propertyId == OMNI_PROPERTY_TMSC)) {
                 tempUnitPrice = rational_t(amount, amountDesired);
                 if (!divisibleDesired) tempUnitPrice = tempUnitPrice/COIN;
@@ -89,14 +91,14 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, const st
             txobj.push_back(Pair("unitprice", xToString(tempUnitPrice)));
         break;
         case MSC_TYPE_METADEX_CANCEL_PAIR:
-            txobj.push_back(Pair("propertyidoffered", (uint64_t)propertyId));
+            txobj.push_back(Pair("propertyidforsale", (uint64_t)propertyId));
             txobj.push_back(Pair("propertyiddesired", (uint64_t)propertyIdDesired));
         break;
         case MSC_TYPE_METADEX_CANCEL_ECOSYSTEM:
             if (isMainEcosystemProperty(propertyId) && isMainEcosystemProperty(propertyIdDesired)) {
-                txobj.push_back(Pair("ecosystem", "Main"));
+                txobj.push_back(Pair("ecosystem", "main"));
             } else {
-                txobj.push_back(Pair("ecosystem", "Test"));
+                txobj.push_back(Pair("ecosystem", "test"));
             }
         break;
     }
@@ -105,7 +107,10 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, const st
                                         type, propertyId, amount, propertyIdDesired, amountDesired, action, txDesc);
 
     // bypass tally update for pending cancel as there is no balance change
-    if (type != MSC_TYPE_METADEX_CANCEL_PRICE && type != MSC_TYPE_METADEX_CANCEL_PAIR && type != MSC_TYPE_METADEX_CANCEL_ECOSYSTEM) {
+    if (!(type == MSC_TYPE_METADEX_CANCEL_PRICE) &&
+        !(type == MSC_TYPE_METADEX_CANCEL_PAIR) &&
+        !(type == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM) &&
+        !(type == MSC_TYPE_TRADE_OFFER && action == 3)) {
         if (!update_tally_map(sendingAddress, propertyId, -amount, PENDING)) {
             PrintToLog("ERROR - Update tally for pending failed! %s(%s,%s,%s,%d,%u,%ld,%u,%ld,%d,%s)\n", __FUNCTION__, txid.GetHex(),
                 sendingAddress, refAddress, type, propertyId, amount, propertyIdDesired, amountDesired, action, txDesc);

--- a/src/omnicore/pending.cpp
+++ b/src/omnicore/pending.cpp
@@ -43,7 +43,7 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, const st
     txobj.push_back(Pair("sendingaddress", sendingAddress));
     if (!refAddress.empty()) txobj.push_back(Pair("referenceaddress", refAddress));
     txobj.push_back(Pair("confirmations", 0));
-    txobj.push_back(Pair("type", c_strMasterProtocolTXType(type)));
+    txobj.push_back(Pair("type", strTransactionType(type)));
     switch (type) {
         case MSC_TYPE_SIMPLE_SEND:
             txobj.push_back(Pair("propertyid", (uint64_t)propertyId));

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -120,7 +120,7 @@ Value omni_senddexsell(const Array& params, bool fHelp)
     int64_t amountForSale = 0; // depending on action
     int64_t amountDesired = 0; // depending on action
     uint8_t paymentWindow = 0; // depending on action
-    int64_t minAcceptFee = ParseDExFee(params[5]);
+    int64_t minAcceptFee = 0;  // depending on action
     uint8_t action = ParseDExAction(params[6]);
 
     // perform conversions
@@ -128,6 +128,7 @@ Value omni_senddexsell(const Array& params, bool fHelp)
         amountForSale = ParseAmount(params[2], true); // TMSC/MSC is divisible
         amountDesired = ParseAmount(params[3], true); // BTC is divisible
         paymentWindow = ParseDExPaymentWindow(params[4]);
+        minAcceptFee = ParseDExFee(params[5]);
     }
 
     // perform checks

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -888,13 +888,22 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
     return how_many_erased;
 }
 
-const char* mastercore::c_strPropertyType(uint16_t propertyType)
+std::string mastercore::strPropertyType(uint16_t propertyType)
 {
     switch (propertyType) {
         case MSC_PROPERTY_TYPE_DIVISIBLE: return "divisible";
-        case MSC_PROPERTY_TYPE_INDIVISIBLE: return"indivisible";
+        case MSC_PROPERTY_TYPE_INDIVISIBLE: return "indivisible";
     }
 
-    return "*** property type error ***";
+    return "unknown";
 }
 
+std::string mastercore::strEcosystem(uint8_t ecosystem)
+{
+    switch (ecosystem) {
+        case OMNI_PROPERTY_MSC: return "main";
+        case OMNI_PROPERTY_TMSC: return "test";
+    }
+
+    return "unknown";
+}

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -209,7 +209,8 @@ typedef std::map<std::string, CMPCrowd> CrowdMap;
 extern CMPSPInfo* _my_sps;
 extern CrowdMap my_crowds;
 
-const char* c_strPropertyType(uint16_t propertyType);
+std::string strPropertyType(uint16_t propertyType);
+std::string strEcosystem(uint8_t ecosystem);
 
 std::string getPropertyName(uint32_t propertyId);
 bool isPropertyDivisible(uint32_t propertyId);

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -33,7 +33,7 @@ using boost::algorithm::token_compress_on;
 using namespace mastercore;
 
 /** Returns a label for the given transaction type. */
-std::string mastercore::c_strMasterProtocolTXType(uint16_t txType)
+std::string mastercore::strTransactionType(uint16_t txType)
 {
     switch (txType) {
         case MSC_TYPE_SIMPLE_SEND: return "Simple Send";
@@ -171,7 +171,7 @@ bool CMPTransaction::interpret_TransactionType()
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t------------------------------\n");
         PrintToLog("\t         version: %d, class %s\n", txVersion, intToClass(encodingClass));
-        PrintToLog("\t            type: %d (%s)\n", txType, c_strMasterProtocolTXType(txType));
+        PrintToLog("\t            type: %d (%s)\n", txType, strTransactionType(txType));
     }
 
     return true;
@@ -399,14 +399,14 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", ecosystem);
-        PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+        PrintToLog("\t   property type: %d (%s)\n", prop_type, strPropertyType(prop_type));
         PrintToLog("\tprev property id: %d\n", prev_prop_id);
         PrintToLog("\t        category: %s\n", category);
         PrintToLog("\t     subcategory: %s\n", subcategory);
         PrintToLog("\t            name: %s\n", name);
         PrintToLog("\t             url: %s\n", url);
         PrintToLog("\t            data: %s\n", data);
-        PrintToLog("\t           value: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
+        PrintToLog("\t           value: %s\n", FormatByType(nValue, prop_type));
     }
 
     if (isOverrun(p)) {
@@ -455,7 +455,7 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", ecosystem);
-        PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+        PrintToLog("\t   property type: %d (%s)\n", prop_type, strPropertyType(prop_type));
         PrintToLog("\tprev property id: %d\n", prev_prop_id);
         PrintToLog("\t        category: %s\n", category);
         PrintToLog("\t     subcategory: %s\n", subcategory);
@@ -463,7 +463,7 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
         PrintToLog("\t             url: %s\n", url);
         PrintToLog("\t            data: %s\n", data);
         PrintToLog("\tproperty desired: %d (%s)\n", property, strMPProperty(property));
-        PrintToLog("\t tokens per unit: %s\n", prop_type == 1 ? FormatIndivisibleMP(nValue) : FormatDivisibleMP(nValue));
+        PrintToLog("\t tokens per unit: %s\n", FormatByType(nValue, prop_type));
         PrintToLog("\t        deadline: %s (%x)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline), deadline);
         PrintToLog("\tearly bird bonus: %d\n", early_bird);
         PrintToLog("\t    issuer bonus: %d\n", percentage);
@@ -519,7 +519,7 @@ bool CMPTransaction::interpret_CreatePropertyManaged()
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", ecosystem);
-        PrintToLog("\t   property type: %d (%s)\n", prop_type, c_strPropertyType(prop_type));
+        PrintToLog("\t   property type: %d (%s)\n", prop_type, strPropertyType(prop_type));
         PrintToLog("\tprev property id: %d\n", prev_prop_id);
         PrintToLog("\t        category: %s\n", category);
         PrintToLog("\t     subcategory: %s\n", subcategory);

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -16,7 +16,7 @@ class CTransaction;
 #include <string.h>
 #include <string>
 
-using mastercore::c_strMasterProtocolTXType;
+using mastercore::strTransactionType;
 
 /** The class is responsible for transaction interpreting/parsing.
  *
@@ -161,7 +161,7 @@ public:
 
     uint256 getHash() const { return txid; }
     unsigned int getType() const { return type; }
-    std::string getTypeString() const { return c_strMasterProtocolTXType(getType()); }
+    std::string getTypeString() const { return strTransactionType(getType()); }
     unsigned int getProperty() const { return property; }
     unsigned short getVersion() const { return version; }
     unsigned short getPropertyType() const { return prop_type; }
@@ -171,7 +171,16 @@ public:
     std::string getPayload() const { return HexStr(pkt, pkt + pkt_size); }
     uint64_t getAmount() const { return nValue; }
     uint64_t getNewAmount() const { return nNewValue; }
+    uint8_t getEcosystem() const { return ecosystem; }
+    uint32_t getPreviousId() const { return prev_prop_id; }
+    std::string getSPCategory() const { return category; }
+    std::string getSPSubCategory() const { return subcategory; }
     std::string getSPName() const { return name; }
+    std::string getSPUrl() const { return url; }
+    std::string getSPData() const { return data; }
+    int64_t getDeadline() const { return deadline; }
+    uint8_t getEarlyBirdBonus() const { return early_bird; }
+    uint8_t getIssuerBonus() const { return percentage; }
     std::string getAlertString() const { return alertString; }
     bool isRpcOnly() const { return rpcOnly; }
     int getEncodingClass() const { return encodingClass; }


### PR DESCRIPTION
- The field labels based on the CMPPending objects were  different than the ones generated by the populateRPC__() functions. The field names of the confirmed transaction objects was adopted.

- Not all stateless fields that can be returned were returned for confirmed transactions.

This PR resolves #170.