### PR TITLE
Force UI update every block with Omni transactions

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -4127,7 +4127,7 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     CheckExpiredAlerts(nBlockNow, pBlockIndex->GetBlockTime());
 
     // transactions were found in the block, signal the UI accordingly
-    if (countMP > 0) CheckWalletUpdate();
+    if (countMP > 0) CheckWalletUpdate(true);
 
     // calculate and print a consensus hash if required
     if (msc_debug_consensus_hash_every_block) {


### PR DESCRIPTION
To ensure that transactions, which have no impact on the balances, also
UI updates, the UI is updated after every block with Omni transactions,
even if they may not involve the wallet at all.

This is a workaround for now, but seems like the lesser evil.

It resolves #301.