### PR TITLE
Expose payload over RPC and add payload size

### DIFF
--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -158,7 +158,7 @@ Value omni_getpayload(const Array& params, bool fHelp)
             "  \"payload\" : \"payloadmessage\",       (string) the decoded Omni payload message\n"
             "  \"payloadsize\" : n,                    (number) the size of the payload\n"
             "}\n"
-            "\nbExamples:\n"
+            "\nExamples:\n"
             + HelpExampleCli("omni_getpayload", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
             + HelpExampleRpc("omni_getpayload", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -191,6 +191,7 @@ public:
     uint16_t getAlertType() const { return alert_type; }
     uint32_t getAlertExpiry() const { return alert_expiry; }
     std::string getAlertMessage() const { return alert_text; }
+    int getPayloadSize() const { return pkt_size; }
 
     /** Creates a new CMPTransaction object. */
     CMPTransaction()

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -377,6 +377,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_gettradehistoryforaddress",  &omni_gettradehistoryforaddress,  false,      true,       false },
     { "omni layer (data retrieval)",         "omni_gettradehistoryforpair",     &omni_gettradehistoryforpair,     false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getcurrentconsensushash",    &omni_getcurrentconsensushash,    false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getpayload",                 &omni_getpayload,                 false,      true,       false },
 #ifdef ENABLE_WALLET
     { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -248,6 +248,7 @@ extern json_spirit::Value omni_getallbalancesforaddress(const json_spirit::Array
 extern json_spirit::Value omni_gettradehistoryforaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_gettradehistoryforpair(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getcurrentconsensushash(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getpayload(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This PR is to add the ability to query the payload for a transaction over RPC.

The use case is primarily that for OmniChest.info, each time I upgrade the back-end daemon I actually use a customized copy of the source to expose the payload.  I'd like to start using our release builds directly without modification, plus I figured it might be of use to others.

This uses the existing ```getPayload``` from ```CMPTransaction``` class and adds a new ```getPayloadSize``` to same.