### PR TITLE
Minor cleanup of MetaDEx status and RPC output

### DIFF
--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -735,3 +735,21 @@ void mastercore::MetaDEx_debug_print(bool bShowPriceLevel, bool bDisplay)
     }
     PrintToLog(">>>\n");
 }
+
+/**
+ * Locates a trade in the MetaDEx maps via txid and returns the trade object
+ *
+ */
+const CMPMetaDEx* mastercore::MetaDEx_RetrieveTrade(const uint256& txid)
+{
+    for (md_PropertiesMap::iterator propIter = metadex.begin(); propIter != metadex.end(); ++propIter) {
+        md_PricesMap & prices = propIter->second;
+        for (md_PricesMap::iterator pricesIter = prices.begin(); pricesIter != prices.end(); ++pricesIter) {
+            md_Set & indexes = pricesIter->second;
+            for (md_Set::iterator tradesIter = indexes.begin(); tradesIter != indexes.end(); ++tradesIter) {
+                if (txid == (*tradesIter).getHash()) return &(*tradesIter);
+            }
+        }
+    }
+    return (CMPMetaDEx*) NULL;
+}

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -674,6 +674,7 @@ std::string mastercore::MetaDEx_getStatusText(int tradeStatus)
         case TRADE_FILLED: return "filled";
         case TRADE_CANCELLED: return "cancelled";
         case TRADE_CANCELLED_PART_FILLED: return "cancelled part filled";
+        case TRADE_INVALID: return "trade invalid";
         default: return "unknown";
     }
 }
@@ -691,6 +692,9 @@ int mastercore::MetaDEx_getStatus(const uint256& txid, uint32_t propertyIdForSal
         int64_t totalReceived;
         t_tradelistdb->getMatchingTrades(txid, propertyIdForSale, tradeArray, totalSold, totalReceived);
     }
+
+    // Return a "trade invalid" status if the trade was invalidated at parsing/interpretation (eg insufficient funds)
+    if (!getValidMPTX(txid)) return TRADE_INVALID;
 
     // Calculate and return the status of the trade via the amount sold and open/closed attributes.
     if (MetaDEx_isOpen(txid, propertyIdForSale)) {

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -137,6 +137,10 @@ void MetaDEx_debug_print(bool bShowPriceLevel = false, bool bDisplay = false);
 bool MetaDEx_isOpen(const uint256& txid, uint32_t propertyIdForSale = 0);
 int MetaDEx_getStatus(const uint256& txid, uint32_t propertyIdForSale, int64_t amountForSale, int64_t totalSold = -1);
 std::string MetaDEx_getStatusText(int tradeStatus);
+
+// Locates a trade in the MetaDEx maps via txid and returns the trade object
+const CMPMetaDEx* MetaDEx_RetrieveTrade(const uint256& txid);
+
 }
 
 

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -26,6 +26,13 @@ typedef boost::rational<int128_t> rational_t;
 
 #define DISPLAY_PRECISION_LEN  50
 
+// MetaDEx trade statuses
+#define TRADE_OPEN                    1
+#define TRADE_OPEN_PART_FILLED        2
+#define TRADE_FILLED                  3
+#define TRADE_CANCELLED               4
+#define TRADE_CANCELLED_PART_FILLED   5
+
 std::string xToString(const dec_float& value);
 std::string xToString(const int128_t& value);
 std::string xToString(const rational_t& value);
@@ -128,7 +135,8 @@ int MetaDEx_CANCEL_EVERYTHING(const uint256& txid, uint32_t block, const std::st
 bool MetaDEx_INSERT(const CMPMetaDEx& objMetaDEx);
 void MetaDEx_debug_print(bool bShowPriceLevel = false, bool bDisplay = false);
 bool MetaDEx_isOpen(const uint256& txid, uint32_t propertyIdForSale = 0);
-std::string MetaDEx_getStatus(const uint256& txid, uint32_t propertyIdForSale, int64_t amountForSale, int64_t totalSold = -1, int64_t totalReceived = -1);
+int MetaDEx_getStatus(const uint256& txid, uint32_t propertyIdForSale, int64_t amountForSale, int64_t totalSold = -1);
+std::string MetaDEx_getStatusText(int tradeStatus);
 }
 
 

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -27,6 +27,7 @@ typedef boost::rational<int128_t> rational_t;
 #define DISPLAY_PRECISION_LEN  50
 
 // MetaDEx trade statuses
+#define TRADE_INVALID                 -1
 #define TRADE_OPEN                    1
 #define TRADE_OPEN_PART_FILLED        2
 #define TRADE_FILLED                  3


### PR DESCRIPTION
This PR performs the following:
* Switches away from string based statuses in code

* With the ```amountremaining``` and ```amounttofill``` MetaDEx fields;
  * Moves them out of ```omni_gettransaction``` and into ```omni_gettrade```
  * Hides the fields if the trade is not open/active
* Fixes a bug where status would show as cancelled if the trade was invalidated during parsing, eg:

 ```
    "status" : "cancelled",
    "canceltxid" : "0000000000000000000000000000000000000000000000000000000000000000",
    "matches" : [
    ],
    "valid" : false,
   ```

For further info please see discussion in https://github.com/OmniLayer/omnicore/issues/200