### PR TITLE
Add RPC support for unconfrimed Omni transactions

### DIFF
--- a/src/omnicore/pending.h
+++ b/src/omnicore/pending.h
@@ -20,7 +20,7 @@ extern CCriticalSection cs_pending;
 extern PendingMap my_pending;
 
 /** Adds a transaction to the pending map using supplied parameters. */
-void PendingAdd(const uint256& txid, const std::string& sendingAddress, const std::string& refAddress, uint16_t type, uint32_t propertyId, int64_t amount, uint32_t propertyIdDesired = 0, int64_t amountDesired = 0, int64_t action = 0);
+void PendingAdd(const uint256& txid, const std::string& sendingAddress, uint16_t type, uint32_t propertyId, int64_t amount, bool fSubtract = true);
 
 /** Deletes a transaction from the pending map and credits the amount back to the pending tally for the address. */
 void PendingDelete(const uint256& txid);
@@ -34,7 +34,6 @@ struct CMPPending
     uint32_t prop;
     int64_t amount;
     uint32_t type;
-    std::string desc; // the description
 
     /** Default constructor. */
     CMPPending() : prop(0), amount(0), type(0) {};

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -81,7 +81,7 @@ Value omni_send(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            PendingAdd(txid, fromAddress, toAddress, MSC_TYPE_SIMPLE_SEND, propertyId, amount);
+            PendingAdd(txid, fromAddress, MSC_TYPE_SIMPLE_SEND, propertyId, amount);
             return txid.GetHex();
         }
     }
@@ -170,7 +170,8 @@ Value omni_senddexsell(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_TRADE_OFFER, propertyIdForSale, amountForSale, 0, amountDesired, action);
+            bool fSubtract = (action <= CMPTransaction::UPDATE); // no pending balances for cancels
+            PendingAdd(txid, fromAddress, MSC_TYPE_TRADE_OFFER, propertyIdForSale, amountForSale, fSubtract);
             return txid.GetHex();
         }
     }
@@ -502,7 +503,7 @@ Value omni_sendsto(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_SEND_TO_OWNERS, propertyId, amount);
+            PendingAdd(txid, fromAddress, MSC_TYPE_SEND_TO_OWNERS, propertyId, amount);
             return txid.GetHex();
         }
     }
@@ -786,7 +787,7 @@ Value omni_sendtrade(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_TRADE, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, CMPTransaction::ADD);
+            PendingAdd(txid, fromAddress, MSC_TYPE_METADEX_TRADE, propertyIdForSale, amountForSale);
             return txid.GetHex();
         }
     }
@@ -845,7 +846,7 @@ Value omni_sendcanceltradesbyprice(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_PRICE, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, CMPTransaction::CANCEL_AT_PRICE);
+            PendingAdd(txid, fromAddress, MSC_TYPE_METADEX_CANCEL_PRICE, propertyIdForSale, amountForSale, false);
             return txid.GetHex();
         }
     }
@@ -900,7 +901,7 @@ Value omni_sendcanceltradesbypair(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_PAIR, propertyIdForSale, 0, propertyIdDesired, 0, CMPTransaction::CANCEL_ALL_FOR_PAIR);
+            PendingAdd(txid, fromAddress, MSC_TYPE_METADEX_CANCEL_PAIR, propertyIdForSale, 0, false);
             return txid.GetHex();
         }
     }
@@ -949,7 +950,7 @@ Value omni_sendcancelalltrades(const Array& params, bool fHelp)
         if (!autoCommit) {
             return rawHex;
         } else {
-            PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_ECOSYSTEM, ecosystem, 0, ecosystem, 0, CMPTransaction::CANCEL_EVERYTHING);
+            PendingAdd(txid, fromAddress, MSC_TYPE_METADEX_CANCEL_ECOSYSTEM, ecosystem, 0, false);
             return txid.GetHex();
         }
     }

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -43,20 +43,6 @@ int populateRPCTransactionObject(const uint256& txid, Object& txobj, std::string
     uint256 blockHash;
     if (!GetTransaction(txid, wtx, blockHash, true)) return MP_TX_NOT_FOUND;
 
-    if (0 == blockHash) {
-        // is it one of our pending transactions?  if so return pending description
-        LOCK(cs_pending);
-        PendingMap::iterator it = my_pending.find(txid);
-        if (it != my_pending.end()) {
-            const CMPPending& pending = it->second;
-            if (!filterAddress.empty() && pending.src != filterAddress) return -1;
-            Value tempVal;
-            json_spirit::read_string(pending.desc, tempVal);
-            txobj = tempVal.get_obj();
-            return 0;
-        }
-    }
-
     int confirmations = 0;
     int64_t blockTime = 0;
     int blockHeight = GetHeight();

--- a/src/qt/metadexcanceldialog.cpp
+++ b/src/qt/metadexcanceldialog.cpp
@@ -371,9 +371,9 @@ void MetaDExCancelDialog::SendCancelTransaction()
         if (!autoCommit) {
             PopulateSimpleDialog(rawHex, "Raw Hex (auto commit is disabled)", "Raw transaction hex");
         } else {
-            if (action == 2) PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_PRICE, propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, 0);
-            if (action == 3) PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_PAIR, propertyIdForSale, 0, propertyIdDesired, 0, 0);
-            if (action == 4) PendingAdd(txid, fromAddress, "", MSC_TYPE_METADEX_CANCEL_ECOSYSTEM, propertyIdForSale, 0, propertyIdDesired, 0, 0);
+            if (action == 2) PendingAdd(txid, fromAddress, MSC_TYPE_METADEX_CANCEL_PRICE, propertyIdForSale, amountForSale, false);
+            if (action == 3) PendingAdd(txid, fromAddress, MSC_TYPE_METADEX_CANCEL_PAIR, propertyIdForSale, 0, false);
+            if (action == 4) PendingAdd(txid, fromAddress, MSC_TYPE_METADEX_CANCEL_ECOSYSTEM, propertyIdForSale, 0, false);
             PopulateTXSentDialog(txid.GetHex());
         }
     }

--- a/src/qt/metadexdialog.cpp
+++ b/src/qt/metadexdialog.cpp
@@ -695,7 +695,7 @@ void MetaDExDialog::sendTrade(bool sell)
         if (!autoCommit) {
             PopulateSimpleDialog(rawHex, "Raw Hex (auto commit is disabled)", "Raw transaction hex");
         } else {
-            PendingAdd(txid, strFromAddress, "", MSC_TYPE_METADEX_TRADE, propertyIdSell, amountSell, propertyIdDes, amountDes, 1);
+            PendingAdd(txid, strFromAddress, MSC_TYPE_METADEX_TRADE, propertyIdSell, amountSell);
             PopulateTXSentDialog(txid.GetHex());
         }
     }

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -329,7 +329,7 @@ void SendMPDialog::sendMPTransaction()
         if (!autoCommit) {
             PopulateSimpleDialog(rawHex, "Raw Hex (auto commit is disabled)", "Raw transaction hex");
         } else {
-            PendingAdd(txid, fromAddress.ToString(), refAddress.ToString(), MSC_TYPE_SIMPLE_SEND, propertyId, sendAmount);
+            PendingAdd(txid, fromAddress.ToString(), MSC_TYPE_SIMPLE_SEND, propertyId, sendAmount);
             PopulateTXSentDialog(txid.GetHex());
         }
     }

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -565,22 +565,10 @@ void TradeHistoryDialog::showDetails()
     txid.SetHex(ui->tradeHistoryTable->item(ui->tradeHistoryTable->currentRow(),0)->text().toStdString());
     std::string strTXText;
 
-    // first of all check if the TX is a pending tx, if so grab details from pending map
-    bool fPending = false;
-    {
-        LOCK(cs_pending);
-
-        PendingMap::iterator it = my_pending.find(txid);
-        if (it != my_pending.end()) {
-            CMPPending *p_pending = &(it->second);
-            strTXText = "*** THIS TRANSACTION IS UNCONFIRMED ***\n" + p_pending->desc;
-            fPending = true;
-        }
-    }
-
-    if (!fPending) {
-        int pop = populateRPCTransactionObject(txid, txobj, "", true);
-        if (0<=pop) strTXText = write_string(Value(txobj), true);
+    if (txid != 0) {
+        // grab extended trade details via the RPC populator
+        int rc = populateRPCTransactionObject(txid, txobj, "", true);
+        if (rc >= 0) strTXText = json_spirit::write_string(Value(txobj), true);
     }
 
     if (!strTXText.empty()) {

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -476,23 +476,10 @@ void TXHistoryDialog::showDetails()
     txid.SetHex(ui->txHistoryTable->item(ui->txHistoryTable->currentRow(),0)->text().toStdString());
     std::string strTXText;
 
-    // first of all check if the TX is a pending tx, if so grab details from pending map
-    bool fPending = false;
-    {
-        LOCK(cs_pending);
-
-        PendingMap::iterator it = my_pending.find(txid);
-        if (it != my_pending.end()) {
-            CMPPending *p_pending = &(it->second);
-            strTXText = "*** THIS TRANSACTION IS UNCONFIRMED ***\n" + p_pending->desc;
-            fPending = true;
-        }
-    }
-
-    if (!fPending) {
-        // otherwise grab details via the RPC populator
-        int pop = populateRPCTransactionObject(txid, txobj, "", true);
-        if (0<=pop) strTXText = write_string(Value(txobj), true);
+    if (txid != 0) {
+        // grab extended transaction details via the RPC populator
+        int rc = populateRPCTransactionObject(txid, txobj, "", true);
+        if (rc >= 0) strTXText = json_spirit::write_string(Value(txobj), true);
     }
 
     if (!strTXText.empty()) {


### PR DESCRIPTION
This PR adds support for unconfirmed transactions via RPC, as well as for the transaction details shown in the UI, when clicking on a pending transaction or trade.

The base fields were slightly reordered, to group related values, and the fields `"blockhash"` and `"block"` were added.

Only if a transaction is confirmed, the fields `"valid"`, `"blockhash"`, `"blocktime"` and `"block"` are included. Unconfrimed DEx payments are rejected, indicating that the transaction is unconfrimed. Because the effect on the global state is only avaiable for confirmed transactions, the extended mode, which is usually interacting with global state, is downgraded to basic mode, if the transaction is unconfirmed. This has an impact on `"omni_getsto"` or `"omni_gettrade"`, but in any case, the basic mode also returns at least the information that would be available via the pending map.

Because the data can now directly be retrieved, there is no longer need to fetch pending transactions from the pending map, which allows to remove the description of pending transaction objects.

The PR resolves #171 for the most part.