### PR TITLE
Don't restrict number of trades and transactions in UI history

### DIFF
--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -300,8 +300,8 @@ int TradeHistoryDialog::PopulateTradeHistoryMap()
     // ### START WALLET TRANSACTIONS PROCESSING ###
     std::list<CAccountingEntry> acentries;
     CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, "*");
-    // iterate through wallet entries backwards, limiting to most recent n (default 500) transactions (override with --omniuiwalletscope=n)
-    int walletTxCount = 0, walletTxMax = GetArg("-omniuiwalletscope", 500);
+    // iterate through wallet entries backwards, limiting to most recent n (default 65535) transactions (override with --omniuiwalletscope=n)
+    int64_t walletTxCount = 0, walletTxMax = GetArg("-omniuiwalletscope", 65535L);
     for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it) {
         if (walletTxCount >= walletTxMax) break;
         ++walletTxCount;

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -191,8 +191,8 @@ int TXHistoryDialog::PopulateHistoryMap()
 
     int64_t nProcessed = 0; // counter for how many transactions we've added to history this time
 
-    // obtain a sorted list of Omni layer wallet transactions (including STO receipts and pending) - default last 1000
-    std::map<std::string,uint256> walletTransactions = FetchWalletOmniTransactions(GetArg("-omniuiwalletscope", 1000));
+    // obtain a sorted list of Omni layer wallet transactions (including STO receipts and pending) - default last 65535
+    std::map<std::string,uint256> walletTransactions = FetchWalletOmniTransactions(GetArg("-omniuiwalletscope", 65535L));
 
     // reverse iterate over (now ordered) transactions and populate history map for each one
     for (std::map<std::string,uint256>::reverse_iterator it = walletTransactions.rbegin(); it != walletTransactions.rend(); it++) {


### PR DESCRIPTION
To avoid that trades and transactions may not be shown in the UI, the default values of the "transactions to consider" is raised to 65535.

This value was almost arbitrarily chosen, and should be high enough to be perceived as "unrestricted".

The PR resolves #208.