### PR TITLE
Add omni_discardmempooltransaction call

### DIFF
--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -180,7 +180,6 @@ Value omni_discardmempooltransaction(const Array& params, bool fHelp)
     Array result;
     BOOST_FOREACH(const CTransaction &tx, removedList) {
         result.push_back(tx.GetHash().GetHex());
-        //result.push_back(Pair("txid", tx.GetHash().GetHex()));
     }
 
     return result;

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -490,7 +490,6 @@ bool IsTransactionTypeAllowed(int txBlock, uint32_t txProperty, uint16_t txType,
  */
 bool VerifyCheckpoint(int block, const uint256& blockHash)
 {
-return true;
     const std::vector<ConsensusCheckpoint>& vCheckpoints = ConsensusParams().GetCheckpoints();
 
     for (std::vector<ConsensusCheckpoint>::const_iterator it = vCheckpoints.begin(); it != vCheckpoints.end(); ++it) {

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -490,6 +490,7 @@ bool IsTransactionTypeAllowed(int txBlock, uint32_t txProperty, uint16_t txType,
  */
 bool VerifyCheckpoint(int block, const uint256& blockHash)
 {
+return true;
     const std::vector<ConsensusCheckpoint>& vCheckpoints = ConsensusParams().GetCheckpoints();
 
     for (std::vector<ConsensusCheckpoint>::const_iterator it = vCheckpoints.begin(); it != vCheckpoints.end(); ++it) {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -387,6 +387,10 @@ static const CRPCCommand vRPCCommands[] =
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
     { "omni layer (configuration)",          "omni_setautocommit",              &omni_setautocommit,              true,       true,       true },
 
+    /* Omni Core miscellaneous calls */
+    /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
+    { "omni layer (misc)",                   "omni_discardmempooltransaction",  &omni_discardmempooltransaction,  true,       true,       false },
+
     /* Omni Core transaction calls */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
     { "omni layer (transaction creation)",   "omni_sendrawtx",                  &omni_sendrawtx,                  false,      true,       true },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -255,6 +255,9 @@ extern json_spirit::Value omni_getmetadexhash(const json_spirit::Array& params, 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);
 
+/* Omni Core miscellaneous calls */
+extern json_spirit::Value omni_discardmempooltransaction(const json_spirit::Array& params, bool fHelp);
+
 /* Omni Core transaction calls */
 extern json_spirit::Value omni_sendrawtx(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_send(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This PR serves to add the capability to Omni Core to manually remove a transaction from the mempool.

Talking with @achamely on issues with OmniWallet whereby a transaction is sent with too low a fee and doesn't get included in a block then gets stuck in the mempool (after being discarded by the rest of the network),  Creating a second transaction to respend those inputs with a higher fee does not work as it's essentially trying to broadcast a double spend through the same node which will be rejected.  A restart of the node is then required (or broadcasting through an alternate node).

A new call is thus added with this PR; `omni_discardmempooltransaction`, just supply a TXID.

In using this call, the transaction will be discarded from the mempool, but will be readded if another node relays it back so the workflow should be to prepare the replacement transaction, remove the stuck transaction from the mempool and immediately broadcast its replacement.

Note: this PR has nothing to do with RBF.

Note: it's important to note that ideally this shouldn't be used on wallet transactions (the command does not remove transactions from the wallet, just the mempool - since OmniWallet doesn't use the wallet functions of Omni Core this shouldn't be an issue).

Usage is pretty simple.  If we look at my current mempool (at time of writing with a just-started node):

```
zathras@OMNIDEV:~/github/build/omnicore$ src/omnicore-cli getrawmempool
[
    "4674f652165d022b60c64ac13bfe152acfe149521ddbfd2e7892515a209f6ad1",
    "666c91bc4d24a4e323239f9a97bcea8ec4c056678c7cb6f4c5f0dbddb1d74ac0",
    "93b4f2d8573f613be0b0b905a079555a6adf2a676d8babb8aee7a3b5b9aacc5a",
    "a5e172aa69a45be37cd2ff1905f81226bfbeb57aced6ce44c3dbb55ec9ce8cde",
    "ba9d5158baddca54e8a7ea17c19eb0d34c5d3020c92e0ebb2be3c0788c717752",
    "c6c0ad63eab139fa86eba7735e213d1a94fc9c5c45c7ee4cd39266ab703e202f",
    "ec7194b411944fa2771da55103e826185599bd99377dcb06e2cdfc5fec5a2626"
]
```

Let's remove the first transaction from the mempool:

```
zathras@OMNIDEV:~/github/build/omnicore$ src/omnicore-cli omni_discardmempooltransaction "4674f652165d022b60c64ac13bfe152acfe149521ddbfd2e7892515a209f6ad1"
[
    "4674f652165d022b60c64ac13bfe152acfe149521ddbfd2e7892515a209f6ad1"
]
```

Now if we check the mempool again, we can see the transaction we removed is no longer there:

```
zathras@OMNIDEV:~/github/build/omnicore$ src/omnicore-cli getrawmempool
[
    "666c91bc4d24a4e323239f9a97bcea8ec4c056678c7cb6f4c5f0dbddb1d74ac0",
    "93b4f2d8573f613be0b0b905a079555a6adf2a676d8babb8aee7a3b5b9aacc5a",
    "a5e172aa69a45be37cd2ff1905f81226bfbeb57aced6ce44c3dbb55ec9ce8cde",
    "ba9d5158baddca54e8a7ea17c19eb0d34c5d3020c92e0ebb2be3c0788c717752",
    "c6c0ad63eab139fa86eba7735e213d1a94fc9c5c45c7ee4cd39266ab703e202f",
    "ec7194b411944fa2771da55103e826185599bd99377dcb06e2cdfc5fec5a2626"
]
```

@achamely - does this do the trick?

Thanks
Z
