### PR TITLE
Support providing height for omni_decodetransaction

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -1325,12 +1325,15 @@ Decodes an Omni transaction.
 
 If the inputs of the transaction are not in the chain, then they must be provided, because the transaction inputs are used to identify the sender of a transaction.
 
+A block height can be provided, which is used to determine the parsing rules.
+
 **Arguments:**
 
 | Name                | Type    | Presence | Description                                                                                  |
 |---------------------|---------|----------|----------------------------------------------------------------------------------------------|
 | `rawtx`             | string  | required | the raw transaction to decode                                                                |
 | `prevtxs`           | string  | optional | a JSON array of transaction inputs (default: none)                                           |
+| `height`            | number  | optional | the parsing block height (default: 0 for chain height)                                       |
 
 The format of `prevtxs` is as following:
 

--- a/src/omnicore/rpcrawtx.cpp
+++ b/src/omnicore/rpcrawtx.cpp
@@ -30,14 +30,16 @@ using namespace json_spirit;
 
 Value omni_decodetransaction(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() < 1 || params.size() > 3)
         throw std::runtime_error(
-            "omni_decodetransaction \"rawtx\" ( \"prevtxs\" )\n"
+            "omni_decodetransaction \"rawtx\" ( \"prevtxs\" height )\n"
 
             "\nDecodes an Omni transaction.\n"
 
             "\nIf the inputs of the transaction are not in the chain, then they must be provided, because "
             "the transaction inputs are used to identify the sender of a transaction.\n"
+
+            "\nA block height can be provided, which is used to determine the parsing rules.\n"
 
             "\nArguments:\n"
             "1. rawtx                (string, required) the raw transaction to decode\n"
@@ -51,6 +53,7 @@ Value omni_decodetransaction(const Array& params, bool fHelp)
             "       }\n"
             "       ,...\n"
             "     ]\n"
+            "3. height               (number, optional) the parsing block height (default: 0 for chain height)\n"
 
             "\nResult:\n"
             "{\n"
@@ -81,6 +84,11 @@ Value omni_decodetransaction(const Array& params, bool fHelp)
         InputsToView(prevTxsParsed, viewTemp);
     }
 
+    int blockHeight = 0;
+    if (params.size() > 2) {
+        blockHeight = params[2].get_int();
+    }
+
     Object txObj;
     int populateResult = -3331;
     {
@@ -88,7 +96,7 @@ Value omni_decodetransaction(const Array& params, bool fHelp)
         // temporarily switch global coins view cache for transaction inputs
         std::swap(view, viewTemp);
         // then get the results
-        populateResult = populateRPCTransactionObject(tx, 0, txObj);
+        populateResult = populateRPCTransactionObject(tx, 0, txObj, "", false, "", blockHeight);
         // and restore the original, unpolluted coins view cache
         std::swap(viewTemp, view);
     }

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -56,11 +56,13 @@ int populateRPCTransactionObject(const uint256& txid, Object& txobj, std::string
     return populateRPCTransactionObject(tx, blockHash, txobj, filterAddress, extendedDetails, extendedDetailsFilter);
 }
 
-int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHash, Object& txobj, std::string filterAddress, bool extendedDetails, std::string extendedDetailsFilter)
+int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHash, Object& txobj, std::string filterAddress, bool extendedDetails, std::string extendedDetailsFilter, int blockHeight)
 {
     int confirmations = 0;
     int64_t blockTime = 0;
-    int blockHeight = GetHeight();
+    if (blockHeight == 0) {
+        blockHeight = GetHeight();
+    }
 
     if (blockHash != 0) {
         CBlockIndex* pBlockIndex = GetBlockIndex(blockHash);
@@ -134,10 +136,14 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
     populateRPCTypeInfo(mp_obj, txobj, mp_obj.getType(), extendedDetails, extendedDetailsFilter);
 
     // state and chain related information
-    if (confirmations > 0) txobj.push_back(Pair("valid", valid));
-    if (confirmations > 0) txobj.push_back(Pair("blockhash", blockHash.GetHex()));
-    if (confirmations > 0) txobj.push_back(Pair("blocktime", blockTime));
-    if (confirmations > 0) txobj.push_back(Pair("block", blockHeight));
+    if (confirmations != 0 && blockHash != 0) {
+        txobj.push_back(Pair("valid", valid));
+        txobj.push_back(Pair("blockhash", blockHash.GetHex()));
+        txobj.push_back(Pair("blocktime", blockTime));
+    }
+    if (confirmations != 0) {
+        txobj.push_back(Pair("block", blockHeight));
+    }
     txobj.push_back(Pair("confirmations", confirmations));
 
     // finished

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -9,7 +9,7 @@ class CMPTransaction;
 class CTransaction;
 
 int populateRPCTransactionObject(const uint256& txid, json_spirit::Object& txobj, std::string filterAddress = "", bool extendedDetails = false, std::string extendedDetailsFilter = "");
-int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHash, json_spirit::Object& txobj, std::string filterAddress = "", bool extendedDetails = false, std::string extendedDetailsFilter = "");
+int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHash, json_spirit::Object& txobj, std::string filterAddress = "", bool extendedDetails = false, std::string extendedDetailsFilter = "", int blockHeight = 0);
 
 void populateRPCTypeInfo(CMPTransaction& mp_obj, json_spirit::Object& txobj, uint32_t txType, bool extendedDetails, std::string extendedDetailsFilter);
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -172,6 +172,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendalert", 2 },
     /* Omni Core - raw transaction calls */
     { "omni_decodetransaction", 1 },
+    { "omni_decodetransaction", 2 },
     { "omni_createrawtx_reference", 2 },
     { "omni_createrawtx_input", 2 },
     { "omni_createrawtx_change", 1 },


### PR DESCRIPTION
Support providing height for `omni_decodetransaction`, which allows decoding of transactions with different parsing rules.

This resolves #313.