### PR TITLE
Add minimum client version to feature activation

### DIFF
--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -379,7 +379,7 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosyste
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock)
+std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock, uint32_t minClientVersion)
 {
     std::vector<unsigned char> payload;
 
@@ -390,11 +390,13 @@ std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uin
     mastercore::swapByteOrder16(messageType);
     mastercore::swapByteOrder16(featureId);
     mastercore::swapByteOrder32(activationBlock);
+    mastercore::swapByteOrder32(minClientVersion);
 
     PUSH_BACK_BYTES(payload, messageVer);
     PUSH_BACK_BYTES(payload, messageType);
     PUSH_BACK_BYTES(payload, featureId);
     PUSH_BACK_BYTES(payload, activationBlock);
+    PUSH_BACK_BYTES(payload, minClientVersion);
 
     return payload;
 }

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -24,7 +24,7 @@ std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale
 std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired);
 std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdForSale, uint32_t propertyIdDesired);
 std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem);
-std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock);
+std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock, uint32_t minClientVersion);
 std::vector<unsigned char> CreatePayload_OmniCoreAlert(int32_t alertType, uint64_t expiryValue, uint32_t typeCheck, uint32_t verCheck, const std::string& alertMessage);
 
 

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -1008,7 +1008,7 @@ Value omni_sendchangeissuer(const Array& params, bool fHelp)
 
 Value omni_sendactivation(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 3)
+    if (fHelp || params.size() != 4)
         throw runtime_error(
             "omni_sendactivation \"fromaddress\" featureid block\n"
             "\nActivate a protocol feature.\n"
@@ -1017,20 +1017,22 @@ Value omni_sendactivation(const Array& params, bool fHelp)
             "1. fromaddress          (string, required) the address to send from\n"
             "2. featureid            (number, required) the identifier of the feature to activate\n"
             "3. block                (number, required) the activation block\n"
+            "4. minclientversion     (number, required) the minimum supported client version\n"
             "\nResult:\n"
             "\"hash\"                  (string) the hex-encoded transaction hash\n"
             "\nExamples:\n"
-            + HelpExampleCli("omni_sendactivation", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\" 1 370000")
-            + HelpExampleRpc("omni_sendactivation", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\", 1, 370000")
+            + HelpExampleCli("omni_sendactivation", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\" 1 370000 999")
+            + HelpExampleRpc("omni_sendactivation", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\", 1, 370000, 999")
         );
 
     // obtain parameters & info
     std::string fromAddress = ParseAddress(params[0]);
     uint16_t featureId = params[1].get_uint64();
     uint32_t activationBlock = params[2].get_uint64();
+    uint32_t minClientVersion = params[3].get_uint64();
 
     // create a payload for the transaction
-    std::vector<unsigned char> payload = CreatePayload_ActivateFeature(featureId, activationBlock);
+    std::vector<unsigned char> payload = CreatePayload_ActivateFeature(featureId, activationBlock, minClientVersion);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -9,6 +9,7 @@
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/utilsbitcoin.h"
+#include "omnicore/version.h"
 
 #include "chainparams.h"
 #include "script/standard.h"
@@ -160,7 +161,7 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     LAST_EXODUS_BLOCK = std::numeric_limits<int>::max();
     // Notice range for feature activations:
     MIN_ACTIVATION_BLOCKS = 0;
-    MAX_ACTIVATION_BLOCKS = std::numeric_limits<int>::max();
+    MAX_ACTIVATION_BLOCKS = 999999;
     // Script related:
     PUBKEYHASH_BLOCK = 0;
     SCRIPTHASH_BLOCK = 0;
@@ -308,7 +309,7 @@ bool IsAllowedOutputType(int whichType, int nBlock)
  *       than 12288 blocks (roughly 12 weeks) to ensure sufficient notice.
  *       This does not apply for activation during initialization (where loadingActivations is set true).
  */
-bool ActivateFeature(uint16_t featureId, int activationBlock, int transactionBlock)
+bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClientVersion, int transactionBlock)
 {
     PrintToLog("Feature activation requested (ID %d to go active as of block: %d)\n", featureId, activationBlock);
 
@@ -318,6 +319,13 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, int transactionBlo
     if ((activationBlock < (transactionBlock + params.MIN_ACTIVATION_BLOCKS)) ||
         (activationBlock > (transactionBlock + params.MAX_ACTIVATION_BLOCKS))) {
         PrintToLog("Feature activation of ID %d refused due to notice checks\n", featureId);
+        return false;
+    }
+
+    // check if client version is high enough
+    if (OMNICORE_VERSION < minClientVersion) {
+        PrintToLog("Feature activation of ID %d refused due to unsupported client (current: %d, needed: %d)\n", featureId, OMNICORE_VERSION, minClientVersion);
+        PrintToLog("WARNING!!! AS OF BLOCK %d THIS CLIENT WILL BE OUT OF CONSENSUS AND WILL AUTOMATICALLY SHUTDOWN.\n", activationBlock);
         return false;
     }
 

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -158,7 +158,7 @@ const CConsensusParams& ConsensusParams();
 CConsensusParams& MutableConsensusParams();
 
 /** Activates a feature at a specific block height. */
-bool ActivateFeature(uint16_t featureId, int activationBlock, int transactionBlock);
+bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClientVersion, int transactionBlock);
 /** Checks, whether a feature is activated at the given block. */
 bool IsFeatureActivated(uint16_t featureId, int transactionBlock);
 

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -363,14 +363,13 @@ BOOST_AUTO_TEST_CASE(payload_change_property_manager)
 
 BOOST_AUTO_TEST_CASE(payload_feature_activation)
 {
-/*
     // Omni Core feature activation [type 65534, version 65535]
     std::vector<unsigned char> vch = CreatePayload_ActivateFeature(
         static_cast<uint16_t>(1),        // feature identifier: 1 (OP_RETURN)
-        static_cast<uint32_t>(370000));  // activation block
+        static_cast<uint32_t>(370000),   // activation block
+        static_cast<uint32_t>(999));     // min client version
 
-    BOOST_CHECK_EQUAL(HexStr(vch), "fffffffe00010005a550");
-*/
+    BOOST_CHECK_EQUAL(HexStr(vch), "fffffffe00010005a550000003e7");
 }
 
 BOOST_AUTO_TEST_CASE(payload_omnicore_alert)

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -363,12 +363,14 @@ BOOST_AUTO_TEST_CASE(payload_change_property_manager)
 
 BOOST_AUTO_TEST_CASE(payload_feature_activation)
 {
+/*
     // Omni Core feature activation [type 65534, version 65535]
     std::vector<unsigned char> vch = CreatePayload_ActivateFeature(
         static_cast<uint16_t>(1),        // feature identifier: 1 (OP_RETURN)
         static_cast<uint32_t>(370000));  // activation block
 
     BOOST_CHECK_EQUAL(HexStr(vch), "fffffffe00010005a550");
+*/
 }
 
 BOOST_AUTO_TEST_CASE(payload_omnicore_alert)

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -591,17 +591,20 @@ bool CMPTransaction::interpret_ChangeIssuer()
 /** Tx 65534 */
 bool CMPTransaction::interpret_Activation()
 {
-    if (pkt_size < 10) {
+    if (pkt_size < 14) {
         return false;
     }
     memcpy(&feature_id, &pkt[4], 2);
     swapByteOrder16(feature_id);
     memcpy(&activation_block, &pkt[6], 4);
     swapByteOrder32(activation_block);
+    memcpy(&min_client_version, &pkt[10], 4);
+    swapByteOrder32(min_client_version);
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t      feature id: %d\n", feature_id);
         PrintToLog("\tactivation block: %d\n", activation_block);
+        PrintToLog("\t minimum version: %d\n", min_client_version);
     }
 
     return true;
@@ -1803,7 +1806,7 @@ int CMPTransaction::logicMath_Activation()
     }
 
     // authorized, request feature activation
-    bool activationSuccess = ActivateFeature(feature_id, activation_block, block);
+    bool activationSuccess = ActivateFeature(feature_id, activation_block, min_client_version, block);
 
     if (!activationSuccess) {
         PrintToLog("%s(): ActivateFeature failed to activate this feature\n", __func__);

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -86,6 +86,7 @@ private:
     // Activation
     uint16_t feature_id;
     uint32_t activation_block;
+    uint32_t min_client_version;
 
     // Indicates whether the transaction can be used to execute logic
     bool rpcOnly;
@@ -219,6 +220,9 @@ public:
         subaction = 0;
         memset(&alertString, 0, sizeof(alertString));
         rpcOnly = true;
+        feature_id = 0;
+        activation_block = 0;
+        min_client_version = 0;
     }
 
     /** Sets the given values. */

--- a/src/omnicore/version.h
+++ b/src/omnicore/version.h
@@ -40,12 +40,13 @@
 #include <string>
 
 //! Omni Core client version
-static const int OMNICORE_VERSION =
+static const int OMNICORE_VERSION = 998;
+/*
                      +  100000000 * OMNICORE_VERSION_MILESTONE
                      +     100000 * OMNICORE_VERSION_MAJOR
                      +        100 * OMNICORE_VERSION_MINOR
                      +          1 * OMNICORE_VERSION_PATCH;
-
+*/
 //! Returns formatted Omni Core version, e.g. "0.0.9.1-dev"
 const std::string OmniCoreVersion();
 

--- a/src/omnicore/version.h
+++ b/src/omnicore/version.h
@@ -40,13 +40,12 @@
 #include <string>
 
 //! Omni Core client version
-static const int OMNICORE_VERSION = 998;
-/*
+static const int OMNICORE_VERSION =
                      +  100000000 * OMNICORE_VERSION_MILESTONE
                      +     100000 * OMNICORE_VERSION_MAJOR
                      +        100 * OMNICORE_VERSION_MINOR
                      +          1 * OMNICORE_VERSION_PATCH;
-*/
+
 //! Returns formatted Omni Core version, e.g. "0.0.9.1-dev"
 const std::string OmniCoreVersion();
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -164,6 +164,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendchangeissuer", 2 },
     { "omni_sendactivation", 1 },
     { "omni_sendactivation", 2 },
+    { "omni_sendactivation", 3 },
     { "omni_sendalert", 1 },
     { "omni_sendalert", 2 },
     { "omni_sendalert", 3 },


### PR DESCRIPTION
Hopefully uncontroversial change to feature activations.

Basically we need to nominate a minimum supported client version within the activation message, as clients may be aware of a feature before they fully support the correct implementation.

For example:

Client 0.10.x knows about feature id 2 (betting) and has no implementation
Client 0.11.0 knows about feature id 2 (betting) and has basic implementation
Client 0.11.1 knows about feature id 2 (betting) and has an improved implementation
Client 0.11.2 knows about feature id 2 (betting) and has some bug fixes to betting
Client 0.11.3 knows about feature id 2 (betting) and has the "final" implementation prior to betting go live

If we just activate as per current, all these clients will go active and have differing interpretations of the state due to differening betting code (ie, out of consensus).

The only way I can see to address this is to embed an Omni Core version in the activation, such that (in the example) only 0.11.3+ clients would be activated and older would be forced to update.

I've done this as a standalone PR in case there are objections, but really it's to go hand in hand with the work I'm doing on alerts as feature activation will integrate there.

