### PR TITLE
Add positioninblock attribute to RPC output for transactions

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -652,6 +652,7 @@ Get detailed information about an Omni transaction.
   "fee" : "n.nnnnnnnn",            // (string) the transaction fee in bitcoins
   "blocktime" : nnnnnnnnnn,        // (number) the timestamp of the block that contains the transaction
   "valid" : true|false,            // (boolean) whether the transaction is valid
+  "positioninblock" : n,           // (number) the position (index) of the transaction within the block
   "version" : n,                   // (number) the transaction version
   "type_int" : n,                  // (number) the transaction type as number
   "type" : "type",                 // (string) the transaction type as string
@@ -693,6 +694,7 @@ List wallet transactions, optionally filtered by an address and block boundaries
     "fee" : "n.nnnnnnnn",            // (string) the transaction fee in bitcoins
     "blocktime" : nnnnnnnnnn,        // (number) the timestamp of the block that contains the transaction
     "valid" : true|false,            // (boolean) whether the transaction is valid
+    "positioninblock" : n,           // (number) the position (index) of the transaction within the block
     "version" : n,                   // (number) the transaction version
     "type_int" : n,                  // (number) the transaction type as number
     "type" : "type",                 // (string) the transaction type as string
@@ -1037,6 +1039,7 @@ Get information and recipients of a send-to-owners transaction.
   "fee" : "n.nnnnnnnn",          // (string) the transaction fee in bitcoins
   "blocktime" : nnnnnnnnnn,      // (number) the timestamp of the block that contains the transaction
   "valid" : true|false,          // (boolean) whether the transaction is valid
+  "positioninblock" : n,         // (number) the position (index) of the transaction within the block
   "version" : n,                 // (number) the transaction version
   "type_int" : n,                // (number) the transaction type as number
   "type" : "type",               // (string) the transaction type as string
@@ -1082,6 +1085,7 @@ Get detailed information and trade matches for orders on the distributed token e
   "fee" : "n.nnnnnnnn",                         // (string) the transaction fee in bitcoins
   "blocktime" : nnnnnnnnnn,                     // (number) the timestamp of the block that contains the transaction
   "valid" : true|false,                         // (boolean) whether the transaction is valid
+  "positioninblock" : n,                        // (number) the position (index) of the transaction within the block
   "version" : n,                                // (number) the transaction version
   "type_int" : n,                               // (number) the transaction type as number
   "type" : "type",                              // (string) the transaction type as string
@@ -1218,6 +1222,7 @@ Retrieves the history of orders on the distributed exchange for the supplied add
     "fee" : "n.nnnnnnnn",                         // (string) the transaction fee in bitcoins
     "blocktime" : nnnnnnnnnn,                     // (number) the timestamp of the block that contains the transaction
     "valid" : true|false,                         // (boolean) whether the transaction is valid
+    "positioninblock" : n,                        // (number) the position (index) of the transaction within the block
     "version" : n,                                // (number) the transaction version
     "type_int" : n,                               // (number) the transaction type as number
     "type" : "type",                              // (string) the transaction type as string

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -152,6 +152,35 @@ extern bool autoCommit;
 //! Global lock for state objects
 extern CCriticalSection cs_tally;
 
+/** LevelDB based storage for storing Omni transaction data.  This will become the new master database, holding serialized Omni transactions.
+ *  Note, intention is to consolidate and clean up data storage
+ */
+class COmniTransactionDB : public CDBBase
+{
+public:
+    COmniTransactionDB(const boost::filesystem::path& path, bool fWipe)
+    {
+        leveldb::Status status = Open(path, fWipe);
+        PrintToConsole("Loading master transactions database: %s\n", status.ToString());
+    }
+
+    virtual ~COmniTransactionDB()
+    {
+        if (msc_debug_persistence) PrintToLog("COmniTransactionDB closed\n");
+    }
+
+    /* These functions would be expanded upon to store a serialized version of the transaction and associated state data
+     *
+     * void RecordTransaction(const uint256& txid, uint32_t posInBlock, various, other, data);
+     * int FetchTransactionPosition(const uint256& txid);
+     * bool FetchTransactionValidity(const uint256& txid);
+     *
+     * and so on...
+     */
+    void RecordTransaction(const uint256& txid, uint32_t posInBlock);
+    uint32_t FetchTransactionPosition(const uint256& txid);
+};
+
 /** LevelDB based storage for STO recipients.
  */
 class CMPSTOList : public CDBBase
@@ -213,7 +242,7 @@ public:
     CMPTxList(const boost::filesystem::path& path, bool fWipe)
     {
         leveldb::Status status = Open(path, fWipe);
-        PrintToConsole("Loading transactions database: %s\n", status.ToString());
+        PrintToConsole("Loading tx meta-info database: %s\n", status.ToString());
     }
 
     virtual ~CMPTxList()
@@ -286,6 +315,7 @@ extern std::map<std::string, CMPTally> mp_tally_map;
 extern CMPTxList *p_txlistdb;
 extern CMPTradeList *t_tradelistdb;
 extern CMPSTOList *s_stolistdb;
+extern COmniTransactionDB *p_OmniTXDB;
 
 // TODO: move, rename
 extern CCoinsView viewDummy;

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -72,17 +72,6 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
             confirmations = 1 + blockHeight - pBlockIndex->nHeight;
             blockTime = pBlockIndex->nTime;
             blockHeight = pBlockIndex->nHeight;
-            /*
-            CBlock block;
-            if (ReadBlockFromDisk(block, pBlockIndex)) {
-                BOOST_FOREACH(const CTransaction &blocktx, block.vtx) {
-                   positionInBlock++;
-                   if (blocktx.GetHash() == tx.GetHash()) {
-                       break; // positionInBlock is now set to the index of the tx in the block
-                   }
-                }
-            }
-            */
         }
     }
 

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -72,6 +72,7 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
             confirmations = 1 + blockHeight - pBlockIndex->nHeight;
             blockTime = pBlockIndex->nTime;
             blockHeight = pBlockIndex->nHeight;
+            /*
             CBlock block;
             if (ReadBlockFromDisk(block, pBlockIndex)) {
                 BOOST_FOREACH(const CTransaction &blocktx, block.vtx) {
@@ -81,12 +82,13 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
                    }
                 }
             }
+            */
         }
     }
 
     // attempt to parse the transaction
     CMPTransaction mp_obj;
-    int parseRC = ParseTransaction(tx, blockHeight, positionInBlock, mp_obj, blockTime);
+    int parseRC = ParseTransaction(tx, blockHeight, 0, mp_obj, blockTime);
     if (parseRC < 0) return MP_TX_IS_NOT_MASTER_PROTOCOL;
 
     const uint256& txid = tx.GetHash();
@@ -127,6 +129,7 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
     if (confirmations > 0) {
         LOCK(cs_tally);
         valid = getValidMPTX(txid);
+        positionInBlock = p_OmniTXDB->FetchTransactionPosition(txid);
     }
 
     // populate some initial info for the transaction
@@ -151,7 +154,7 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
         txobj.push_back(Pair("valid", valid));
         txobj.push_back(Pair("blockhash", blockHash.GetHex()));
         txobj.push_back(Pair("blocktime", blockTime));
-        txobj.push_back(Pair("positioninblock", (uint64_t)mp_obj.getIndexInBlock()));
+        txobj.push_back(Pair("positioninblock", positionInBlock));
     }
     if (confirmations != 0) {
         txobj.push_back(Pair("block", blockHeight));

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -195,8 +195,6 @@ public:
     uint16_t getFeatureId() const { return feature_id; }
     uint32_t getActivationBlock() const { return activation_block; }
     uint32_t getMinClientVersion() const { return min_client_version; }
-    uint64_t getUniqueTokenStart() const { return unique_token_start; }
-    uint64_t getUniqueTokenEnd() const { return unique_token_end; }
     unsigned int getIndexInBlock() const { return tx_idx; }
 
     /** Creates a new CMPTransaction object. */

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -195,6 +195,9 @@ public:
     uint16_t getFeatureId() const { return feature_id; }
     uint32_t getActivationBlock() const { return activation_block; }
     uint32_t getMinClientVersion() const { return min_client_version; }
+    uint64_t getUniqueTokenStart() const { return unique_token_start; }
+    uint64_t getUniqueTokenEnd() const { return unique_token_end; }
+    unsigned int getIndexInBlock() const { return tx_idx; }
 
     /** Creates a new CMPTransaction object. */
     CMPTransaction()


### PR DESCRIPTION
This PR adds the ```positioninblock``` attribute to RPC transaction objects to provide visibility into the order of an Omni transaction within a block.

Requested by @achamely to help OmniEngine determine which trade was first in the scenario that a trade & a match are both mined in the same block.

NOTE: this is a fairly slow way to do it as it requires loading the block from disk to iterate the transaction order.  Unfortunately when reparsing an individual transaction we don't have the context of the rest of the transactions in the block to do it quickly, so we only know its order/index during inital parsing, not during reparsing (eg when requested to by the RPC layer).

Perhaps a better way would be to store the position in the block via persistence (eg LevelDB) when we initially parse so we can fetch it atomically when transactions are being reparsed later.