### PR TITLE
Refine RPC input parsing related to addresses

### DIFF
--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -347,8 +347,8 @@ Value omni_sendrawtx(const Array& params, bool fHelp)
 
     std::string fromAddress = ParseAddress(params[0]);
     std::vector<unsigned char> data = ParseHexV(params[1], "raw transaction");
-    std::string toAddress = (params.size() > 2 && !ParseText(params[2]).empty()) ? ParseAddress(params[2]): "";
-    std::string redeemAddress = (params.size() > 3 && !ParseText(params[3]).empty()) ? ParseAddress(params[3]): "";
+    std::string toAddress = (params.size() > 2) ? ParseAddressOrEmpty(params[2]): "";
+    std::string redeemAddress = (params.size() > 3) ? ParseAddressOrEmpty(params[3]): "";
     int64_t referenceAmount = (params.size() > 4) ? ParseAmount(params[4], true): 0;
 
     //some sanity checking of the data supplied?
@@ -1115,7 +1115,7 @@ Value omni_getactivedexsells(const Array& params, bool fHelp)
     std::string addressFilter;
 
     if (params.size() > 0) {
-        addressFilter = ParseAddress(params[0]);
+        addressFilter = ParseAddressOrEmpty(params[0]);
     }
 
     Array response;
@@ -1275,7 +1275,7 @@ Value omni_gettransaction(const Array& params, bool fHelp)
             + HelpExampleRpc("omni_gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 
-    uint256 hash(params[0].get_str());
+    uint256 hash = ParseHashV(params[0], "txid");
 
     Object txobj;
     int populateResult = populateRPCTransactionObject(hash, txobj);
@@ -1491,9 +1491,9 @@ Value omni_getsto(const Array& params, bool fHelp)
             + HelpExampleRpc("omni_getsto", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\", \"*\"")
         );
 
-    uint256 hash(params[0].get_str());
+    uint256 hash = ParseHashV(params[0], "txid");
     std::string filterAddress;
-    if (params.size() > 1) filterAddress = ParseAddress(params[1]);
+    if (params.size() > 1) filterAddress = ParseAddressOrWildcard(params[1]);
 
     Object txobj;
     int populateResult = populateRPCTransactionObject(hash, txobj, "", true, filterAddress);
@@ -1549,7 +1549,7 @@ Value omni_gettrade(const Array& params, bool fHelp)
             + HelpExampleRpc("omni_gettrade", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 
-    uint256 hash(params[0].get_str());
+    uint256 hash = ParseHashV(params[0], "txid");
 
     Object txobj;
     int populateResult = populateRPCTransactionObject(hash, txobj, "", true);

--- a/src/omnicore/rpcvalues.cpp
+++ b/src/omnicore/rpcvalues.cpp
@@ -20,6 +20,22 @@ std::string ParseAddress(const json_spirit::Value& value)
     return address.ToString();
 }
 
+std::string ParseAddressOrEmpty(const json_spirit::Value& value)
+{
+    if (value.is_null() || value.get_str().empty()) {
+        return "";
+    }
+    return ParseAddress(value);
+}
+
+std::string ParseAddressOrWildcard(const json_spirit::Value& value)
+{
+    if (value.get_str() == "*") {
+        return "*";
+    }
+    return ParseAddress(value);
+}
+
 uint32_t ParsePropertyId(const json_spirit::Value& value)
 {
     int64_t propertyId = value.get_int64();

--- a/src/omnicore/rpcvalues.h
+++ b/src/omnicore/rpcvalues.h
@@ -7,6 +7,8 @@
 #include <string>
 
 std::string ParseAddress(const json_spirit::Value& value);
+std::string ParseAddressOrEmpty(const json_spirit::Value& value);
+std::string ParseAddressOrWildcard(const json_spirit::Value& value);
 uint32_t ParsePropertyId(const json_spirit::Value& value);
 int64_t ParseAmount(const json_spirit::Value& value, bool isDivisible);
 int64_t ParseAmount(const json_spirit::Value& value, int propertyType);

--- a/src/omnicore/test/rpc_value_tests.cpp
+++ b/src/omnicore/test/rpc_value_tests.cpp
@@ -39,6 +39,35 @@ BOOST_AUTO_TEST_CASE(rpcvalues_address)
     BOOST_CHECK_THROW(ParseAddress(ValueFromString("0.1")), std::runtime_error);
 }
 
+BOOST_AUTO_TEST_CASE(rpcvalues_address_or_empty)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseAddressOrEmpty(Value()), "");
+    BOOST_CHECK_EQUAL(ParseAddressOrEmpty(Value("")), "");
+    BOOST_CHECK_EQUAL(ParseAddressOrEmpty(ValueFromString("null")), "");
+    BOOST_CHECK_EQUAL(ParseAddressOrEmpty(Value("1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX")), "1f2dj45pxYb8BCW5sSbCgJ5YvXBfSapeX");
+    // Invalid CBitcoinAddress
+    BOOST_CHECK_THROW(ParseAddressOrEmpty(Value("*")), Object);
+    BOOST_CHECK_THROW(ParseAddressOrEmpty(Value("asdrf234")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseAddressOrEmpty(ValueFromString("0.1")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpcvalues_address_or_wildcard)
+{
+    // Valid input
+    BOOST_CHECK_EQUAL(ParseAddressOrWildcard(Value("*")), "*");
+    BOOST_CHECK_EQUAL(ParseAddressOrWildcard(Value("3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL")), "3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL");
+    // Invalid CBitcoinAddress
+    BOOST_CHECK_THROW(ParseAddressOrWildcard(Value("")), Object);
+    BOOST_CHECK_THROW(ParseAddressOrWildcard(Value("-")), Object);
+    BOOST_CHECK_THROW(ParseAddressOrWildcard(Value("9EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P")), Object);
+    // Invalid types
+    BOOST_CHECK_THROW(ParseAddressOrWildcard(Value()), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAddressOrWildcard(ValueFromString("null")), std::runtime_error);
+    BOOST_CHECK_THROW(ParseAddressOrWildcard(ValueFromString("123456789")), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(rpcvalues_property_id)
 {
     // Valid input


### PR DESCRIPTION
Added:
 - ParseAddressOrEmpty()
 - ParseAddressOrWildcard()

Parsing hashes is now fully checked, too.

This resolves #212.