### PR TITLE
Add API documentation for "omni_getpayload"

### DIFF
--- a/src/omnicore/doc/release-notes.md
+++ b/src/omnicore/doc/release-notes.md
@@ -523,6 +523,9 @@ The following list includes relevant pull requests merged into this release:
 - #282 Update base to Bitcoin Core 0.10.4
 - #285 Don't use "N/A" label for transactions with type 0
 - #286 Bump version to Omni Core 0.0.10-rc3
+- #288 Expose payload over RPC and add payload size
+- #291 Add error handlers for "omni_getpayload"
+- #292 Add API documentation for "omni_getpayload"
 ```
 
 Credits

--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -1287,6 +1287,32 @@ $ omnicore-cli "omni_getactivations"
 
 ---
 
+### omni_getpayload
+
+Get the payload for an Omni transaction.
+
+**Arguments:**
+
+| Name                | Type    | Presence | Description                                                                                  |
+|---------------------|---------|----------|----------------------------------------------------------------------------------------------|
+| `txid`              | string  | required | the hash of the transaction to retrieve payload                                              |
+
+**Result:**
+```js
+{
+  "payload" : "payloadmessage",  // (string) the decoded Omni payload message
+  "payloadsize" : n              // (number) the size of the payload
+}
+```
+
+**Example:**
+
+```bash
+$ omnicore-cli "omni_getactivations" "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"
+```
+
+---
+
 ## Raw transactions
 
 The RPCs for raw transactions can be used to decode or create raw Omni transactions.


### PR DESCRIPTION
This pull request adds the API documentation for `"omni_getpayload"` and updates  the change log.

It resolves #290.