### PR TITLE
Grow balances to fit on overview tab

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -238,6 +238,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>1</width>


### PR DESCRIPTION
For users with many different tokens the balances panel on the overview page may not be big enough, which results in a scroll bar. However, when resizing the client window, the panel doesn't grow:


![screen shot 2015-12-01 at 7 04 02 pm](https://cloud.githubusercontent.com/assets/61612/11521938/a3271094-9866-11e5-95cb-54006e606161.png)

With this patch the spacer below the panel is fixed, which results in "sticking" panels. Unfortunally this only works very well for the balances tab, whereby the "recent transactions" remain to be limited to 6 entries.

**Minimum size:**

![small](https://cloud.githubusercontent.com/assets/5836089/12064881/f0c6c442-afcd-11e5-80b0-e04477c0eecf.png)

**Resized:**

![big](https://cloud.githubusercontent.com/assets/5836089/12064888/005ea73a-afce-11e5-8932-debe757e6d7d.png)

This partially resolves #296.