### PR TITLE
Fix Bitcoin balance disappears from the UI on reorg

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -464,8 +464,8 @@ void OverviewPage::reinitOmni()
 {
     recentCache.clear();
     ui->overviewLW->clear();
-    UpdatePropertyBalance(0,0,0);
-    UpdatePropertyBalance(1,0,0);
+    UpdatePropertyBalance(0, walletModel->getBalance(), walletModel->getUnconfirmedBalance());
+    UpdatePropertyBalance(1, 0, 0);
     updateOmni();
 }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -464,7 +464,9 @@ void OverviewPage::reinitOmni()
 {
     recentCache.clear();
     ui->overviewLW->clear();
-    UpdatePropertyBalance(0, walletModel->getBalance(), walletModel->getUnconfirmedBalance());
+    if (walletModel != NULL) {
+        UpdatePropertyBalance(0, walletModel->getBalance(), walletModel->getUnconfirmedBalance());
+    }
     UpdatePropertyBalance(1, 0, 0);
     updateOmni();
 }


### PR DESCRIPTION
Fixes an issue where the BTC balance can disappear from the UI when there is a chain reorg.

See issue https://github.com/OmniLayer/omnicore/issues/219