### PR TITLE
Fix/remove empty build target of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@
 
 os: linux
 language: cpp
+compiler: gcc
 env:
   global:
     - MAKEJOBS=-j3
@@ -79,6 +80,8 @@ matrix:
             - libbz2-dev
             - zlib1g-dev
             - libcap-dev
+  exclude:
+    - compiler: gcc
 
 before_install:
     - mkdir -p depends/SDKs depends/sdk-sources


### PR DESCRIPTION
Currently the Travis CI builds fail, and it looks like there is a new "empty" build target:

- https://travis-ci.org/OmniLayer/omnicore/jobs/78127065

This is a workaround, which resolves the issue, see:

- https://github.com/travis-ci/travis-ci/issues/4681