### PR TITLE
Fix calculation of crowdsale participation on Windows

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -25,6 +25,7 @@ OMNICORE_H = \
   omnicore/sto.h \
   omnicore/tally.h \
   omnicore/tx.h \
+  omnicore/uint256_extensions.h \
   omnicore/utils.h \
   omnicore/utilsbitcoin.h \
   omnicore/version.h \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -31,6 +31,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/strtoint64_tests.cpp \
   omnicore/test/swapbyteorder_tests.cpp \
   omnicore/test/tally_tests.cpp \
+  omnicore/test/uint256_extensions_tests.cpp \
   omnicore/test/utils_tx.cpp
 
 BITCOIN_TESTS += \

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -5,6 +5,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/alert_tests.cpp \
   omnicore/test/checkpoint_tests.cpp \
   omnicore/test/create_payload_tests.cpp \
+  omnicore/test/crowdsale_participation_tests.cpp \
   omnicore/test/dex_purchase_tests.cpp \
   omnicore/test/encoding_b_tests.cpp \
   omnicore/test/encoding_c_tests.cpp \

--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -11,6 +11,7 @@
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/rules.h"
+#include "omnicore/uint256_extensions.h"
 
 #include "main.h"
 #include "tinyformat.h"
@@ -18,7 +19,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include <openssl/sha.h>
 
@@ -411,11 +411,16 @@ static int64_t calculateDExPurchase(const int64_t amountOffered, const int64_t a
  */
 int64_t calculateDExPurchase(const int64_t amountOffered, const int64_t amountDesired, const int64_t amountPaid)
 {
-    using boost::multiprecision::int128_t;
+    // conversion
+    uint256 amountOffered256 = ConvertTo256(amountOffered);
+    uint256 amountDesired256 = ConvertTo256(amountDesired);
+    uint256 amountPaid256 = ConvertTo256(amountPaid);
 
-    int128_t amountPurchased = int128_t(1) + ((int128_t(amountPaid) * int128_t(amountOffered)) - int128_t(1)) / int128_t(amountDesired);
+    // actual calculation; round up
+    uint256 amountPurchased256 = DivideAndRoundUp((amountPaid256 * amountOffered256), amountDesired256);
 
-    return amountPurchased.convert_to<int64_t>();
+    // convert back to int64_t
+    return ConvertTo64(amountPurchased256);
 }
 
 /**

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -319,16 +319,20 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
     return NewReturn;
 }
 
-// Used for display of unit prices to 8 decimal places at UI layer - automatically returns unit or inverse price as needed
+/**
+ * Used for display of unit prices to 8 decimal places at UI layer.
+ *
+ * Automatically returns unit or inverse price as needed.
+ */
 std::string CMPMetaDEx::displayUnitPrice() const
 {
      rational_t tmpDisplayPrice;
-     if (desired_property == OMNI_PROPERTY_MSC || desired_property == OMNI_PROPERTY_TMSC) {
+     if (getDesProperty() == OMNI_PROPERTY_MSC || getDesProperty() == OMNI_PROPERTY_TMSC) {
          tmpDisplayPrice = unitPrice();
-         if (isPropertyDivisible(property)) tmpDisplayPrice = tmpDisplayPrice * COIN;
+         if (isPropertyDivisible(getProperty())) tmpDisplayPrice = tmpDisplayPrice * COIN;
      } else {
          tmpDisplayPrice = inversePrice();
-         if (isPropertyDivisible(desired_property)) tmpDisplayPrice = tmpDisplayPrice * COIN;
+         if (isPropertyDivisible(getDesProperty())) tmpDisplayPrice = tmpDisplayPrice * COIN;
      }
 
      // offers with unit prices under 0.00000001 will be excluded from UI layer - TODO: find a better way to identify sub 0.00000001 prices
@@ -342,16 +346,36 @@ std::string CMPMetaDEx::displayUnitPrice() const
      return displayValue;
 }
 
+/**
+ * Used for display of unit prices with 50 decimal places at RPC layer.
+ *
+ * Automatically returns unit or inverse price as needed.
+ */
+std::string CMPMetaDEx::displayFullUnitPrice() const
+{
+    // unit price display adjustment based on divisibility and always showing prices in MSC/TMSC
+    rational_t tempUnitPrice;
+    if ((getProperty() == OMNI_PROPERTY_MSC) || (getProperty() == OMNI_PROPERTY_TMSC)) {
+        tempUnitPrice = inversePrice();
+        if (!isPropertyDivisible(getDesProperty())) tempUnitPrice = tempUnitPrice/COIN;
+    } else {
+        tempUnitPrice = unitPrice();
+        if (!isPropertyDivisible(getProperty())) tempUnitPrice = tempUnitPrice/COIN;
+    }
+    std::string unitPriceStr = xToString(tempUnitPrice);
+    return unitPriceStr;
+}
+
 rational_t CMPMetaDEx::unitPrice() const
 {
-    rational_t effectivePrice(int128_t(0));
+    rational_t effectivePrice;
     if (amount_forsale) effectivePrice = rational_t(amount_desired, amount_forsale);
     return effectivePrice;
 }
 
 rational_t CMPMetaDEx::inversePrice() const
 {
-    rational_t inversePrice(int128_t(0));
+    rational_t inversePrice;
     if (amount_desired) inversePrice = rational_t(amount_forsale, amount_desired);
     return inversePrice;
 }

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -5,6 +5,7 @@
 #include "omnicore/omnicore.h"
 #include "omnicore/sp.h"
 #include "omnicore/tx.h"
+#include "omnicore/uint256_extensions.h"
 
 #include "chain.h"
 #include "main.h"
@@ -25,7 +26,13 @@
 #include <set>
 #include <string>
 
+typedef boost::multiprecision::cpp_dec_float_100 dec_float;
+typedef boost::multiprecision::checked_int128_t int128_t;
+
 using namespace mastercore;
+
+//! Number of digits of unit price
+#define DISPLAY_PRECISION_LEN  50
 
 //! Global map for price and order data
 md_PropertiesMap mastercore::metadex;
@@ -71,33 +78,23 @@ static const std::string getTradeReturnType(MatchReturnType ret)
     }
 }
 
+// Used by rangeInt64, xToInt64
 static bool rangeInt64(const int128_t& value)
 {
     return (std::numeric_limits<int64_t>::min() <= value && value <= std::numeric_limits<int64_t>::max());
 }
 
+// Used by xToString
 static bool rangeInt64(const rational_t& value)
 {
     return (rangeInt64(value.numerator()) && rangeInt64(value.denominator()));
 }
 
-static int128_t xToInt128(const rational_t& value, bool fRoundUp)
+// Used by CMPMetaDEx::displayUnitPrice
+static int64_t xToRoundUpInt64(const rational_t& value)
 {
     // for integer rounding up: ceil(num / denom) => 1 + (num - 1) / denom
-    int128_t result(0);
-
-    if (!fRoundUp) {
-        result = value.numerator() / value.denominator();
-    } else {
-        result = int128_t(1) + (value.numerator() - int128_t(1)) / value.denominator();
-    }
-
-    return result;
-}
-
-static int64_t xToInt64(const rational_t& value, bool fRoundUp)
-{
-    int128_t result = xToInt128(value, fRoundUp);
+    int128_t result = int128_t(1) + (value.numerator() - int128_t(1)) / value.denominator();
 
     assert(rangeInt64(result));
 
@@ -203,15 +200,13 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 
             // First determine how many representable (indivisible) tokens Alice can
             // purchase from Bob, using Bob's unit price
-            rational_t rCouldBuy = pnew->getAmountRemaining() * pold->inversePrice();
-
             // This implies rounding down, since rounding up is impossible, and would
             // require more tokens than Alice has
-            int128_t iCouldBuy = xToInt128(rCouldBuy, false);
+            uint256 iCouldBuy = (ConvertTo256(pnew->getAmountRemaining()) * ConvertTo256(pold->getAmountForSale())) / ConvertTo256(pold->getAmountDesired());
 
             int64_t nCouldBuy = 0;
-            if (iCouldBuy < int128_t(pold->getAmountRemaining())) {
-                nCouldBuy = iCouldBuy.convert_to<int64_t>();
+            if (iCouldBuy < ConvertTo256(pold->getAmountRemaining())) {
+                nCouldBuy = ConvertTo64(iCouldBuy);
             } else {
                 nCouldBuy = pold->getAmountRemaining();
             }
@@ -225,11 +220,10 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 
             // If the amount Alice would have to pay to buy Bob's tokens at his price
             // is fractional, always round UP the amount Alice has to pay
-            rational_t rWouldPay = nCouldBuy * pold->unitPrice();
-
             // This will always be better for Bob. Rounding in the other direction
             // will always be impossible, because ot would violate Bob's accepted price
-            int64_t nWouldPay = xToInt64(rWouldPay, true);
+            uint256 iWouldPay = DivideAndRoundUp((ConvertTo256(nCouldBuy) * ConvertTo256(pold->getAmountDesired())), ConvertTo256(pold->getAmountForSale()));
+            int64_t nWouldPay = ConvertTo64(iWouldPay);
 
             // If the resulting adjusted unit price is higher than Alice' price, the
             // orders shall not execute, and no representable fill is made
@@ -342,7 +336,7 @@ std::string CMPMetaDEx::displayUnitPrice() const
      // we must always round up here - for example if the actual price required is 0.3333333344444
      // round: 0.33333333 - price is insufficient and thus won't result in a trade
      // round: 0.33333334 - price will be sufficient to result in a trade
-     std::string displayValue = FormatDivisibleMP(xToInt64(tmpDisplayPrice, true));
+     std::string displayValue = FormatDivisibleMP(xToRoundUpInt64(tmpDisplayPrice));
      return displayValue;
 }
 
@@ -382,10 +376,10 @@ rational_t CMPMetaDEx::inversePrice() const
 
 int64_t CMPMetaDEx::getAmountToFill() const
 {
-    rational_t rAmountNeededToFill = amount_remaining * unitPrice();
     // round up to ensure that the amount we present will actually result in buying all available tokens
-    int64_t iAmountNeededToFill = xToInt64(rAmountNeededToFill, true);
-    return iAmountNeededToFill;
+    uint256 iAmountNeededToFill = DivideAndRoundUp((ConvertTo256(amount_remaining) * ConvertTo256(amount_desired)), ConvertTo256(amount_forsale));
+    int64_t nAmountNeededToFill = ConvertTo64(iAmountNeededToFill);
+    return nAmountNeededToFill;
 }
 
 int64_t CMPMetaDEx::getBlockTime() const

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -34,8 +34,7 @@ typedef boost::rational<int128_t> rational_t;
 #define TRADE_CANCELLED               4
 #define TRADE_CANCELLED_PART_FILLED   5
 
-std::string xToString(const dec_float& value);
-std::string xToString(const int128_t& value);
+/** Converts price to string. */
 std::string xToString(const rational_t& value);
 
 /** A trade on the distributed exchange.
@@ -100,8 +99,10 @@ public:
     rational_t unitPrice() const;
     rational_t inversePrice() const;
 
+    /** Used for display of unit prices to 8 decimal places at UI layer. */
     std::string displayUnitPrice() const;
-    std::string displayInversePrice() const;
+    /** Used for display of unit prices with 50 decimal places at RPC layer. */
+    std::string displayFullUnitPrice() const;
 
     void saveOffer(std::ofstream& file, SHA256_CTX* shaCtx) const;
 };

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -19,12 +19,7 @@
 #include <set>
 #include <string>
 
-using boost::multiprecision::int128_t;
-
-typedef boost::multiprecision::cpp_dec_float_100 dec_float;
-typedef boost::rational<int128_t> rational_t;
-
-#define DISPLAY_PRECISION_LEN  50
+typedef boost::rational<boost::multiprecision::checked_int128_t> rational_t;
 
 // MetaDEx trade statuses
 #define TRADE_INVALID                 -1

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3804,7 +3804,7 @@ void CMPTradeList::getTradesForPair(uint32_t propertyIdSideA, uint32_t propertyI
       inversePrice = rational_t(amountSold, amountReceived);
       if (!propertyIdSideAIsDivisible) unitPrice = unitPrice / COIN;
       if (!propertyIdSideBIsDivisible) inversePrice = inversePrice / COIN;
-      std::string unitPriceStr = xToString(unitPrice);
+      std::string unitPriceStr = xToString(unitPrice); // TODO: not here!
       std::string inversePriceStr = xToString(inversePrice);
 
       int64_t blockNum = boost::lexical_cast<int64_t>(vecValues[6]);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -55,7 +55,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include <openssl/sha.h>
 
@@ -75,7 +74,6 @@
 #include <vector>
 
 using boost::algorithm::token_compress_on;
-using boost::multiprecision::int128_t;
 using boost::to_string;
 
 using json_spirit::Array;
@@ -3798,10 +3796,8 @@ void CMPTradeList::getTradesForPair(uint32_t propertyIdSideA, uint32_t propertyI
           continue;
       }
 
-      rational_t unitPrice(int128_t(0));
-      rational_t inversePrice(int128_t(0));
-      unitPrice = rational_t(amountReceived, amountSold);
-      inversePrice = rational_t(amountSold, amountReceived);
+      rational_t unitPrice(amountReceived, amountSold);
+      rational_t inversePrice(amountSold, amountReceived);
       if (!propertyIdSideAIsDivisible) unitPrice = unitPrice / COIN;
       if (!propertyIdSideBIsDivisible) inversePrice = inversePrice / COIN;
       std::string unitPriceStr = xToString(unitPrice); // TODO: not here!

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -291,15 +291,7 @@ void populateRPCTypeMetaDExTrade(CMPTransaction& omniObj, Object& txobj, bool ex
     // unit price display adjustment based on divisibility and always showing prices in MSC/TMSC
     bool propertyIdForSaleIsDivisible = isPropertyDivisible(omniObj.getProperty());
     bool propertyIdDesiredIsDivisible = isPropertyDivisible(metaObj.getDesProperty());
-    rational_t tempUnitPrice(int128_t(0));
-    if ((omniObj.getProperty() == OMNI_PROPERTY_MSC) || (omniObj.getProperty() == OMNI_PROPERTY_TMSC)) {
-        tempUnitPrice = metaObj.inversePrice();
-        if (!propertyIdDesiredIsDivisible) tempUnitPrice = tempUnitPrice/COIN;
-    } else {
-        tempUnitPrice = metaObj.unitPrice();
-        if (!propertyIdForSaleIsDivisible) tempUnitPrice = tempUnitPrice/COIN;
-    }
-    std::string unitPriceStr = xToString(tempUnitPrice);
+    std::string unitPriceStr = metaObj.displayFullUnitPrice();
 
     // populate
     txobj.push_back(Pair("propertyidforsale", (uint64_t)omniObj.getProperty()));
@@ -319,15 +311,7 @@ void populateRPCTypeMetaDExCancelPrice(CMPTransaction& omniObj, Object& txobj, b
     // unit price display adjustment based on divisibility and always showing prices in MSC/TMSC
     bool propertyIdForSaleIsDivisible = isPropertyDivisible(omniObj.getProperty());
     bool propertyIdDesiredIsDivisible = isPropertyDivisible(metaObj.getDesProperty());
-    rational_t tempUnitPrice(int128_t(0));
-    if ((omniObj.getProperty() == OMNI_PROPERTY_MSC) || (omniObj.getProperty() == OMNI_PROPERTY_TMSC)) {
-        tempUnitPrice = metaObj.inversePrice();
-        if (!propertyIdDesiredIsDivisible) tempUnitPrice = tempUnitPrice/COIN;
-    } else {
-        tempUnitPrice = metaObj.unitPrice();
-        if (!propertyIdForSaleIsDivisible) tempUnitPrice = tempUnitPrice/COIN;
-    }
-    std::string unitPriceStr = xToString(tempUnitPrice);
+    std::string unitPriceStr = metaObj.displayFullUnitPrice();
 
     // populate
     txobj.push_back(Pair("propertyidforsale", (uint64_t)omniObj.getProperty()));

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -4,6 +4,7 @@
 
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/uint256_extensions.h"
 
 #include "base58.h"
 #include "clientversion.h"
@@ -15,7 +16,6 @@
 #include "utiltime.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -660,66 +660,63 @@ void mastercore::calculateFundraiser(int64_t amtTransfer, uint8_t bonusPerc,
         int64_t fundraiserSecs, int64_t currentSecs, int64_t numProps, uint8_t issuerPerc, int64_t totalTokens,
         std::pair<int64_t, int64_t>& tokens, bool& close_crowdsale)
 {
-    using boost::multiprecision::cpp_int;
-    using boost::multiprecision::int128_t;
-
     // Weeks in seconds
-    int128_t weeks_sec_(604800);
+    uint256 weeks_sec_ = ConvertTo256(604800);
 
     // Precision for all non-bitcoin values (bonus percentages, for example)
-    int128_t precision_(1000000000000LL);
+    uint256 precision_ = ConvertTo256(1000000000000LL);
 
     // Precision for all percentages (10/100 = 10%)
-    int128_t percentage_precision(100);
+    uint256 percentage_precision = ConvertTo256(100);
 
     // Calculate the bonus seconds
-    int128_t bonusSeconds_ = fundraiserSecs - currentSecs;
+    uint256 bonusSeconds_ = ConvertTo256(fundraiserSecs) - ConvertTo256(currentSecs);
 
     // Calculate the whole number of weeks to apply bonus
-    int128_t weeks_ = (bonusSeconds_ / weeks_sec_) * precision_;
-    weeks_ += ((bonusSeconds_ % weeks_sec_) * precision_) / weeks_sec_;
+    uint256 weeks_ = (bonusSeconds_ / weeks_sec_) * precision_;
+    weeks_ += (Modulo256(bonusSeconds_, weeks_sec_) * precision_) / weeks_sec_;
 
     // Calculate the earlybird percentage to be applied
-    int128_t ebPercentage_ = weeks_ * bonusPerc;
+    uint256 ebPercentage_ = weeks_ * ConvertTo256(bonusPerc);
 
     // Calcluate the bonus percentage to apply up to percentage_precision number of digits
-    int128_t bonusPercentage_ = (precision_ * percentage_precision);
+    uint256 bonusPercentage_ = (precision_ * percentage_precision);
     bonusPercentage_ += ebPercentage_;
     bonusPercentage_ /= percentage_precision;
 
     // Calculate the bonus percentage for the issuer
-    int128_t issuerPercentage_(issuerPerc);
+    uint256 issuerPercentage_ = ConvertTo256(issuerPerc);
     issuerPercentage_ *= precision_;
     issuerPercentage_ /= percentage_precision;
 
     // Precision for bitcoin amounts (satoshi)
-    int128_t satoshi_precision_(100000000L);
+    uint256 satoshi_precision_ = ConvertTo256(100000000L);
 
     // Total tokens including remainders
-    cpp_int createdTokens(amtTransfer);
-    createdTokens *= cpp_int(numProps);
-    createdTokens *= cpp_int(bonusPercentage_);
+    uint256 createdTokens = ConvertTo256(amtTransfer);
+    createdTokens *= ConvertTo256(numProps);
+    createdTokens *= bonusPercentage_;
 
-    cpp_int issuerTokens = createdTokens / satoshi_precision_;
+    uint256 issuerTokens = createdTokens / satoshi_precision_;
     issuerTokens /= precision_;
     issuerTokens *= (issuerPercentage_ / 100);
     issuerTokens *= precision_;
 
-    cpp_int createdTokens_int = createdTokens / precision_;
+    uint256 createdTokens_int = createdTokens / precision_;
     createdTokens_int /= satoshi_precision_;
 
-    cpp_int issuerTokens_int = issuerTokens / precision_;
+    uint256 issuerTokens_int = issuerTokens / precision_;
     issuerTokens_int /= satoshi_precision_;
     issuerTokens_int /= 100;
 
-    cpp_int newTotalCreated = totalTokens + createdTokens_int + issuerTokens_int;
+    uint256 newTotalCreated = ConvertTo256(totalTokens) + createdTokens_int + issuerTokens_int;
 
-    if (newTotalCreated > MAX_INT_8_BYTES) {
-        cpp_int maxCreatable = MAX_INT_8_BYTES - totalTokens;
-        cpp_int created = createdTokens_int + issuerTokens_int;
+    if (newTotalCreated > ConvertTo256(MAX_INT_8_BYTES)) {
+        uint256 maxCreatable = ConvertTo256(MAX_INT_8_BYTES) - ConvertTo256(totalTokens);
+        uint256 created = createdTokens_int + issuerTokens_int;
 
         // Calcluate the ratio of tokens for what we can create and apply it
-        cpp_int ratio = created * precision_;
+        uint256 ratio = created * precision_;
         ratio *= satoshi_precision_;
         ratio /= maxCreatable;
 
@@ -729,16 +726,14 @@ void mastercore::calculateFundraiser(int64_t amtTransfer, uint8_t bonusPerc,
         issuerTokens_int /= ratio;
 
         // The tokens for the user
-        createdTokens_int = MAX_INT_8_BYTES - issuerTokens_int;
+        createdTokens_int = ConvertTo256(MAX_INT_8_BYTES) - issuerTokens_int;
 
         // Close the crowdsale after assigning all tokens
         close_crowdsale = true;
     }
 
     // The tokens to credit
-    assert(createdTokens_int <= std::numeric_limits<int64_t>::max());
-    assert(issuerTokens_int <= std::numeric_limits<int64_t>::max());
-    tokens = std::make_pair(createdTokens_int.convert_to<int64_t>(), issuerTokens_int.convert_to<int64_t>());
+    tokens = std::make_pair(ConvertTo64(createdTokens_int), ConvertTo64(issuerTokens_int));
 }
 
 // go hunting for whether a simple send is a crowdsale purchase

--- a/src/omnicore/test/crowdsale_participation_tests.cpp
+++ b/src/omnicore/test/crowdsale_participation_tests.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(overpayment_close)
             tokensCreated, fClosed);
 
     BOOST_CHECK(fClosed);
-    BOOST_CHECK_EQUAL(8384883669867978007LL, tokens.first); // user
-    BOOST_CHECK_EQUAL(838488366986797800LL, tokens.second); // issuer
+    BOOST_CHECK_EQUAL(8384883669867978007LL, tokensCreated.first); // user
+    BOOST_CHECK_EQUAL(838488366986797800LL, tokensCreated.second); // issuer
 }
 
 

--- a/src/omnicore/test/crowdsale_participation_tests.cpp
+++ b/src/omnicore/test/crowdsale_participation_tests.cpp
@@ -1,0 +1,46 @@
+#include "omnicore/sp.h"
+
+#include <stdint.h>
+#include <utility>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(omnicore_crowdsale_participation_tests)
+
+BOOST_AUTO_TEST_CASE(overpayment_close)
+{
+    //
+    // txid: eda3d2bbb8125397f4d4909ea25d845dc451e8a3206035bf0d736bb3ece5d758
+    //
+    // http://builder.bitwatch.co/?version=1&type=51&ecosystem=2&property_type=2&
+    // currency_identifier=0&text=436f696e436f696e00&text=436f696e436f696e00&
+    // text=43726f7764436f696e00&text=687474703a2f2f616c6c746865636f696e2e757300&
+    // text=69646b00&currency_identifier=2&number_of_coins=3133700000000&
+    // timestamp=1407064860000&percentage=6&percentage=10
+    // 
+    int64_t amountPerUnitInvested = 3133700000000LL;
+    int64_t deadline = 1407064860000LL;
+    int8_t earlyBirdBonus = 6;
+    int8_t issuerBonus = 10;
+
+    //
+    // txid: 8fbd96005aba5671daf8288f89df8026a7ce4782a0bb411937537933956b827b
+    //
+    int64_t timestamp = 1407877014LL;
+    int64_t amountInvested = 3000000000LL;
+
+    int64_t totalTokens = 0;
+    std::pair<int64_t, int64_t> tokensCreated;
+    bool fClosed = false;
+
+    mastercore::calculateFundraiser(amountInvested, earlyBirdBonus, deadline,
+            timestamp, amountPerUnitInvested, issuerBonus, totalTokens,
+            tokensCreated, fClosed);
+
+    BOOST_CHECK(fClosed);
+    BOOST_CHECK_EQUAL(8384883669867978007LL, tokens.first); // user
+    BOOST_CHECK_EQUAL(838488366986797800LL, tokens.second); // issuer
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/test/uint256_extensions_tests.cpp
+++ b/src/omnicore/test/uint256_extensions_tests.cpp
@@ -1,0 +1,98 @@
+#include "omnicore/uint256_extensions.h"
+
+#include "uint256.h"
+
+#include <stdint.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(omnicore_uint256_extensions_tests)
+
+BOOST_AUTO_TEST_CASE(uint256_from_uint64_t)
+{
+    uint64_t number = 103242;
+
+    base_uint<256> a(number);
+
+    BOOST_CHECK_EQUAL(number, a.GetLow64());
+}
+
+BOOST_AUTO_TEST_CASE(uint256_add)
+{
+    uint64_t number_a = 103242;
+    uint64_t number_b = 234324;
+    uint64_t number_c = number_a + number_b;
+
+    base_uint<256> a(number_a);
+    base_uint<256> b(number_b);
+    base_uint<256> c = a + b;
+
+    BOOST_CHECK_EQUAL(number_c, c.GetLow64());
+}
+
+BOOST_AUTO_TEST_CASE(uint256_sub)
+{
+    uint64_t number_a = 503242;
+    uint64_t number_b = 234324;
+    uint64_t number_c = number_a - number_b;
+
+    base_uint<256> a(number_a);
+    base_uint<256> b(number_b);
+    base_uint<256> c = a - b;
+
+    BOOST_CHECK_EQUAL(number_c, c.GetLow64());
+}
+
+BOOST_AUTO_TEST_CASE(uint256_mul)
+{
+    uint64_t number_a = 503242;
+    uint64_t number_b = 234324;
+    uint64_t number_c = number_a * number_b;
+
+    base_uint<256> a(number_a);
+    base_uint<256> b(number_b);
+    base_uint<256> c = a * b;
+
+    BOOST_CHECK_EQUAL(number_c, c.GetLow64());
+}
+
+BOOST_AUTO_TEST_CASE(uint256_div)
+{
+    uint64_t number_a = 9;
+    uint64_t number_b = 4;
+    uint64_t number_c = number_a / number_b;
+
+    base_uint<256> a(number_a);
+    base_uint<256> b(number_b);
+    base_uint<256> c = a / b;
+
+    BOOST_CHECK_EQUAL(number_c, c.GetLow64());
+}
+
+BOOST_AUTO_TEST_CASE(uint256_conversion)
+{
+    BOOST_CHECK_EQUAL(0, ConvertTo64(ConvertTo256(0)));
+    BOOST_CHECK_EQUAL(1, ConvertTo64(ConvertTo256(1)));
+    BOOST_CHECK_EQUAL(1000000000000000000LL, ConvertTo64(ConvertTo256(1000000000000000000LL)));
+    BOOST_CHECK_EQUAL(9223372036854775807LL, ConvertTo64(ConvertTo256(9223372036854775807LL)));
+}
+
+BOOST_AUTO_TEST_CASE(uint256_modulo)
+{
+    BOOST_CHECK_EQUAL(1, ConvertTo64(Modulo256(ConvertTo256(9), ConvertTo256(4))));
+}
+
+BOOST_AUTO_TEST_CASE(uint256_modulo_auto_conversion)
+{
+    BOOST_CHECK_EQUAL(2, ConvertTo64(Modulo256(17, 3)));
+}
+
+BOOST_AUTO_TEST_CASE(uint256_divide_and_round_up)
+{
+    BOOST_CHECK_EQUAL(3, ConvertTo64(DivideAndRoundUp(ConvertTo256(5), ConvertTo256(2))));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/uint256_extensions.h
+++ b/src/omnicore/uint256_extensions.h
@@ -1,0 +1,62 @@
+/**
+ * @file uint256_extensions.h
+ *
+ * This file provides helper to handle uint256 calculations.
+ */
+
+#ifndef OMNICORE_UINT256_EXTENSIONS_H
+#define OMNICORE_UINT256_EXTENSIONS_H
+
+#include "uint256.h"
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <limits>
+
+namespace mastercore {
+namespace uint256_const {
+//! The number 1 as uint256
+static const uint256 one(static_cast<uint64_t>(1));
+//! The highest number in range of int64_t as uint256
+static const uint256 max_int64(static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+}
+
+/**
+ * Returns a mod n.
+ */
+inline uint256 Modulo256(const uint256& a, const uint256& n)
+{
+    return (a - (n * (a / n)));
+}
+
+/**
+ * Converts a positive primitive number to uint256.
+ */
+template<typename NumberT>
+inline uint256 ConvertTo256(const NumberT& number)
+{
+    assert(number >= 0);
+    return uint256(static_cast<uint64_t>(number));
+}
+
+/**
+ * Converts an uint256 to int64_t.
+ */
+inline int64_t ConvertTo64(const uint256& number)
+{
+    assert(number <= uint256_const::max_int64);
+    return static_cast<int64_t>(number.GetLow64());
+}
+
+/**
+ * Returns ceil(numerator / denominator).
+ */
+inline uint256 DivideAndRoundUp(const uint256& numerator, const uint256& denominator)
+{
+    return uint256_const::one + (numerator - uint256_const::one) / denominator;
+}
+
+} // namespace mastercore
+
+#endif // OMNICORE_UINT256_EXTENSIONS_H


### PR DESCRIPTION
This pull request replaces the use of `boost::multiprecision` for internal calculations with "native" `uint256` to resolve #222.
