### PR TITLE
No longer allow wildcard when cancelling all MetaDEx orders

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -269,7 +269,7 @@ Cancel all offers on the distributed token exchange.
 **Arguments:**
 
 1. ***fromaddress          (string, required):*** the address to trade with
-2. ***ecosystem            (number, required):*** the ecosystem of the offers to cancel: (0) both, (1) main, (2) test
+2. ***ecosystem            (number, required):*** the ecosystem of the offers to cancel: (1) main, (2) test
 
 **Example:**
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -37,7 +37,7 @@ int const MAX_STATE_HISTORY = 50;
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 
 // increment this value to force a refresh of the state (similar to --startclean)
-#define DB_VERSION 1
+#define DB_VERSION 2
 
 // could probably also use: int64_t maxInt64 = std::numeric_limits<int64_t>::max();
 // maximum numeric values from the spec:

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -929,7 +929,7 @@ Value omni_sendcancelalltrades(const Array& params, bool fHelp)
 
             "\nArguments:\n"
             "1. fromaddress          (string, required) the address to trade with\n"
-            "2. ecosystem            (number, required) the ecosystem of the offers to cancel: (0) both, (1) main, (2) test\n"
+            "2. ecosystem            (number, required) the ecosystem of the offers to cancel: (1) main, (2) test\n"
 
             "\nResult:\n"
             "\"hash\"                  (string) the hex-encoded transaction hash\n"
@@ -941,7 +941,7 @@ Value omni_sendcancelalltrades(const Array& params, bool fHelp)
 
     // obtain parameters & info
     std::string fromAddress = ParseAddress(params[0]);
-    uint8_t ecosystem = (params[1].get_int() != 0) ? ParseEcosystem(params[1]): 0;
+    uint8_t ecosystem = ParseEcosystem(params[1]);
 
     // perform checks
     // TODO: check, if there are matching offers to cancel

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -55,7 +55,7 @@ std::vector<TransactionRestriction> CConsensusParams::GetRestrictions() const
         { MSC_TYPE_METADEX_TRADE,             MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
         { MSC_TYPE_METADEX_CANCEL_PRICE,      MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
         { MSC_TYPE_METADEX_CANCEL_PAIR,       MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
-        { MSC_TYPE_METADEX_CANCEL_ECOSYSTEM,  MP_TX_PKT_V0,  true,    MSC_METADEX_BLOCK  },
+        { MSC_TYPE_METADEX_CANCEL_ECOSYSTEM,  MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
 
         { MSC_TYPE_OFFER_ACCEPT_A_BET,        MP_TX_PKT_V0,  false,   MSC_BET_BLOCK      },
     };

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1260,7 +1260,10 @@ int CMPTransaction::logicMath_MetaDExCancelEcosystem()
         return (PKT_ERROR_METADEX -22);
     }
 
-    // ------------------------------------------
+    if (OMNI_PROPERTY_MSC != ecosystem && OMNI_PROPERTY_TMSC != ecosystem) {
+        PrintToLog("%s(): rejected: invalid ecosystem: %d\n", __func__, ecosystem);
+        return (PKT_ERROR_METADEX -21);
+    }
 
     int rc = MetaDEx_CANCEL_EVERYTHING(txid, block, sender, ecosystem);
 

--- a/src/qt/forms/metadexcanceldialog.ui
+++ b/src/qt/forms/metadexcanceldialog.ui
@@ -130,7 +130,7 @@
              <string notr="true">padding-left:10px;</string>
             </property>
             <property name="text">
-             <string>Cancel everything</string>
+             <string>Cancel by ecosystem</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Using a wildcard is no longer allowed to cancel orders in both ecosystems, but instead a valid ecosystem is required.

This is a change of consensus rules, and "-startclean" may be needed.

The PR resolves #205.