### PR TITLE
Add ARM and a no-wallet build as build target for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - compiler: ": ARM"
+      env: HOST=arm-linux-gnueabihf DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
+      addons:
+        apt:
+          packages:
+            - g++-arm-linux-gnueabihf
     - compiler: ": omnicored DDEBUG_LOCKORDER"
       env: HOST=x86_64-unknown-linux-gnu DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat CPPFLAGS=-DDEBUG_LOCKORDER"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ matrix:
             - mingw-w64-dev
             - wine
             - bc
+    - compiler: ": No wallet"
+      env: HOST=x86_64-unknown-linux-gnu DEP_OPTS="NO_WALLET=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
     - compiler: ": Cross-Mac"
       env: HOST=x86_64-apple-darwin11 OSX_SDK=10.7 GOAL="deploy"
       addons:

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -1,29 +1,36 @@
-// Handler for populating RPC transaction objects
+/**
+ * @file rpctxobject.cpp
+ *
+ * Handler for populating RPC transaction objects.
+ */
+
 #include "omnicore/rpctxobject.h"
 
-// Bitcoin Core includes
-#include "wallet.h"
-#include "json/json_spirit_value.h"
-#include "json/json_spirit_reader_template.h"
-
-// Omni Core includes
-#include "omnicore/rpctxobject.h"
-#include "omnicore/omnicore.h"
 #include "omnicore/dex.h"
-#include "omnicore/mdex.h"
 #include "omnicore/errors.h"
+#include "omnicore/mdex.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/pending.h"
+#include "omnicore/rpctxobject.h"
 #include "omnicore/sp.h"
 #include "omnicore/tx.h"
-#include "omnicore/pending.h"
 #include "omnicore/utilsbitcoin.h"
 #include "omnicore/wallettxs.h"
 
-// Boost includes
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
+#include "main.h"
+#include "primitives/transaction.h"
+#include "sync.h"
+#include "uint256.h"
 
-// Generic includes
+#include "json/json_spirit_reader_template.h"
+#include "json/json_spirit_value.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <stdint.h>
 #include <string>
+#include <vector>
 
 // Namespaces
 using namespace json_spirit;


### PR DESCRIPTION
This PR adds ARM and a non-wallet build as build target for Travis CI.

While it seemed to work before due to non-obvious reasons, a non-wallet build wasn't successful, so the header includes of `rpctxobject.cpp` were refined.