### PR TITLE
Don't use "N/A" label for transactions with type 0

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -130,8 +130,7 @@ public:
                 }
                 // override amount for cancels
                 if (p_pending->type == MSC_TYPE_METADEX_CANCEL_PRICE || p_pending->type == MSC_TYPE_METADEX_CANCEL_PAIR ||
-                    p_pending->type == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM || p_pending->type == MSC_TYPE_SEND_ALL ||
-                    p_pending->type == 0 /* Unknown */) {
+                    p_pending->type == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM || p_pending->type == MSC_TYPE_SEND_ALL) {
                     omniAmountStr = QString::fromStdString("N/A");
                 }
             }
@@ -208,8 +207,7 @@ public:
 
                             // override amount for cancels
                             if (mp_obj.getType() == MSC_TYPE_METADEX_CANCEL_PRICE || mp_obj.getType() == MSC_TYPE_METADEX_CANCEL_PAIR ||
-                                mp_obj.getType() == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM || mp_obj.getType() == MSC_TYPE_SEND_ALL ||
-                                mp_obj.getType() == 0 /* Unknown */) {
+                                mp_obj.getType() == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM || mp_obj.getType() == MSC_TYPE_SEND_ALL) {
                                 omniAmountStr = QString::fromStdString("N/A");
                             }
 

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -240,8 +240,7 @@ int TXHistoryDialog::PopulateHistoryMap()
             bool fundsMoved = true;
             htxo.txType = shrinkTxType(pending.type, &fundsMoved);
             if (pending.type == MSC_TYPE_METADEX_CANCEL_PRICE || pending.type == MSC_TYPE_METADEX_CANCEL_PAIR ||
-                pending.type == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM || pending.type == MSC_TYPE_SEND_ALL ||
-                pending.type == 0 /* Unknown */) {
+                pending.type == MSC_TYPE_METADEX_CANCEL_ECOSYSTEM || pending.type == MSC_TYPE_SEND_ALL) {
                 htxo.amount = "N/A";
             }
             txHistoryMap.insert(std::make_pair(txHash, htxo));


### PR DESCRIPTION
Recent simple sends were shown with "N/A" amounts on the overview page.

This resolves #284.