### PR TITLE
Refine amount recalculations of traditional DEx via RPC

### DIFF
--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -110,11 +110,17 @@ static int64_t calculateDesiredBTC(const int64_t amountOffered, const int64_t am
 }
 
 /**
- * Determines adjusted amount desired, in case it needs to be recalculated.
- * @return The new number of tokens
+ * Determines the amount of bitcoins desired, in case it needs to be recalculated.
+ *
+ * TODO: use plain integers, don't expose it!
+ * @return The amount of bitcoins desired
  */
-static int64_t adjustDExOffer(const int64_t amountOffered, const int64_t amountDesired, const int64_t amountAvailable)
+int64_t calculateDesiredBTC(const int64_t amountOffered, const int64_t amountDesired, const int64_t amountAvailable)
 {
+    if (amountOffered == 0) {
+        return 0; // divide by null protection
+    }
+
     return legacy::calculateDesiredBTC(amountOffered, amountDesired, amountAvailable);
 }
 
@@ -152,8 +158,7 @@ int DEx_offerCreate(const std::string& addressSeller, uint32_t propertyId, int64
                         FormatDivisibleMP(balanceReallyAvailable), strMPProperty(propertyId));
 
         // AND we must also re-adjust the BTC desired in this case...
-        // TODO: no floating numbers
-        amountDesired = adjustDExOffer(amountOffered, amountDesired, balanceReallyAvailable);
+        amountDesired = calculateDesiredBTC(amountOffered, amountDesired, balanceReallyAvailable);
         amountOffered = balanceReallyAvailable;
         if (nAmended) *nAmended = amountOffered;
 

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -133,8 +133,8 @@ public:
     // TODO: it may not intuitive that this is *not* the hash of the accept order
     uint256 getHash() const { return offer_txid; }
 
-    int64_t getOfferAmountOriginal() { return offer_amount_original; }
-    int64_t getBTCDesiredOriginal() { return BTC_desired_original; }
+    int64_t getOfferAmountOriginal() const { return offer_amount_original; }
+    int64_t getBTCDesiredOriginal() const { return BTC_desired_original; }
 
     uint8_t getBlockTimeLimit() const { return blocktimelimit; }
     uint32_t getProperty() const { return property; }
@@ -222,6 +222,9 @@ typedef std::map<std::string, CMPAccept> AcceptMap;
 
 extern OfferMap my_offers;
 extern AcceptMap my_accepts;
+
+/** Determines the amount of bitcoins desired, in case it needs to be recalculated. TODO: don't expose! */
+int64_t calculateDesiredBTC(const int64_t amountOffered, const int64_t amountDesired, const int64_t amountAvailable);
 
 bool DEx_offerExists(const std::string& addressSeller, uint32_t propertyId);
 CMPOffer* DEx_getOffer(const std::string& addressSeller, uint32_t propertyId);


### PR DESCRIPTION
The original DEx calculations of Master Core 0.0.9 were restored, which seems safer, if we consider all aspects and mirror it to 100 %.

As temporary solution the core calculation is exposed, so it can be used in other places. The additional "divide by zero" protection was added, because the function is now exposed.

When using `"omni_gettransaction"` in combination with a DEx sell offer, which was adjusted, because the seller offered more than available, then the amounts returned via RPC reflect the adjustment properly, and it's no longer one sided, i.e. previously only the amount for sale was adjusted, but not the desired amount. This resolves #188.

The use of `{ }` solely serves as hint, to point out that these parts shouldn't be done on the RPC layer.

More information is returned for active accept orders on the traditional DEx, when using `"omni_getactivedexsells"`. It also replaces the amount recalculations with the original function that is also used for the core logic.