### PR TITLE
Update and add unit tests for new consensus hashes

### DIFF
--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -3,6 +3,7 @@ OMNICORE_TEST_H = \
 
 OMNICORE_TEST_CPP = \
   omnicore/test/alert_tests.cpp \
+  omnicore/test/checkpoint_tests.cpp \
   omnicore/test/create_payload_tests.cpp \
   omnicore/test/create_tx_tests.cpp \
   omnicore/test/crowdsale_participation_tests.cpp \

--- a/src/omnicore/consensushash.cpp
+++ b/src/omnicore/consensushash.cpp
@@ -34,10 +34,10 @@ std::string GenerateConsensusString(const CMPTally& tallyObj, const std::string&
 }
 
 // Generates a consensus string for hashing based on a DEx sell offer object
-std::string GenerateConsensusString(const CMPOffer& offerObj, const std::string& address, const uint32_t propertyId)
+std::string GenerateConsensusString(const CMPOffer& offerObj, const std::string& address)
 {
     return strprintf("%s|%s|%d|%d|%d|%d|%d",
-            offerObj.getHash().GetHex(), address, propertyId, offerObj.getOfferAmountOriginal(),
+            offerObj.getHash().GetHex(), address, offerObj.getProperty(), offerObj.getOfferAmountOriginal(),
             offerObj.getBTCDesiredOriginal(), offerObj.getMinFee(), offerObj.getBlockTimeLimit());
 }
 
@@ -151,14 +151,13 @@ uint256 GetConsensusHash()
     for (OfferMap::iterator it = my_offers.begin(); it != my_offers.end(); ++it) {
         const CMPOffer& selloffer = it->second;
         const std::string& sellCombo = it->first;
-        uint32_t propertyId = selloffer.getProperty();
         std::string seller = sellCombo.substr(0, sellCombo.size() - 2);
-        std::string dataStr = GenerateConsensusString(selloffer, seller, propertyId);
+        std::string dataStr = GenerateConsensusString(selloffer, seller);
         vecDExOffers.push_back(std::make_pair(selloffer.getHash(), dataStr));
     }
     std::sort (vecDExOffers.begin(), vecDExOffers.end());
     for (std::vector<std::pair<uint256, std::string> >::iterator it = vecDExOffers.begin(); it != vecDExOffers.end(); ++it) {
-        std::string dataStr = (*it).second;
+        const std::string& dataStr = it->second;
         if (msc_debug_consensus_hash) PrintToLog("Adding DEx offer data to consensus hash: %s\n", dataStr);
         SHA256_Update(&shaCtx, dataStr.c_str(), dataStr.length());
     }
@@ -176,7 +175,7 @@ uint256 GetConsensusHash()
     }
     std::sort (vecAccepts.begin(), vecAccepts.end());
     for (std::vector<std::pair<std::string, std::string> >::iterator it = vecAccepts.begin(); it != vecAccepts.end(); ++it) {
-        std::string dataStr = (*it).second;
+        const std::string& dataStr = it->second;
         if (msc_debug_consensus_hash) PrintToLog("Adding DEx accept to consensus hash: %s\n", dataStr);
         SHA256_Update(&shaCtx, dataStr.c_str(), dataStr.length());
     }
@@ -197,7 +196,7 @@ uint256 GetConsensusHash()
     }
     std::sort (vecMetaDExTrades.begin(), vecMetaDExTrades.end());
     for (std::vector<std::pair<uint256, std::string> >::iterator it = vecMetaDExTrades.begin(); it != vecMetaDExTrades.end(); ++it) {
-        std::string dataStr = (*it).second;
+        const std::string& dataStr = it->second;
         if (msc_debug_consensus_hash) PrintToLog("Adding MetaDEx trade data to consensus hash: %s\n", dataStr);
         SHA256_Update(&shaCtx, dataStr.c_str(), dataStr.length());
     }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2547,7 +2547,7 @@ int mastercore_save_state( CBlockIndex const *pBlockIndex )
 /**
  * Clears the state of the system.
  */
-static void clear_all_state()
+void clear_all_state()
 {
     LOCK2(cs_tally, cs_pending);
 

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -91,9 +91,8 @@ std::vector<ConsensusCheckpoint> CMainConsensusParams::GetCheckpoints() const
 {
     // block height, block hash and consensus hash
     const ConsensusCheckpoint vCheckpoints[] = {
-        /** TODO: Generate block 0 checkpoint
         {      0, uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                  uint256("") }, **/
+                  uint256("15cecb88f2d0eb8a2a85e8c8c3e2f60df1b2b365404eac97abfecead8d92e371") },
         { 250000, uint256("000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"),
                   uint256("c2e1e0f3cf3c49d8ee08bd45ad39be27eb400041d6288864ee144892449c97df") },
         { 260000, uint256("000000000000001fb91fbcebaaba0e2d926f04908d798a8b598c3bd962951080"),

--- a/src/omnicore/test/checkpoint_tests.cpp
+++ b/src/omnicore/test/checkpoint_tests.cpp
@@ -1,4 +1,7 @@
 #include "omnicore/consensushash.h"
+#include "omnicore/dex.h"
+#include "omnicore/mdex.h"
+#include "omnicore/sp.h"
 #include "omnicore/omnicore.h"
 #include "omnicore/rules.h"
 #include "omnicore/tally.h"
@@ -11,49 +14,86 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace mastercore
+{
+extern std::string GenerateConsensusString(const CMPTally& tallyObj, const std::string& address, const uint32_t propertyId); // done
+extern std::string GenerateConsensusString(const CMPOffer& offerObj, const std::string& address); // half
+extern std::string GenerateConsensusString(const CMPAccept& acceptObj, const std::string& address);
+extern std::string GenerateConsensusString(const CMPMetaDEx& tradeObj);
+extern std::string GenerateConsensusString(const CMPCrowd& crowdObj);
+extern std::string GenerateConsensusString(const uint32_t propertyId, const std::string& address);
+}
+
+extern void clear_all_state();
+
 using namespace mastercore;
 
 BOOST_AUTO_TEST_SUITE(omnicore_checkpoint_tests)
 
-BOOST_AUTO_TEST_CASE(hash_generation)
+BOOST_AUTO_TEST_CASE(consensus_string_tally)
 {
-    LOCK(cs_tally);
-    mp_tally_map.clear();
+    CMPTally tally;
+    BOOST_CHECK_EQUAL("", GenerateConsensusString(tally, "3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1));
+    BOOST_CHECK_EQUAL("", GenerateConsensusString(tally, "3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 3));
 
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "55b852781b9995a44c939b64e441ae2724b96f99c8f4fb9a141cfc9842c4b0e3");
-    BOOST_CHECK(update_tally_map("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1, 12345, BALANCE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "33c9eb05f8720c170d93cfcd835bd53bca879ab10990ff178ebe682fc6d6d05c");
-    BOOST_CHECK(update_tally_map("1LCShN3ntEbeRrj8XBFWdScGqw5NgDXL5R", 3,  3400, BALANCE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "53c82a68c4d53195853fde3f55fa86c0c29dc0f5e328dd05346d177012f4b8c4");
-    BOOST_CHECK(update_tally_map("1LCShN3ntEbeRrj8XBFWdScGqw5NgDXL5R", 3, -3400, BALANCE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "33c9eb05f8720c170d93cfcd835bd53bca879ab10990ff178ebe682fc6d6d05c");
-    BOOST_CHECK(update_tally_map("1LP7G6uiHPaG8jm64aconFF8CLBAnRGYcb", 2, 50000, METADEX_RESERVE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "f7a031b7ab173531fa2d06a18b85d3158ccea2831097c12df2e389210c74a935");
-    BOOST_CHECK(update_tally_map("1LP7G6uiHPaG8jm64aconFF8CLBAnRGYcb", 10, 1, ACCEPT_RESERVE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "19784f4446df274cca995935163694e49566c7a02e9f50ea871540129dd395af");
-    BOOST_CHECK(update_tally_map("1LP7G6uiHPaG8jm64aconFF8CLBAnRGYcb", 1, 100, SELLOFFER_RESERVE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "1751f9ecd4ba1d14ad779ae8a2f33586312788573e72b1b99df65368b124fec7");
-    BOOST_CHECK(update_tally_map("1LP7G6uiHPaG8jm64aconFF8CLBAnRGYcb", 1, 9223372036854775807, BALANCE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "b4dabf6d23ffe815d811b1ccee0dbf2357afaf0546300889ae1ad7d60210a27b");
-    BOOST_CHECK(update_tally_map("1LP7G6uiHPaG8jm64aconFF8CLBAnRGYcb", 1, -9223372036854775807, BALANCE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "1751f9ecd4ba1d14ad779ae8a2f33586312788573e72b1b99df65368b124fec7");
-    BOOST_CHECK(update_tally_map("1LCShN3ntEbeRrj8XBFWdScGqw5NgDXL5R", 31, -8000, PENDING));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "1751f9ecd4ba1d14ad779ae8a2f33586312788573e72b1b99df65368b124fec7");
-    BOOST_CHECK(update_tally_map("1LCShN3ntEbeRrj8XBFWdScGqw5NgDXL5R", 31, 8000, BALANCE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "1321c7a7590f03c46706a1be64b9c58f9d49239fc3bdfdb0d238cb0fc2d80175");
-    BOOST_CHECK(update_tally_map("1LCShN3ntEbeRrj8XBFWdScGqw5NgDXL5R", 2147483657, 234235245, METADEX_RESERVE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "f02f133992121312244c355de3fbd3dd64523972e7129b77579061205e1b7dfc");
-    BOOST_CHECK(update_tally_map("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1, -50000, PENDING));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "f02f133992121312244c355de3fbd3dd64523972e7129b77579061205e1b7dfc");
-    BOOST_CHECK(update_tally_map("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1, 9000, METADEX_RESERVE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "dc2d2536556d55d872a65e11aead6475bf283cd44deaa375722e583780c34152");
-    BOOST_CHECK(update_tally_map("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1, 777, ACCEPT_RESERVE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "78bc5630403a25626b19bc6dd2ed6f93b5b84502a63d203efbd378897d56640c");
-    BOOST_CHECK(update_tally_map("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1, 5, SELLOFFER_RESERVE));
-    BOOST_CHECK_EQUAL(GetConsensusHash().GetHex(), "3580e94167f75620dfa8c267862aa47af46164ed8edaec3a800d732050ec0607");
+    BOOST_CHECK(tally.updateMoney(3, 7, BALANCE));
+    BOOST_CHECK_EQUAL("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b|3|7|0|0|0",
+            GenerateConsensusString(tally, "3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 3));
 
-    // Cleanup
-    mp_tally_map.clear();
+    BOOST_CHECK(tally.updateMoney(3, 7, BALANCE));
+    BOOST_CHECK(tally.updateMoney(3, 100, SELLOFFER_RESERVE));
+    BOOST_CHECK(tally.updateMoney(3, int64_t(9223372036854775807LL), ACCEPT_RESERVE));
+    BOOST_CHECK(tally.updateMoney(3, (-int64_t(9223372036854775807LL)-1), PENDING)); // ignored
+    BOOST_CHECK(tally.updateMoney(3, int64_t(4294967296L), METADEX_RESERVE));
+    BOOST_CHECK_EQUAL("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b|3|14|100|9223372036854775807|4294967296",
+            GenerateConsensusString(tally, "3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 3));
+}
+
+BOOST_AUTO_TEST_CASE(consensus_string_offer)
+{
+    CMPOffer offerA;
+    BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000000|3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b|0|0|0|0|0",
+            GenerateConsensusString(offerA, "3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b"));
+
+    CMPOffer offerB(340000, 3000, 2, 100000, 1000, 10, uint256("3c9a055899147b03b2c5240a020c1f94d243a834ecc06ab8cfa504ee29d07b7d"));
+    BOOST_CHECK_EQUAL("3c9a055899147b03b2c5240a020c1f94d243a834ecc06ab8cfa504ee29d07b7d|1HG3s4Ext3sTqBTHrgftyUzG3cvx5ZbPCj|2|3000|100000|1000|10",
+            GenerateConsensusString(offerB, "1HG3s4Ext3sTqBTHrgftyUzG3cvx5ZbPCj"));
+}
+
+BOOST_AUTO_TEST_CASE(consensus_string_accept)
+{
+    CMPAccept accept(1234, 1000, 350000, 10, 2, 2000, 4000, uint256("2c9a055899147b03b2c5240a020c1f94d243a834ecc06ab8cfa504ee29d07b7b"));
+    BOOST_CHECK_EQUAL("2c9a055899147b03b2c5240a020c1f94d243a834ecc06ab8cfa504ee29d07b7b|3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b|1234|1000|350000",
+            GenerateConsensusString(accept, "3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b"));
+}
+
+BOOST_AUTO_TEST_CASE(consensus_string_mdex)
+{
+    CMPMetaDEx tradeA;
+    BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000000||0|0|0|0|0",
+            GenerateConsensusString(tradeA));
+
+    CMPMetaDEx tradeB("1PxejjeWZc9ZHph7A3SYDo2sk2Up4AcysH", 395000, 31, 1000000, 1, 2000000,
+            uint256("2c9a055899147b03b2c5240a020c1f94d243a834ecc06ab8cfa504ee29d07b7d"), 1, 1, 900000);
+    BOOST_CHECK_EQUAL("2c9a055899147b03b2c5240a020c1f94d243a834ecc06ab8cfa504ee29d07b7d|1PxejjeWZc9ZHph7A3SYDo2sk2Up4AcysH|31|1000000|1|2000000|900000",
+            GenerateConsensusString(tradeB));
+}
+
+BOOST_AUTO_TEST_CASE(consensus_string_crowdsale)
+{
+    CMPCrowd crowdsaleA;
+    BOOST_CHECK_EQUAL("0|0|0|0|0",
+            GenerateConsensusString(crowdsaleA));
+
+    CMPCrowd crowdsaleB(77, 500000, 3, 1514764800, 10, 255, 10000, 25500);
+    BOOST_CHECK_EQUAL("77|3|1514764800|10000|25500",
+            GenerateConsensusString(crowdsaleB));
+}
+
+BOOST_AUTO_TEST_CASE(consensus_string_property_issuer)
+{
+    BOOST_CHECK_EQUAL("5|3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b",
+            GenerateConsensusString(5, "3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b"));
 }
 
 BOOST_AUTO_TEST_CASE(get_checkpoints)
@@ -67,7 +107,7 @@ BOOST_AUTO_TEST_CASE(get_checkpoints)
 BOOST_AUTO_TEST_CASE(verify_checkpoints)
 {
     LOCK(cs_tally);
-    mp_tally_map.clear();
+    clear_all_state();
 
     // Not a checkpoint (so we assume it's valid)
     BOOST_CHECK(VerifyCheckpoint(1, uint256("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048")));
@@ -82,7 +122,7 @@ BOOST_AUTO_TEST_CASE(verify_checkpoints)
     BOOST_CHECK(!VerifyCheckpoint(0, uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")));
 
     // Cleanup
-    mp_tally_map.clear();
+    clear_all_state();
     BOOST_CHECK(VerifyCheckpoint(0, uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")));
 }
 


### PR DESCRIPTION
This pull request adds and updates the unit tests for consensus hashes and checkpoints.

In particular, the string generation is tested with empty objects and populated objects. The impact on the whole state (and thus consensus hash generation) is not well tested, due to the unhandiness of modifying the state (e.g. adding new orders etc.).

The checkpoint for a blank state and the mainnet genesis block was updated and is tested.