### PR TITLE
Do not save state when a block fails checkpoint validation

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4101,11 +4101,6 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     // transactions were found in the block, signal the UI accordingly
     if (countMP > 0) CheckWalletUpdate();
 
-    // save out the state after this block
-    if (writePersistence(nBlockNow)) {
-        mastercore_save_state(pBlockIndex);
-    }
-
     // calculate and print a consensus hash if required
     if (msc_debug_consensus_hash_every_block) {
         uint256 consensusHash = GetConsensusHash();
@@ -4119,6 +4114,11 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
         const std::string& msg = strprintf("Shutting down due to failed checkpoint for block %d (hash %s)\n", nBlockNow, pBlockIndex->GetBlockHash().GetHex());
         PrintToLog(msg);
         if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode(msg, msg);
+    } else {
+        // save out the state after this block
+        if (writePersistence(nBlockNow)) {
+            mastercore_save_state(pBlockIndex);
+        }
     }
 
     return 0;


### PR DESCRIPTION
Currently the state is saved after processing a block before any consensus hashing or checkpoint validation takes place.

This results in the following scenario:

1) Client processes block n
2) State for block n is written out
3) Checkpoint validation for block n is performed and fails
4) Client is shutdown
5) Client is restarted
6) Client loads latest state from disk (which is now block n)
7) Client continues parsing from block n+1

This PR changes the block handler to only save the state if there is no checkpoint failure.  On client restarts after a checkpoint failure we thus load state from block n-1 and run into the checkpoint failure again parsing the next block.

