### PR TITLE
Switch to Bitcoin tab in Send page when handling Bitcoin URIs

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -83,10 +83,10 @@ WalletView::WalletView(QWidget *parent):
     QVBoxLayout *svbox = new QVBoxLayout();
     sendCoinsTab = new SendCoinsDialog();
     sendMPTab = new SendMPDialog();
-    QTabWidget *tabHolder = new QTabWidget();
-    tabHolder->addTab(sendMPTab,tr("Omni Layer"));
-    tabHolder->addTab(sendCoinsTab,tr("Bitcoin"));
-    svbox->addWidget(tabHolder);
+    sendTabHolder = new QTabWidget();
+    sendTabHolder->addTab(sendMPTab,tr("Omni Layer"));
+    sendTabHolder->addTab(sendCoinsTab,tr("Bitcoin"));
+    svbox->addWidget(sendTabHolder);
     sendCoinsPage->setLayout(svbox);
     // exchange page
     exchangePage = new QWidget(this);
@@ -307,6 +307,7 @@ void WalletView::gotoVerifyMessageTab(QString addr)
 
 bool WalletView::handlePaymentRequest(const SendCoinsRecipient& recipient)
 {
+    sendTabHolder->setCurrentIndex(1);
     return sendCoinsTab->handlePaymentRequest(recipient);
 }
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -89,6 +89,7 @@ private:
     QWidget *bitcoinTXTab;
     QProgressDialog *progressDialog;
     QTabWidget *txTabHolder;
+    QTabWidget *sendTabHolder;
 
 public slots:
     /** Switch to overview (home) page */


### PR DESCRIPTION
The ```handlePaymentRequest``` function of the wallet view has no knowledge of the extra Omni tab we've implemented and since the Omni tab is now the default, Bitcoin URIs do not necessarily activate the Bitcoin tab of the Send page.

This PR serves to automatically switch the tab in the Send page to Bitcoin when handling Bitcoin URIs.

Resolves https://github.com/OmniLayer/omnicore/issues/311.