### PR TITLE
Remove "Experimental UI" label GUI splash screen

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -35,7 +35,7 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
 
     // define text to place
     QString titleText       = tr("Omni Core");
-    QString versionText     = QString("Experimental UI %1").arg(QString::fromStdString(OmniCoreVersion()));
+    QString versionText     = QString("v%1").arg(QString::fromStdString(OmniCoreVersion()));
     QString copyrightText   = QChar(0xA9)+QString(" 2009-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Bitcoin Core developers"));
             copyrightText  += QString(", ");
             copyrightText  += QChar(0xA9)+QString(" 2013-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Omni Core developers"));


### PR DESCRIPTION
Even though Omni Core may be considered as experimental, as sign of confidence the label on the UI splash screen is removed.

Before:

![splash_old](https://cloud.githubusercontent.com/assets/5836089/10864433/4b358e14-7fee-11e5-91cc-06ad332bc01c.png)

Updated:

![splash_v](https://cloud.githubusercontent.com/assets/5836089/10864461/df2a128e-7fee-11e5-9083-97b31fcedf17.png)

This resolves #271.