### PR TITLE
Fix missing client notification for new activations

### DIFF
--- a/src/omnicore/activation.cpp
+++ b/src/omnicore/activation.cpp
@@ -69,6 +69,8 @@ void AddPendingActivation(uint16_t featureId, int activationBlock, uint32_t minC
     featureActivation.minClientVersion = minClientVersion;
 
     vecPendingActivations.push_back(featureActivation);
+
+    uiInterface.OmniStateChanged();
 }
 
 /**


### PR DESCRIPTION
Currently a UI notification for a new activation will only appear after a restart of the client, instead of when it is processed as expected.  This PR instructs the UI to refresh after processing a pending activation.