### PR TITLE
Do not invalidate MetaDEx cancels if they don't match any open trades

### DIFF
--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -495,6 +495,11 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
 
     int numCancelled = 0;
 
+    if (!prices) {
+        PrintToLog("%s(): FOUND 0 MATCHING TRADES (no active trades selling property %d).\n", __FUNCTION__, prop);
+        return 0; // cancels do not require matching trades to be valid
+    }
+
     // within the desired property map (given one property) iterate over the items
     for (md_PricesMap::iterator my_it = prices->begin(); my_it != prices->end(); ++my_it) {
         rational_t sellers_price = my_it->first;
@@ -549,6 +554,11 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
     if (msc_debug_metadex3) MetaDEx_debug_print();
 
     int numCancelled = 0;
+
+    if (!prices) {
+        PrintToLog("%s(): FOUND 0 MATCHING TRADES (no active trades selling property %d).\n", __FUNCTION__, prop);
+        return 0; // cancels do not require matching trades to be valid
+    }
 
     // within the desired property map (given one property) iterate over the items
     for (md_PricesMap::iterator my_it = prices->begin(); my_it != prices->end(); ++my_it) {

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -493,10 +493,7 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
 
     if (msc_debug_metadex2) MetaDEx_debug_print();
 
-    if (!prices) {
-        PrintToLog("%s() NOTHING FOUND for %s\n", __FUNCTION__, mdex.ToString());
-        return rc -1;
-    }
+    int numCancelled = 0;
 
     // within the desired property map (given one property) iterate over the items
     for (md_PricesMap::iterator my_it = prices->begin(); my_it != prices->end(); ++my_it) {
@@ -516,7 +513,6 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
                 continue;
             }
 
-            rc = 0;
             PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
 
             // move from reserve to main
@@ -528,10 +524,16 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
             p_txlistdb->recordMetaDExCancelTX(txid, p_mdex->getHash(), bValid, block, p_mdex->getProperty(), p_mdex->getAmountRemaining());
 
             indexes->erase(iitt++);
+            numCancelled++;
         }
     }
 
-    if (msc_debug_metadex2) MetaDEx_debug_print();
+    PrintToLog("%s(): FOUND %d MATCHING TRADES.\n", __FUNCTION__, numCancelled);
+    rc = 0; // cancels do not require matching trades to be valid
+
+    if (numCancelled) {
+        if (msc_debug_metadex2) MetaDEx_debug_print();
+    }
 
     return rc;
 }
@@ -546,10 +548,7 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
 
     if (msc_debug_metadex3) MetaDEx_debug_print();
 
-    if (!prices) {
-        PrintToLog("%s() NOTHING FOUND\n", __FUNCTION__);
-        return rc -1;
-    }
+    int numCancelled = 0;
 
     // within the desired property map (given one property) iterate over the items
     for (md_PricesMap::iterator my_it = prices->begin(); my_it != prices->end(); ++my_it) {
@@ -565,7 +564,6 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
                 continue;
             }
 
-            rc = 0;
             PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
 
             // move from reserve to main
@@ -577,10 +575,16 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
             p_txlistdb->recordMetaDExCancelTX(txid, p_mdex->getHash(), bValid, block, p_mdex->getProperty(), p_mdex->getAmountRemaining());
 
             indexes->erase(iitt++);
+            numCancelled++;
         }
     }
 
-    if (msc_debug_metadex3) MetaDEx_debug_print();
+    PrintToLog("%s(): FOUND %d MATCHING TRADES.\n", __FUNCTION__, numCancelled);
+    rc = 0; // cancels do not require matching trades to be valid
+
+    if (numCancelled) {
+        if (msc_debug_metadex3) MetaDEx_debug_print();
+    }
 
     return rc;
 }
@@ -595,6 +599,8 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
     PrintToLog("%s()\n", __FUNCTION__);
 
     if (msc_debug_metadex2) MetaDEx_debug_print();
+
+    int numCancelled = 0;
 
     PrintToLog("<<<<<<\n");
 
@@ -622,7 +628,6 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
                     continue;
                 }
 
-                rc = 0;
                 PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, it->ToString());
 
                 // move from reserve to balance
@@ -634,12 +639,18 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
                 p_txlistdb->recordMetaDExCancelTX(txid, it->getHash(), bValid, block, it->getProperty(), it->getAmountRemaining());
 
                 indexes.erase(it++);
+                numCancelled++;
             }
         }
     }
     PrintToLog(">>>>>>\n");
 
-    if (msc_debug_metadex2) MetaDEx_debug_print();
+    PrintToLog("%s(): FOUND %d MATCHING TRADES.\n", __FUNCTION__, numCancelled);
+    rc = 0; // cancels do not require matching trades to be valid
+
+    if (numCancelled) {
+        if (msc_debug_metadex2) MetaDEx_debug_print();
+    }
 
     return rc;
 }


### PR DESCRIPTION
This PR serves to remove the invalidation of MetaDEx cancels if the values provided in the packet are valid but do not result in any matches for open trades to cancel.