### PR TITLE
Expose feature activation fields when decoding transaction

### DIFF
--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -197,6 +197,9 @@ void populateRPCTypeInfo(CMPTransaction& mp_obj, Object& txobj, uint32_t txType,
         case MSC_TYPE_CHANGE_ISSUER_ADDRESS:
             populateRPCTypeChangeIssuer(mp_obj, txobj);
             break;
+        case OMNICORE_MESSAGE_TYPE_ACTIVATION:
+            populateRPCTypeActivation(mp_obj, txobj);
+            break;
     }
 }
 
@@ -221,6 +224,7 @@ bool showRefForTx(uint32_t txType)
         case MSC_TYPE_REVOKE_PROPERTY_TOKENS: return false;
         case MSC_TYPE_CHANGE_ISSUER_ADDRESS: return true;
         case MSC_TYPE_SEND_ALL: return true;
+        case OMNICORE_MESSAGE_TYPE_ACTIVATION: return false;
     }
     return true; // default to true, shouldn't be needed but just in case
 }
@@ -476,6 +480,13 @@ void populateRPCTypeChangeIssuer(CMPTransaction& omniObj, Object& txobj)
     uint32_t propertyId = omniObj.getProperty();
     txobj.push_back(Pair("propertyid", (uint64_t)propertyId));
     txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
+}
+
+void populateRPCTypeActivation(CMPTransaction& omniObj, Object& txobj)
+{
+    txobj.push_back(Pair("featureid", (uint64_t) omniObj.getFeatureId()));
+    txobj.push_back(Pair("activationblock", (uint64_t) omniObj.getActivationBlock()));
+    txobj.push_back(Pair("minimumversion", (uint64_t) omniObj.getMinClientVersion()));
 }
 
 void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, Object& txobj)

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -29,6 +29,7 @@ void populateRPCTypeCloseCrowdsale(CMPTransaction& omniObj, json_spirit::Object&
 void populateRPCTypeGrant(CMPTransaction& omniObj, json_spirit::Object& txobj);
 void populateRPCTypeRevoke(CMPTransaction& omniOobj, json_spirit::Object& txobj);
 void populateRPCTypeChangeIssuer(CMPTransaction& omniObj, json_spirit::Object& txobj);
+void populateRPCTypeActivation(CMPTransaction& omniObj, json_spirit::Object& txobj);
 
 void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, json_spirit::Object& txobj);
 void populateRPCExtendedTypeMetaDExTrade(const uint256& txid, uint32_t propertyIdForSale, int64_t amountForSale, json_spirit::Object& txobj);

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -192,6 +192,9 @@ public:
     uint32_t getAlertExpiry() const { return alert_expiry; }
     std::string getAlertMessage() const { return alert_text; }
     int getPayloadSize() const { return pkt_size; }
+    uint16_t getFeatureId() const { return feature_id; }
+    uint32_t getActivationBlock() const { return activation_block; }
+    uint32_t getMinClientVersion() const { return min_client_version; }
 
     /** Creates a new CMPTransaction object. */
     CMPTransaction()


### PR DESCRIPTION
Expose feature activation fields when decoding transaction to support parsing of feature activation transactions.

This resolves #314.