### PR TITLE
Add omni_getmetadexhash() RPC call to hash state of MetaDEx

### DIFF
--- a/src/omnicore/consensushash.h
+++ b/src/omnicore/consensushash.h
@@ -7,6 +7,10 @@ namespace mastercore
 {
 /** Obtains a hash of all balances to use for consensus verification and checkpointing. */
 uint256 GetConsensusHash();
+
+/** Obtains a hash of the overall MetaDEx state (default) or a specific orderbook (supply a property ID). */
+uint256 GetMetaDExHash(const uint32_t propertyId = 0);
+
 }
 
 #endif // OMNICORE_CONSENSUSHASH_H

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1804,3 +1804,47 @@ Value omni_getcurrentconsensushash(const Array& params, bool fHelp)
 
     return response;
 }
+
+Value omni_getmetadexhash(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "omni_getmetadexhash propertyId\n"
+            "\nReturns a hash of the current state of the MetaDEx (default) or orderbook.\n"
+            "\nArguments:\n"
+            "1. propertyid                  (number, optional) hash orderbook (only trades selling propertyid)\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"block\" : nnnnnn,          (number) the index of the block this hash applies to\n"
+            "  \"blockhash\" : \"hash\",    (string) the hash of the corresponding block\n"
+            "  \"propertyid\" : nnnnnn,     (number) the market this hash applies to (or 0 for all markets)\n"
+            "  \"metadexhash\" : \"hash\"   (string) the hash for the state of the MetaDEx/orderbook\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("omni_getmetadexhash", "3")
+            + HelpExampleRpc("omni_getmetadexhash", "3")
+        );
+
+    LOCK(cs_main);
+
+    uint32_t propertyId = 0;
+    if (params.size() > 0) {
+        propertyId = ParsePropertyId(params[0]);
+        RequireExistingProperty(propertyId);
+    }
+
+    int block = GetHeight();
+    CBlockIndex* pblockindex = chainActive[block];
+    uint256 blockHash = pblockindex->GetBlockHash();
+
+    uint256 metadexHash = GetMetaDExHash(propertyId);
+
+    Object response;
+    response.push_back(Pair("block", block));
+    response.push_back(Pair("blockhash", blockHash.GetHex()));
+    response.push_back(Pair("propertyid", (uint64_t)propertyId));
+    response.push_back(Pair("metadexhash", metadexHash.GetHex()));
+
+    return response;
+}

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -131,6 +131,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getorderbook", 1 },
     { "omni_getseedblocks", 0 },
     { "omni_getseedblocks", 1 },
+    { "omni_getmetadexhash", 0 },
 
     /* Omni Core - transaction calls */
     { "omni_send", 2 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -379,6 +379,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_getcurrentconsensushash",    &omni_getcurrentconsensushash,    false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getpayload",                 &omni_getpayload,                 false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getseedblocks",              &omni_getseedblocks,              false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getmetadexhash",             &omni_getmetadexhash,             false,      true,       false },
 #ifdef ENABLE_WALLET
     { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -250,6 +250,7 @@ extern json_spirit::Value omni_gettradehistoryforpair(const json_spirit::Array& 
 extern json_spirit::Value omni_getcurrentconsensushash(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getpayload(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getseedblocks(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getmetadexhash(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This PR provides a mechanism to monitor the MetaDEx for changes, initially required by OmniChest to avoid continually refreshing the same data when it hasn't changed.

Traditionally consensus hashes would be used for this purpose, but as the increase in blocks grants dev Omni to the Exodus address, the consensus hash is thus continually changing.  The new call ```omni_getmetadexhash``` can be used to obtain a hash of just the state of the MetaDEx.  Optionally, a property ID can be supplied to hash a specific orderbook (trades with a specific property ID for sale).

This PR does not change any consensus critical code.
