### PR TITLE
Automate state refresh on client version change when needed

### DIFF
--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -36,6 +36,9 @@ int const MAX_STATE_HISTORY = 50;
 
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 
+// increment this value to force a refresh of the state (similar to --startclean)
+#define DB_VERSION 1
+
 // could probably also use: int64_t maxInt64 = std::numeric_limits<int64_t>::max();
 // maximum numeric values from the spec:
 #define MAX_INT_8_BYTES (9223372036854775807UL)
@@ -228,6 +231,9 @@ public:
     bool getPurchaseDetails(const uint256 txid, int purchaseNumber, string *buyer, string *seller, uint64_t *vout, uint64_t *propertyId, uint64_t *nValue);
     int getMPTransactionCountTotal();
     int getMPTransactionCountBlock(int block);
+
+    int getDBVersion();
+    int setDBVersion();
 
     bool exists(const uint256 &txid);
     bool getTX(const uint256 &txid, string &value);

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -90,6 +90,14 @@ CMPSPInfo::~CMPSPInfo()
     if (msc_debug_persistence) PrintToLog("CMPSPInfo closed\n");
 }
 
+void CMPSPInfo::Clear()
+{
+    // wipe database via parent class
+    CDBBase::Clear();
+    // reset "next property identifiers"
+    init();
+}
+
 void CMPSPInfo::init(uint32_t nextSPID, uint32_t nextTestSPID)
 {
     next_spid = nextSPID;

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -140,6 +140,9 @@ public:
     CMPSPInfo(const boost::filesystem::path& path, bool fWipe);
     virtual ~CMPSPInfo();
 
+    /** Extends clearing of CDBBase. */
+    void Clear();
+
     void init(uint32_t nextSPID = 0x3UL, uint32_t nextTestSPID = TEST_ECO_PROPERTY_1);
 
     uint32_t peekNextSPID(uint8_t ecosystem) const;


### PR DESCRIPTION
Note: increment DB_VERSION definition along with changes that require repopulating databases (reparsing) to ensure clients only use a database compatible with their codebase.