### PR TITLE
Update handling of crowdsales and missing bonus amounts

### DIFF
--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -37,7 +37,7 @@ int const MAX_STATE_HISTORY = 50;
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 
 // increment this value to force a refresh of the state (similar to --startclean)
-#define DB_VERSION 2
+#define DB_VERSION 3
 
 // could probably also use: int64_t maxInt64 = std::numeric_limits<int64_t>::max();
 // maximum numeric values from the spec:

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -589,6 +589,17 @@ bool mastercore::isCrowdsaleActive(uint32_t propertyId)
     return false;
 }
 
+int64_t mastercore::calculateFractional(const CMPSPInfo::Entry& sp, const CMPCrowd& crowdsale)
+{
+    return calculateFractional(sp.prop_type,
+            sp.early_bird,
+            sp.deadline,
+            sp.num_tokens,
+            sp.percentage,
+            crowdsale.getDatabase(),
+            crowdsale.getIssuerCreated());
+}
+
 // calculates and returns fundraiser bonus, issuer premine, and total tokens
 // propType : divisible/indiv
 // bonusPerc: bonus percentage
@@ -845,13 +856,7 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
             assert(_my_sps->getSP(crowdsale.getPropertyId(), sp));
 
             // find missing tokens
-            int64_t missedTokens = calculateFractional(sp.prop_type,
-                    sp.early_bird,
-                    sp.deadline,
-                    sp.num_tokens,
-                    sp.percentage,
-                    crowdsale.getDatabase(),
-                    crowdsale.getIssuerCreated());
+            int64_t missedTokens = calculateFractional(sp, crowdsale);
 
             // get txdata
             sp.historicalData = crowdsale.getDatabase();

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -654,7 +654,10 @@ void mastercore::calculateFundraiser(bool inflateAmount, int64_t amtTransfer, ui
     uint256 percentage_precision = ConvertTo256(100);
 
     // Calculate the bonus seconds
-    uint256 bonusSeconds_ = ConvertTo256(fundraiserSecs) - ConvertTo256(currentSecs);
+    uint256 bonusSeconds_ = 0;
+    if (currentSecs < fundraiserSecs) {
+        bonusSeconds_ = ConvertTo256(fundraiserSecs) - ConvertTo256(currentSecs);
+    }
 
     // Calculate the whole number of weeks to apply bonus
     uint256 weeks_ = (bonusSeconds_ / weeks_sec_) * precision_;
@@ -715,7 +718,6 @@ void mastercore::calculateFundraiser(bool inflateAmount, int64_t amtTransfer, ui
         assert(issuerTokens_int <= maxCreatable);
 
         // The tokens for the user
-        //createdTokens_int = ConvertTo256(MAX_INT_8_BYTES) - issuerTokens_int;
         createdTokens_int = maxCreatable - issuerTokens_int;
 
         // Close the crowdsale after assigning all tokens

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -656,7 +656,7 @@ int64_t mastercore::calculateFractional(uint16_t propType, uint8_t bonusPerc, in
 
 // calculateFundraiser does token calculations per transaction
 // calcluateFractional does calculations for missed tokens
-void mastercore::calculateFundraiser(int64_t amtTransfer, uint8_t bonusPerc,
+void mastercore::calculateFundraiser(bool inflateAmount, int64_t amtTransfer, uint8_t bonusPerc,
         int64_t fundraiserSecs, int64_t currentSecs, int64_t numProps, uint8_t issuerPerc, int64_t totalTokens,
         std::pair<int64_t, int64_t>& tokens, bool& close_crowdsale)
 {
@@ -694,6 +694,9 @@ void mastercore::calculateFundraiser(int64_t amtTransfer, uint8_t bonusPerc,
 
     // Total tokens including remainders
     uint256 createdTokens = ConvertTo256(amtTransfer);
+    if (inflateAmount) {
+        createdTokens *= ConvertTo256(100000000L);
+    }
     createdTokens *= ConvertTo256(numProps);
     createdTokens *= bonusPercentage_;
 

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -228,7 +228,7 @@ int64_t calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundra
         int64_t numProps, uint8_t issuerPerc, const std::map<uint256, std::vector<int64_t> >& txFundraiserData,
         const int64_t amountPremined);
 
-void calculateFundraiser(int64_t amtTransfer, uint8_t bonusPerc,
+void calculateFundraiser(bool inflateAmount, int64_t amtTransfer, uint8_t bonusPerc,
         int64_t fundraiserSecs, int64_t currentSecs, int64_t numProps, uint8_t issuerPerc, int64_t totalTokens,
         std::pair<int64_t, int64_t>& tokens, bool& close_crowdsale);
 

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -227,6 +227,7 @@ bool isCrowdsalePurchase(const uint256& txid, const std::string& address, int64_
 int64_t calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundraiserSecs,
         int64_t numProps, uint8_t issuerPerc, const std::map<uint256, std::vector<int64_t> >& txFundraiserData,
         const int64_t amountPremined);
+int64_t calculateFractional(const CMPSPInfo::Entry& sp, const CMPCrowd& crowdsale);
 
 void calculateFundraiser(bool inflateAmount, int64_t amtTransfer, uint8_t bonusPerc,
         int64_t fundraiserSecs, int64_t currentSecs, int64_t numProps, uint8_t issuerPerc, int64_t totalTokens,

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -223,12 +223,10 @@ CMPCrowd* getCrowd(const std::string& address);
 bool isCrowdsaleActive(uint32_t propertyId);
 bool isCrowdsalePurchase(const uint256& txid, const std::string& address, int64_t* propertyId, int64_t* userTokens, int64_t* issuerTokens);
 
-// TODO: check, if this could be combined with the other calculate* functions
-int64_t calculateFractional(uint16_t propType, uint8_t bonusPerc, int64_t fundraiserSecs,
-        int64_t numProps, uint8_t issuerPerc, const std::map<uint256, std::vector<int64_t> >& txFundraiserData,
-        const int64_t amountPremined);
-int64_t calculateFractional(const CMPSPInfo::Entry& sp, const CMPCrowd& crowdsale);
+/** Calculates missing bonus tokens, which are credited to the crowdsale issuer. */
+int64_t GetMissedIssuerBonus(const CMPSPInfo::Entry& sp, const CMPCrowd& crowdsale);
 
+/** Calculates amounts credited for a crowdsale purchase. */
 void calculateFundraiser(bool inflateAmount, int64_t amtTransfer, uint8_t bonusPerc,
         int64_t fundraiserSecs, int64_t currentSecs, int64_t numProps, uint8_t issuerPerc, int64_t totalTokens,
         std::pair<int64_t, int64_t>& tokens, bool& close_crowdsale);

--- a/src/omnicore/test/crowdsale_participation_tests.cpp
+++ b/src/omnicore/test/crowdsale_participation_tests.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(overpayment_close)
     std::pair<int64_t, int64_t> tokensCreated;
     bool fClosed = false;
 
-    mastercore::calculateFundraiser(amountInvested, earlyBirdBonus, deadline,
+    mastercore::calculateFundraiser(true, amountInvested, earlyBirdBonus, deadline,
             timestamp, amountPerUnitInvested, issuerBonus, totalTokens,
             tokensCreated, fClosed);
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -757,7 +757,7 @@ int CMPTransaction::logicHelper_CrowdsaleParticipation()
     assert(_my_sps->getSP(pcrowdsale->getPropertyId(), sp));
     PrintToLog("INVESTMENT SEND to Crowdsale Issuer: %s\n", receiver);
 
-    // Holds the tokens to be credited to the sender and receiver
+    // Holds the tokens to be credited to the sender and issuer
     std::pair<int64_t, int64_t> tokens;
 
     // Passed by reference to determine, if max_tokens has been reached
@@ -765,16 +765,14 @@ int CMPTransaction::logicHelper_CrowdsaleParticipation()
 
     // Units going into the calculateFundraiser function must match the unit of
     // the fundraiser's property_type. By default this means satoshis in and
-    // satoshis out. In the condition that the fundraiser is divisible, but 
+    // satoshis out. In the condition that the fundraiser is divisible, but
     // indivisible tokens are accepted, it must account for .0 Div != 1 Indiv,
     // but actually 1.0 Div == 100000000 Indiv. The unit must be shifted or the
     // values will be incorrect, which is what is checked below.
-    if (!isPropertyDivisible(property)) {
-        nValue = nValue * 1e8;
-    }
- 
+    bool inflateAmount = isPropertyDivisible(property) ? false : true;
+
     // Calculate the amounts to credit for this fundraiser
-    calculateFundraiser(nValue, sp.early_bird, sp.deadline, blockTime,
+    calculateFundraiser(inflateAmount, nValue, sp.early_bird, sp.deadline, blockTime,
             sp.num_tokens, sp.percentage, getTotalTokens(pcrowdsale->getPropertyId()),
             tokens, close_crowdsale);
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1558,13 +1558,7 @@ int CMPTransaction::logicMath_CloseCrowdsale()
     CMPSPInfo::Entry sp;
     assert(_my_sps->getSP(property, sp));
 
-    int64_t missedTokens = calculateFractional(sp.prop_type,
-            sp.early_bird,
-            sp.deadline,
-            sp.num_tokens,
-            sp.percentage,
-            crowd.getDatabase(),
-            crowd.getIssuerCreated());
+    int64_t missedTokens = GetMissedIssuerBonus(sp, crowd);
 
     sp.historicalData = crowd.getDatabase();
     sp.update_block = blockHash;


### PR DESCRIPTION
This pull request

- .. closes #247 Potential overflow in crowdsale participation with indivisible tokens
- .. closes #248 Potentially inaccurate results in crowdsale participation with indivisible tokens
- .. closes #249 Crowdsale participation amounts may be off by 100000000
- .. closes #247 Granted user amount out of bounds when reaching crowdsale limit

The "inflation" of indivisible amounts for crowdsales is directly moved into `calculateFundraiser`, where 256 bit wide integers are used, to avoid constraints related to the max. representable amounts.

Instead of recalculating the credited amounts to determine the missing issuer bonus, the totals, which are available via the crowdsale objects, are directly used.

The FP math was removed and replaced with plain 256 bit wide integers calculations.

This update triggers reparsing, to clear the bad persistence data (see #249).