### PR TITLE
Simple Send v1 with Memo field

### DIFF
--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -1,7 +1,6 @@
 // This file serves to provide payload creation functions.
 
 #include "omnicore/createpayload.h"
-
 #include "omnicore/convert.h"
 
 #include "tinyformat.h"
@@ -25,11 +24,11 @@
     reinterpret_cast<unsigned char *>((ptr)) + (size));
 
 
-std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount)
+std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount, std::string memo)
 {
     std::vector<unsigned char> payload;
     uint16_t messageType = 0;
-    uint16_t messageVer = 0;
+    uint16_t messageVer = memo.empty() ? 0 : 1;
     mastercore::swapByteOrder16(messageType);
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder32(propertyId);
@@ -39,6 +38,11 @@ std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_
     PUSH_BACK_BYTES(payload, messageType);
     PUSH_BACK_BYTES(payload, propertyId);
     PUSH_BACK_BYTES(payload, amount);
+    if (!memo.empty()) {
+        if (memo.size() > 255) memo = memo.substr(0,255);
+        payload.insert(payload.end(), memo.begin(), memo.end());
+        payload.push_back('\0');
+    }
 
     return payload;
 }

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <stdint.h>
 
-std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount);
+std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount, std::string memo);
 std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem);
 std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction);
 std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount);

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -48,8 +48,9 @@ Value omni_send(const Array& params, bool fHelp)
             "2. toaddress            (string, required) the address of the receiver\n"
             "3. propertyid           (number, required) the identifier of the tokens to send\n"
             "4. amount               (string, required) the amount to send\n"
-            "5. redeemaddress        (string, optional) an address that can spend the transaction dust (sender by default)\n"
-            "6. referenceamount      (string, optional) a bitcoin amount that is sent to the receiver (minimal by default)\n"
+            "5. memo                 (string, optional) attach a note to the transaction\n"
+            "6. redeemaddress        (string, optional) an address that can spend the transaction dust (sender by default)\n"
+            "7. referenceamount      (string, optional) a bitcoin amount that is sent to the receiver (minimal by default)\n"
 
             "\nResult:\n"
             "\"hash\"                  (string) the hex-encoded transaction hash\n"
@@ -64,8 +65,9 @@ Value omni_send(const Array& params, bool fHelp)
     std::string toAddress = ParseAddress(params[1]);
     uint32_t propertyId = ParsePropertyId(params[2]);
     int64_t amount = ParseAmount(params[3], isPropertyDivisible(propertyId));
-    std::string redeemAddress = (params.size() > 4 && !ParseText(params[4]).empty()) ? ParseAddress(params[4]): "";
-    int64_t referenceAmount = (params.size() > 5) ? ParseAmount(params[5], true): 0;
+    std::string memo = (params.size() > 4) ? ParseText(params[4]) : "";
+    std::string redeemAddress = (params.size() > 5 && !ParseText(params[5]).empty()) ? ParseAddress(params[5]): "";
+    int64_t referenceAmount = (params.size() > 6) ? ParseAmount(params[6], true): 0;
 
     // perform checks
     RequireExistingProperty(propertyId);
@@ -73,7 +75,7 @@ Value omni_send(const Array& params, bool fHelp)
     RequireSaneReferenceAmount(referenceAmount);
 
     // create a payload for the transaction
-    std::vector<unsigned char> payload = CreatePayload_SimpleSend(propertyId, amount);
+    std::vector<unsigned char> payload = CreatePayload_SimpleSend(propertyId, amount, memo);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -244,6 +244,7 @@ void populateRPCTypeSimpleSend(CMPTransaction& omniObj, Object& txobj)
         txobj.push_back(Pair("propertyid", (uint64_t)propertyId));
         txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
         txobj.push_back(Pair("amount", FormatMP(propertyId, omniObj.getAmount())));
+        txobj.push_back(Pair("memo", omniObj.getMemo()));
     }
 }
 

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -41,6 +41,7 @@ std::vector<TransactionRestriction> CConsensusParams::GetRestrictions() const
         { OMNICORE_MESSAGE_TYPE_ACTIVATION,   0xFFFF,        true,    MSC_ALERT_BLOCK    },
 
         { MSC_TYPE_SIMPLE_SEND,               MP_TX_PKT_V0,  false,   MSC_SEND_BLOCK     },
+        { MSC_TYPE_SIMPLE_SEND,               MP_TX_PKT_V1,  false,   MSC_SEND_BLOCK     },
 
         { MSC_TYPE_TRADE_OFFER,               MP_TX_PKT_V0,  false,   MSC_DEX_BLOCK      },
         { MSC_TYPE_TRADE_OFFER,               MP_TX_PKT_V1,  false,   MSC_DEX_BLOCK      },

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -199,6 +199,19 @@ bool CMPTransaction::interpret_SimpleSend()
         PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
     }
 
+    if (version == MP_TX_PKT_V1 && pkt_size > 16) {
+        const char* p = 16 + (char*) &pkt;
+        std::string memostr(p);
+        memcpy(memo, memostr.c_str(), std::min(memostr.length(), sizeof(memo)-1));
+        if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
+            PrintToLog("\t            memo: %s\n", memo);
+        }
+        if (isOverrun(p)) {
+            PrintToLog("%s(): rejected: malformed string value(s)\n", __func__);
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -54,6 +54,9 @@ private:
     // CreatePropertyMananged, GrantTokens, RevokeTokens, ChangeIssuer
     unsigned int property;
 
+    // SimpleSend, [future] GrantTokens, RevokeTokens
+    char memo[SP_STRING_FIELD_LEN];
+
     // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged, MetaDEx, SendAll
     unsigned char ecosystem;
 
@@ -171,6 +174,7 @@ public:
     unsigned short getVersion() const { return version; }
     unsigned short getPropertyType() const { return prop_type; }
     uint64_t getFeePaid() const { return tx_fee_paid; }
+    std::string getMemo() const { return memo; }
     std::string getSender() const { return sender; }
     std::string getReceiver() const { return receiver; }
     std::string getPayload() const { return HexStr(pkt, pkt + pkt_size); }
@@ -215,6 +219,7 @@ public:
         version = 0;
         nValue = 0;
         nNewValue = 0;
+        memset(&memo, 0, sizeof(memo));
         property = 0;
         ecosystem = 0;
         prop_type = 0;


### PR DESCRIPTION
@CraigSellars has requested a priority addition to simple send, to allow a note/memo to be attached with the transaction.

This PR serves as proof of concept code for the addition and as a placeholder for discussion of the change.  It is not intended to be merged as-is.

`omni_send` has been adjusted to allow for an optional memo string.  If text for the memo field is supplied the payload will be created v1 with the memo, if none is supplied the payload will be created v0 with no memo.  

@dexX7 I reordered the params on `omni_send` so a memo could be sent without having to specify manual redeem address and reference amounts - it feels better this way but does change the parameter order which I usually don't like doing (can break backwards compat) - conversely I see a memo being used probably more often that manual redeem addresses/reference amounts.  What do you think?

I haven't added feature activation for this one, I'm not 100% sure how we should handle it.  Basically because the memo is appended to the end of the payload in this proposed v1 simple send, we could actually skip incrementing the transaction version.  Earlier versions of Omni Core only look at the first 16 bytes of a simple send and would decode it fine (just without the memo).  So it shouldn't be consensus breaking on unsupported clients if we added memos to v0 transactions, though I'm also not really a fan of that idea.  Currently I built the PR with separate versions, and if we keep it this way I'll need to add activation for the new version.

A regular simple send gets sent as v0

```
$ src/omnicore-cli --testnet omni_send mkS9rGbmSefsWmBkCYGJpzcrJbcaziWVLK mfv4NUBwzFf81zxpXHTJNonYXKZTZi3VuZ 1 0.1
3c7caa789c8bdbee7c8f914714b0b22130cf07dfe869843ba1c45a7e2ae36dff
$ src/omnicore-cli --testnet omni_gettransaction 3c7caa789c8bdbee7c8f914714b0b22130cf07dfe869843ba1c45a7e2ae36dff | grep version
    "version" : 0,
```

A simple send with a memo gets sent as v1

```
$ src/omnicore-cli --testnet omni_send mkS9rGbmSefsWmBkCYGJpzcrJbcaziWVLK mfv4NUBwzFf81zxpXHTJNonYXKZTZi3VuZ 1 2.1 "Test Memo"
f64599f8a87f9f036142d5b00dea4669800a44602952ee1a5123ad291b68e29b
$ src/omnicore-cli --testnet omni_gettransaction f64599f8a87f9f036142d5b00dea4669800a44602952ee1a5123ad291b68e29b | grep version
    "version" : 1,
```

Decoding is pretty straight forward:

```
parseTransaction(block=577671, 2015-10-13 06:51:23 idx= 8); txid: f64599f8a87f9f036142d5b00dea4669800a44602952ee1a5123ad291b68e29b
2015-10-13 06:53:32     ------------------------------
2015-10-13 06:53:32              version: 1, class C
2015-10-13 06:53:32                 type: 0 (Simple Send)
2015-10-13 06:53:32             property: 1 (OMNI)
2015-10-13 06:53:32                value: 2.10000000
2015-10-13 06:53:32                 memo: Test Memo
2015-10-13 06:53:32 update_tally_map(mkS9rGbmSefsWmBkCYGJpzcrJbcaziWVLK, 1=0x1, -210000000, ttype=0): before=1680000000, after=1470000000
2015-10-13 06:53:32 update_tally_map(mfv4NUBwzFf81zxpXHTJNonYXKZTZi3VuZ, 1=0x1, +210000000, ttype=0): before=120000000, after=330000000
2015-10-13 06:53:32 recordTX(f64599f8a87f9f036142d5b00dea4669800a44602952ee1a5123ad291b68e29b, valid=YES, block= 577671, type= 0, value= 210000000)

{
    "txid" : "f64599f8a87f9f036142d5b00dea4669800a44602952ee1a5123ad291b68e29b",
    "fee" : "0.00027853",
    "sendingaddress" : "mkS9rGbmSefsWmBkCYGJpzcrJbcaziWVLK",
    "referenceaddress" : "mfv4NUBwzFf81zxpXHTJNonYXKZTZi3VuZ",
    "ismine" : true,
    "version" : 1,
    "type_int" : 0,
    "type" : "Simple Send",
    "propertyid" : 1,
    "divisible" : true,
    "amount" : "2.10000000",
    "memo" : "Test Memo",
    "valid" : true,
    "blockhash" : "000000000db09a900cfbb4a9391262e630380821943e55909c300d616094ab3d",
    "blocktime" : 1444719083,
    "block" : 577671,
    "confirmations" : 1
}
```

Thoughts on approach and concept code?

Thanks
Z
