### PR TITLE
Fix Omni transaction count value passed into block end handler

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1812,6 +1812,7 @@ static int msc_initial_scan(int nFirstBlock)
         }
 
         unsigned int nTxNum = 0;
+        uint32_t nBlockFound = 0;
         mastercore_handler_block_begin(nBlock, pblockindex);
 
         if (!seedBlockFilterEnabled || !SkipBlock(nBlock)) {
@@ -1819,13 +1820,14 @@ static int msc_initial_scan(int nFirstBlock)
             if (!ReadBlockFromDisk(block, pblockindex)) break;
 
             BOOST_FOREACH(const CTransaction&tx, block.vtx) {
-                if (mastercore_handler_tx(tx, nBlock, nTxNum, pblockindex)) ++nFound;
+                if (mastercore_handler_tx(tx, nBlock, nTxNum, pblockindex)) ++nBlockFound;
                 ++nTxNum;
             }
         }
 
+        nFound += nBlockFound;
         nTotal += nTxNum;
-        mastercore_handler_block_end(nBlock, pblockindex, nFound);
+        mastercore_handler_block_end(nBlock, pblockindex, nBlockFound);
     }
 
     if (nBlock < nLastBlock) {


### PR DESCRIPTION
Note: Instead of passing the number of Omni transactions in the block to the block end handler, ```msc_initial_scan``` passes in ```nFound``` which is a cumulative total of the number of transactions found during the entire scan, not the number of transactions found in that particular block.  

Thus the block end handler gets a positive value for the number of Omni transactions in each block regardless of whether there actually were any.  

This causes any actions that should only be executed on Omni containing blocks (such as wallet cache checks) to instead be executed every block.