### PR TITLE
Various small improvements to ensure correct state

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3692,15 +3692,11 @@ int CMPSTOList::deleteAboveBlock(int blockNum)
     if(needsUpdate)
     {
         ++n_found;
-        const string key = address;
+        const std::string& key = address;
         // write updated record
-        Status status;
-        if (pdb)
-        {
-            status = pdb->Put(writeoptions, key, newValue);
-            PrintToLog("DEBUG STO - rewriting STO data after reorg\n");
-            PrintToLog("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
-        }
+        leveldb::Status status = pdb->Put(writeoptions, key, newValue);
+        PrintToLog("DEBUG STO - rewriting STO data after reorg\n");
+        PrintToLog("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
     }
   }
 

--- a/src/omnicore/persistence.h
+++ b/src/omnicore/persistence.h
@@ -5,6 +5,9 @@
 
 #include <boost/filesystem/path.hpp>
 
+#include <assert.h>
+#include <stddef.h>
+
 /** Base class for LevelDB based storage.
  */
 class CDBBase
@@ -35,7 +38,7 @@ protected:
     //! Number of entries written
     unsigned int nWritten;
 
-    CDBBase() : nRead(0), nWritten(0)
+    CDBBase() : pdb(NULL), nRead(0), nWritten(0)
     {
         options.paranoid_checks = true;
         options.create_if_missing = true;
@@ -52,8 +55,17 @@ protected:
         Close();
     }
 
+    /**
+     * Creates and returns a new LevelDB iterator.
+     *
+     * It is expected that the database is not closed. The iterator is owned by the
+     * caller, and the object has to be deleted explicitly.
+     *
+     * @return A new LevelDB iterator
+     */
     leveldb::Iterator* NewIterator() const
     {
+        assert(pdb != NULL);
         return pdb->NewIterator(iteroptions);
     }
 
@@ -69,16 +81,16 @@ protected:
      */
     leveldb::Status Open(const boost::filesystem::path& path, bool fWipe = false);
 
+    /**
+     * Deinitializes and closes the database.
+     */
+    void Close();
+
 public:
     /**
      * Deletes all entries of the database, and resets the counters.
      */
     void Clear();
-
-    /**
-     * Deinitializes and closes the database.
-     */
-    void Close();
 };
 
 

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -798,7 +798,7 @@ void mastercore::eraseMaxedCrowdsale(const std::string& address, int64_t blockTi
 
         // get sp from data struct
         CMPSPInfo::Entry sp;
-        _my_sps->getSP(crowdsale.getPropertyId(), sp);
+        assert(_my_sps->getSP(crowdsale.getPropertyId(), sp));
 
         // get txdata
         sp.historicalData = crowdsale.getDatabase();
@@ -808,7 +808,7 @@ void mastercore::eraseMaxedCrowdsale(const std::string& address, int64_t blockTi
 
         // update SP with this data
         sp.update_block = chainActive[block]->GetBlockHash();
-        _my_sps->updateSP(crowdsale.getPropertyId(), sp);
+        assert(_my_sps->updateSP(crowdsale.getPropertyId(), sp));
 
         // no calculate fractional calls here, no more tokens (at MAX)
         my_crowds.erase(it);
@@ -839,7 +839,7 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
 
             // get sp from data struct
             CMPSPInfo::Entry sp;
-            _my_sps->getSP(crowdsale.getPropertyId(), sp);
+            assert(_my_sps->getSP(crowdsale.getPropertyId(), sp));
 
             // find missing tokens
             double missedTokens = calculateFractional(sp.prop_type,
@@ -856,7 +856,7 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
 
             // update SP with this data
             sp.update_block = pBlockIndex->GetBlockHash();
-            _my_sps->updateSP(crowdsale.getPropertyId(), sp);
+            assert(_my_sps->updateSP(crowdsale.getPropertyId(), sp));
 
             // update values
             update_tally_map(sp.issuer, crowdsale.getPropertyId(), missedTokens, BALANCE);

--- a/src/omnicore/test/exodus_tests.cpp
+++ b/src/omnicore/test/exodus_tests.cpp
@@ -31,11 +31,11 @@ BOOST_AUTO_TEST_CASE(exodus_crowdsale_address_mainnet)
     BOOST_CHECK(CBitcoinAddress("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P") ==
                 ExodusCrowdsaleAddress(0));
     BOOST_CHECK(CBitcoinAddress("1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P") ==
-                ExodusCrowdsaleAddress(std::numeric_limits<int>().max()));
+                ExodusCrowdsaleAddress(std::numeric_limits<int>::max()));
     BOOST_CHECK(!(CBitcoinAddress("1rDQWR9yZLJY7ciyghAaF7XKD9tGzQuP6") ==
                 ExodusCrowdsaleAddress(0)));
     BOOST_CHECK(!(CBitcoinAddress("1rDQWR9yZLJY7ciyghAaF7XKD9tGzQuP6") ==
-                ExodusCrowdsaleAddress(std::numeric_limits<int>().max())));
+                ExodusCrowdsaleAddress(std::numeric_limits<int>::max())));
 
     SelectParams(CBaseChainParams::UNITTEST);
 }
@@ -79,11 +79,11 @@ BOOST_AUTO_TEST_CASE(exodus_crowdsale_address_testnet)
     BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
                 ExodusCrowdsaleAddress(MONEYMAN_TESTNET_BLOCK));
     BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
-                ExodusCrowdsaleAddress(std::numeric_limits<int>().max()));
+                ExodusCrowdsaleAddress(std::numeric_limits<int>::max()));
     BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
                 ExodusCrowdsaleAddress(MONEYMAN_TESTNET_BLOCK)));
     BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
-                ExodusCrowdsaleAddress(std::numeric_limits<int>().max())));
+                ExodusCrowdsaleAddress(std::numeric_limits<int>::max())));
 
     SelectParams(CBaseChainParams::UNITTEST);
 }
@@ -103,11 +103,11 @@ BOOST_AUTO_TEST_CASE(exodus_crowdsale_address_regtest)
     BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
                 ExodusCrowdsaleAddress(MONEYMAN_REGTEST_BLOCK));
     BOOST_CHECK(CBitcoinAddress("moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP") ==
-                ExodusCrowdsaleAddress(std::numeric_limits<int>().max()));
+                ExodusCrowdsaleAddress(std::numeric_limits<int>::max()));
     BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
                 ExodusCrowdsaleAddress(MONEYMAN_REGTEST_BLOCK)));
     BOOST_CHECK(!(CBitcoinAddress("mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv") ==
-                ExodusCrowdsaleAddress(std::numeric_limits<int>().max())));
+                ExodusCrowdsaleAddress(std::numeric_limits<int>::max())));
 
     SelectParams(CBaseChainParams::UNITTEST);
 }

--- a/src/omnicore/test/marker_tests.cpp
+++ b/src/omnicore/test/marker_tests.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(omnicore_marker_tests)
 BOOST_AUTO_TEST_CASE(class_no_marker)
 {
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         CTransaction tx(mutableTx);
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(class_no_marker)
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(PayToPubKeyHash_Unrelated());
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(class_no_marker)
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), NO_MARKER);
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(PayToPubKey_Unrelated());
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(class_class_a)
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_A);
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(NonStandardOutput());
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(class_class_b)
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_B);
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(PayToPubKeyHash_ExodusCrowdsale(nBlock));
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(OpReturn_SimpleSend());
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(NonStandardOutput());
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(class_class_c)
         BOOST_CHECK_EQUAL(GetEncodingClass(tx, nBlock), OMNI_CLASS_C);
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         CMutableTransaction mutableTx;
         mutableTx.vout.push_back(OpReturn_UnrelatedShort());

--- a/src/omnicore/test/output_restriction_tests.cpp
+++ b/src/omnicore/test/output_restriction_tests.cpp
@@ -16,19 +16,19 @@ BOOST_AUTO_TEST_SUITE(omnicore_output_restriction_tests)
 BOOST_AUTO_TEST_CASE(input_nonstandard)
 {
     BOOST_CHECK(!IsAllowedInputType(TX_NONSTANDARD, 0));
-    BOOST_CHECK(!IsAllowedInputType(TX_NONSTANDARD, std::numeric_limits<int>().max()));
+    BOOST_CHECK(!IsAllowedInputType(TX_NONSTANDARD, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(input_pubkey)
 {
     BOOST_CHECK(!IsAllowedInputType(TX_PUBKEY, 0));
-    BOOST_CHECK(!IsAllowedInputType(TX_PUBKEY, std::numeric_limits<int>().max()));
+    BOOST_CHECK(!IsAllowedInputType(TX_PUBKEY, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(input_pubkeyhash)
 {
     BOOST_CHECK(IsAllowedInputType(TX_PUBKEYHASH, 0));
-    BOOST_CHECK(IsAllowedInputType(TX_PUBKEYHASH, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedInputType(TX_PUBKEYHASH, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(input_scripthash)
@@ -38,45 +38,45 @@ BOOST_AUTO_TEST_CASE(input_scripthash)
     BOOST_CHECK(!IsAllowedInputType(TX_SCRIPTHASH, 0));
     BOOST_CHECK(!IsAllowedInputType(TX_SCRIPTHASH, P2SH_BLOCK-1));
     BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, P2SH_BLOCK));
-    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(input_scripthash_testnet)
 {
     SelectParams(CBaseChainParams::TESTNET);
     BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, 0));
-    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedInputType(TX_SCRIPTHASH, std::numeric_limits<int>::max()));
     SelectParams(CBaseChainParams::UNITTEST);
 }
 
 BOOST_AUTO_TEST_CASE(input_multisig)
 {
     BOOST_CHECK(!IsAllowedInputType(TX_MULTISIG, 0));
-    BOOST_CHECK(!IsAllowedInputType(TX_MULTISIG, std::numeric_limits<int>().max()));
+    BOOST_CHECK(!IsAllowedInputType(TX_MULTISIG, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(input_nulldata)
 {
     BOOST_CHECK(!IsAllowedInputType(TX_NULL_DATA, 0));
-    BOOST_CHECK(!IsAllowedInputType(TX_NULL_DATA, std::numeric_limits<int>().max()));
+    BOOST_CHECK(!IsAllowedInputType(TX_NULL_DATA, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(output_nonstandard)
 {
     BOOST_CHECK(!IsAllowedOutputType(TX_NONSTANDARD, 0));
-    BOOST_CHECK(!IsAllowedOutputType(TX_NONSTANDARD, std::numeric_limits<int>().max()));
+    BOOST_CHECK(!IsAllowedOutputType(TX_NONSTANDARD, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(output_pubkey)
 {
     BOOST_CHECK(!IsAllowedOutputType(TX_PUBKEY, 0));
-    BOOST_CHECK(!IsAllowedOutputType(TX_PUBKEY, std::numeric_limits<int>().max()));
+    BOOST_CHECK(!IsAllowedOutputType(TX_PUBKEY, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(output_pubkeyhash)
 {
     BOOST_CHECK(IsAllowedOutputType(TX_PUBKEYHASH, 0));
-    BOOST_CHECK(IsAllowedOutputType(TX_PUBKEYHASH, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedOutputType(TX_PUBKEYHASH, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(output_scripthash)
@@ -86,21 +86,21 @@ BOOST_AUTO_TEST_CASE(output_scripthash)
     BOOST_CHECK(!IsAllowedOutputType(TX_SCRIPTHASH, 0));
     BOOST_CHECK(!IsAllowedOutputType(TX_SCRIPTHASH, P2SH_BLOCK-1));
     BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, P2SH_BLOCK));
-    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(output_scripthash_testnet)
 {
     SelectParams(CBaseChainParams::TESTNET);
     BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, 0));
-    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedOutputType(TX_SCRIPTHASH, std::numeric_limits<int>::max()));
     SelectParams(CBaseChainParams::UNITTEST);
 }
 
 BOOST_AUTO_TEST_CASE(output_multisig)
 {
     BOOST_CHECK(IsAllowedOutputType(TX_MULTISIG, 0));
-    BOOST_CHECK(IsAllowedOutputType(TX_MULTISIG, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedOutputType(TX_MULTISIG, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(output_nulldata)
@@ -110,14 +110,14 @@ BOOST_AUTO_TEST_CASE(output_nulldata)
     BOOST_CHECK(!IsAllowedOutputType(TX_NULL_DATA, 0));
     BOOST_CHECK(!IsAllowedOutputType(TX_NULL_DATA, OP_RETURN_BLOCK-1));
     BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, OP_RETURN_BLOCK));
-    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, std::numeric_limits<int>::max()));
 }
 
 BOOST_AUTO_TEST_CASE(output_nulldata_testnet)
 {
     SelectParams(CBaseChainParams::TESTNET);
     BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, 0));
-    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, std::numeric_limits<int>().max()));
+    BOOST_CHECK(IsAllowedOutputType(TX_NULL_DATA, std::numeric_limits<int>::max()));
     SelectParams(CBaseChainParams::UNITTEST);
 }
 

--- a/src/omnicore/test/parsing_a_tests.cpp
+++ b/src/omnicore/test/parsing_a_tests.cpp
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(valid_class_a)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "000000000000000200000002540be400000000");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(1815000, "1HRE7U9XNPD8kJBCwm5Q1VAepz25GBXnVk"));

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(reference_identification)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000070000000006dac2c0");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(80000, "1M773vkrQDtBpkorfHTdctRo6kHxb4fXuT"));
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(reference_identification)
         BOOST_CHECK_EQUAL(metaTx.getPayload(), "00000000000000070000000006dac2c0");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(80000, "19NNUnwsKZK5dCnDCZ7pqeruL2syA8hSVh"));
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(reference_identification)
         BOOST_CHECK_EQUAL(metaTx.getReceiver(), "37pwWHk1oFaWxVsnYKfGs7Lyt5yJEVomTH");
     }
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(55550, "35iqJySouevicrYzMhjKSsqokSGwGovGov"));
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(reference_identification)
 BOOST_AUTO_TEST_CASE(empty_op_return)
 {
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(900000, "35iqJySouevicrYzMhjKSsqokSGwGovGov"));
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(multiple_op_return)
 BOOST_AUTO_TEST_CASE(multiple_op_return_pushes)
 {
     {
-        int nBlock = std::numeric_limits<int>().max();
+        int nBlock = std::numeric_limits<int>::max();
 
         std::vector<CTxOut> txInputs;
         txInputs.push_back(createTxOut(100000, "3LzuqJs1deHYeFyJz5JXqrZXpuMk3GBEX2"));

--- a/src/omnicore/test/rules_txs_tests.cpp
+++ b/src/omnicore/test/rules_txs_tests.cpp
@@ -10,8 +10,8 @@ using namespace mastercore;
 
 BOOST_AUTO_TEST_SUITE(omnicore_rules_txs_tests)
 
-const int MAX_BLOCK = std::numeric_limits<int>().max();
-const int MAX_VERSION = std::numeric_limits<uint16_t>().max();
+const int MAX_BLOCK = std::numeric_limits<int>::max();
+const int MAX_VERSION = std::numeric_limits<uint16_t>::max();
 
 BOOST_AUTO_TEST_CASE(simple_send_restrictions)
 {

--- a/src/omnicore/test/sender_bycontribution_tests.cpp
+++ b/src/omnicore/test/sender_bycontribution_tests.cpp
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(sender_selection_mixed_test)
         std::vector<CTxOut> vouts;
         for (unsigned n = 0; n < nOutputs; ++n) {
             CScript scriptPubKey;
-            if (std::rand() % 2 == 0) {
+            if (GetRandInt(2) == 0) {
                 scriptPubKey = GetScriptForDestination(createRandomKeyId());
             } else {
                 scriptPubKey = GetScriptForDestination(createRandomScriptId());
@@ -390,7 +390,7 @@ static CKeyID createRandomKeyId()
     std::vector<unsigned char> vch;
     vch.reserve(20);
     for (int i = 0; i < 20; ++i) {
-        vch.push_back(static_cast<unsigned char>(std::rand() % 256));
+        vch.push_back(static_cast<unsigned char>(GetRandInt(256)));
     }
     return CKeyID(uint160(vch));
 }
@@ -401,7 +401,7 @@ static CScriptID createRandomScriptId()
     std::vector<unsigned char> vch;
     vch.reserve(20);
     for (int i = 0; i < 20; ++i) {
-        vch.push_back(static_cast<unsigned char>(std::rand() % 256));
+        vch.push_back(static_cast<unsigned char>(GetRandInt(256)));
     }
     return CScriptID(uint160(vch));
 }

--- a/src/omnicore/test/sender_bycontribution_tests.cpp
+++ b/src/omnicore/test/sender_bycontribution_tests.cpp
@@ -365,7 +365,7 @@ static CTransaction TxClassB(const std::vector<CTxOut>& txInputs)
 /** Extracts the sender "by contribution". */
 static bool GetSenderByContribution(const std::vector<CTxOut>& vouts, std::string& strSender)
 {
-    int nBlock = std::numeric_limits<int>().max();
+    int nBlock = std::numeric_limits<int>::max();
 
     CMPTransaction metaTx;
     CTransaction dummyTx = TxClassB(vouts);

--- a/src/omnicore/test/sender_firstin_tests.cpp
+++ b/src/omnicore/test/sender_firstin_tests.cpp
@@ -75,7 +75,7 @@ static CTxOut createTxOut(int64_t amount, const std::string& dest)
 /** Extracts the "first" sender. */
 static bool GetFirstSender(const std::vector<CTxOut>& txInputs, std::string& strSender)
 {
-    int nBlock = std::numeric_limits<int>().max();
+    int nBlock = std::numeric_limits<int>::max();
 
     CMPTransaction metaTx;
     CTransaction dummyTx = TxClassC(txInputs);

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -241,7 +241,8 @@ bool CMPTransaction::interpret_SendAll()
 /** Tx 20 */
 bool CMPTransaction::interpret_TradeOffer()
 {
-    if (pkt_size < 34) {
+    int expectedSize = (version == MP_TX_PKT_V0) ? 33 : 34;
+    if (pkt_size < expectedSize) {
         return false;
     }
     memcpy(&property, &pkt[4], 4);
@@ -252,7 +253,9 @@ bool CMPTransaction::interpret_TradeOffer()
     memcpy(&amount_desired, &pkt[16], 8);
     memcpy(&blocktimelimit, &pkt[24], 1);
     memcpy(&min_fee, &pkt[25], 8);
-    memcpy(&subaction, &pkt[33], 1);
+    if (version > MP_TX_PKT_V0) {
+        memcpy(&subaction, &pkt[33], 1);
+    }
     swapByteOrder64(amount_desired);
     swapByteOrder64(min_fee);
 
@@ -262,7 +265,9 @@ bool CMPTransaction::interpret_TradeOffer()
         PrintToLog("\t  amount desired: %s\n", FormatDivisibleMP(amount_desired));
         PrintToLog("\tblock time limit: %d\n", blocktimelimit);
         PrintToLog("\t         min fee: %s\n", FormatDivisibleMP(min_fee));
-        PrintToLog("\t      sub-action: %d\n", subaction);
+        if (version > MP_TX_PKT_V0) {
+            PrintToLog("\t      sub-action: %d\n", subaction);
+        }
     }
 
     return true;

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1555,7 +1555,7 @@ int CMPTransaction::logicMath_CloseCrowdsale()
     CMPSPInfo::Entry sp;
     assert(_my_sps->getSP(property, sp));
 
-    double missedTokens = calculateFractional(sp.prop_type,
+    int64_t missedTokens = calculateFractional(sp.prop_type,
             sp.early_bird,
             sp.deadline,
             sp.num_tokens,
@@ -1568,7 +1568,7 @@ int CMPTransaction::logicMath_CloseCrowdsale()
     sp.close_early = true;
     sp.timeclosed = blockTime;
     sp.txid_close = txid;
-    sp.missedTokens = (int64_t) missedTokens;
+    sp.missedTokens = missedTokens;
 
     assert(_my_sps->updateSP(property, sp));
     if (missedTokens > 0) {

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -230,6 +230,8 @@ public:
         min_fee = 0;
         subaction = 0;
         memset(&alertString, 0, sizeof(alertString));
+        feature_id = 0;
+        activation_block = 999999;
         rpcOnly = true;
     }
 

--- a/src/omnicore/utils.cpp
+++ b/src/omnicore/utils.cpp
@@ -14,12 +14,15 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <assert.h>
 #include <string.h>
 #include <string>
 #include <vector>
 
 /**
  * Generates hashes used for obfuscation via ToUpper(HexStr(SHA256(x))).
+ *
+ * It is expected that the seed has a length of less than 128 characters.
  *
  * @see The class B transaction encoding specification:
  * https://github.com/mastercoin-MSC/spec#class-b-transactions-also-known-as-the-multisig-method
@@ -32,7 +35,10 @@ void PrepareObfuscatedHashes(const std::string& strSeed, std::string(&vstrHashes
     unsigned char sha_input[128];
     unsigned char sha_result[128];
     std::vector<unsigned char> vec_chars;
+
+    assert(strSeed.size() < sizeof(sha_input));
     strcpy((char *)sha_input, strSeed.c_str());
+
     // Do only as many re-hashes as there are data packets, 255 per specification
     for (unsigned int j = 1; j <= MAX_SHA256_OBFUSCATION_TIMES; ++j)
     {
@@ -41,6 +47,8 @@ void PrepareObfuscatedHashes(const std::string& strSeed, std::string(&vstrHashes
         memcpy(&vec_chars[0], &sha_result[0], 32);
         vstrHashes[j] = HexStr(vec_chars);
         boost::to_upper(vstrHashes[j]); // Convert to upper case characters
+
+        assert(vstrHashes[j].size() < sizeof(sha_input));
         strcpy((char *)sha_input, vstrHashes[j].c_str());
     }
 }


### PR DESCRIPTION
1) Fix expressions with std::numeric_limits<T>::max()

Instead of `std::numeric_limits<T>().max()`, `std::numeric_limits<T>::max()` is used. `max()` is a static method, and this is how it's actually intended to be used.

2) Use "native" GetRandInt() instead of std::rand()

This is a weak improvement (if at all), but more convenient in my opinon. :)

3) Assert existence and successful updates of SPs

All uses of `CMPSPInfo::getSP()` and `CMPSPInfo::updateSP()` in consensus relevant functions are now checked.

4) Use explicit cast for result of calculateFractional()

`calculateFractional()` internally uses `double` to store missing tokens, but returns `int64_t`. Callers of this function stored the result again in `double`, but passed it into functions, which expect `int64_t`.

So the conversions were:
```
  double -> int64_t -> double -> int64_t
```
This update removes one round trip and changes the flow to:
```
  double -> int64_t
```
5) Ensure database objects exist, when creating iterators

When creating iterators, it is assumed that the database is not closed.

While the databases are already initialized in the constructors of the child classes, this makes it harder to misuse the class, by restricting who can actually close the database.

The internal database object is further initialized, as it should be, even though this is a noop.

6) Assert size of seed and hashes for obfuscation is within bounds

The standard input, a base58-encoded pubkeyhash, for the obfuscation has a size of at most 35 characters, and the hexified SHA256 hashes have a size of 64 characters, which is both within the bounds of the arrays used during the obfuscation.

This change enforces these conditions and ensures the input, and hash results are guaranteed within bounds.

7) Resolve null pointer dereference in CMPSTOList::deleteAboveBlock() 

The use of `NewIterator()` implies the existence of `pdb`, and therefore the check `if (pdb)` is never false, so it can safely be removed in `CMPSTOList::deleteAboveBlock()`.

8) Initialize and clear feature related members in CMPTransaction

While `feature_id` and `activation_block` in `CMPTransaction` are currently always set before usage, explicit initialiaztion and resetting of the values is nevertheless recommended.

9) Add special handling when parsing v0 trade offers

Trade offers with version 0 have no sub-action byte. This was irrelevant so far, because class B packets are padded, but with class C it may turn into a pitfall.