### PR TITLE
Add new RPC to list pending Omni transactions

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -28,7 +28,7 @@ Create and broadcast a simple send transaction.
 4. ***amount               (string, required):*** the amount to send
 
 **Example:**
- 
+
 ```bash
 $ omnicore-cli "omni_send" "3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY" "37FaKponF7zqoMLUjEiko25pDiuVH5YLEa" 1 "100.0"
 ```
@@ -433,6 +433,24 @@ Lists all Omni transactions in a block.
 $ omnicore-cli "omni_listblocktransactions" 279007
 ```
 
+### omni_listpendingtransactions
+
+Returns a list of unconfirmed Omni transactions, pending in the memory pool.
+
+An optional filter can be provided to only include transactions which involve the given address.
+
+Note: the validity of pending transactions is uncertain, and the state of the memory pool may change at any moment. It is recommended to check transactions after confirmation, and pending transactions should be considered as invalid.
+
+**Arguments:**
+
+1. ***address              (string, optional):*** filter results by address (default: "" for no filter)
+
+**Example:**
+
+```bash
+$ omnicore-cli "omni_listpendingtransactions"
+```
+
 ### omni_getactivedexsells
 
 Returns currently active offers on the distributed exchange.
@@ -589,7 +607,7 @@ $ omnicore-cli "omni_gettradehistoryforaddress" "1MCHESTptvd2LnNp7wmr2sGTpRomteA
 
 ## Depreciated RPC Calls
 
-To ensure compability, depreciated RPC calls are kept for at least one major version.
+To ensure compatibility, depreciated RPC calls are kept for at least one major version.
 
 The following calls are replaced in Omni Core 0.0.10, and queries with the old command are forwarded.
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1363,6 +1363,57 @@ Value omni_listtransactions(const Array& params, bool fHelp)
     return response;
 }
 
+Value omni_listpendingtransactions(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "omni_listpendingtransactions ( \"address\" )\n"
+            "\nReturns a list of unconfirmed Omni transactions, pending in the memory pool.\n"
+            "\nAn optional filter can be provided to only include transactions which involve the given address.\n"
+            "\nNote: the validity of pending transactions is uncertain, and the state of the memory pool may "
+            "change at any moment. It is recommended to check transactions after confirmation, and pending "
+            "transactions should be considered as invalid.\n"
+            "\nArguments:\n"
+            "1. address              (string, optional) address filter (default: \"\" for no filter)\n"
+            "\nResult:\n"
+            "[                                 (array of JSON objects)\n"
+            "  {\n"
+            "    \"txid\" : \"hash\",                  (string) the hex-encoded hash of the transaction\n"
+            "    \"sendingaddress\" : \"address\",     (string) the Bitcoin address of the sender\n"
+            "    \"referenceaddress\" : \"address\",   (string) a Bitcoin address used as reference (if any)\n"
+            "    \"ismine\" : true|false,            (boolean) whether the transaction involes an address in the wallet\n"
+            "    \"fee\" : \"n.nnnnnnnn\",             (string) the transaction fee in bitcoins\n"
+            "    \"version\" : n,                    (number) the transaction version\n"
+            "    \"type_int\" : n,                   (number) the transaction type as number\n"
+            "    \"type\" : \"type\",                  (string) the transaction type as string\n"
+            "    [...]                             (mixed) other transaction type specific properties\n"
+            "  },\n"
+            "  ...\n"
+            "]\n"
+            "\nExamples:\n"
+            + HelpExampleCli("omni_listpendingtransactions", "")
+            + HelpExampleRpc("omni_listpendingtransactions", "")
+        );
+
+    std::string filterAddress;
+    if (params.size() > 0) {
+        filterAddress = ParseAddressOrEmpty(params[0]);
+    }
+
+    std::vector<uint256> vTxid;
+    mempool.queryHashes(vTxid);
+
+    Array result;
+    BOOST_FOREACH(const uint256& hash, vTxid) {
+        Object txObj;
+        if (populateRPCTransactionObject(hash, txObj, filterAddress) == 0) {
+            result.push_back(txObj);
+        }
+    }
+
+    return result;
+}
+
 Value omni_getinfo(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -371,6 +371,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_gettrade",                   &omni_gettrade,                   false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getsto",                     &omni_getsto,                     false,      true,       false },
     { "omni layer (data retrieval)",         "omni_listblocktransactions",      &omni_listblocktransactions,      false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_listpendingtransactions",    &omni_listpendingtransactions,    false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getallbalancesforaddress",   &omni_getallbalancesforaddress,   false,      true,       false },
     { "omni layer (data retrieval)",         "omni_gettradehistoryforaddress",  &omni_gettradehistoryforaddress,  false,      true,       false },
     { "omni layer (data retrieval)",         "omni_gettradehistoryforpair",     &omni_gettradehistoryforpair,     false,      true,       false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -242,6 +242,7 @@ extern json_spirit::Value omni_getorderbook(const json_spirit::Array& params, bo
 extern json_spirit::Value omni_gettrade(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getsto(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_listblocktransactions(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_listpendingtransactions(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getallbalancesforaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_gettradehistoryforaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_gettradehistoryforpair(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
The new RPC `"omni_listpendingtransactions"` can be used to retrieve a list of pending Omni transactions.

This resolves #211.