### PR TITLE
Add A Fee Caching/Distribution System

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -7,6 +7,7 @@ OMNICORE_H = \
   omnicore/dex.h \
   omnicore/encoding.h \
   omnicore/errors.h \
+  omnicore/fees.h \
   omnicore/fetchwallettx.h \
   omnicore/log.h \
   omnicore/mbstring.h \
@@ -45,6 +46,7 @@ OMNICORE_CPP = \
   omnicore/createtx.cpp \
   omnicore/dex.cpp \
   omnicore/encoding.cpp \
+  omnicore/fees.cpp \
   omnicore/fetchwallettx.cpp \
   omnicore/log.cpp \
   omnicore/mbstring.cpp \

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -100,7 +100,7 @@ void COmniFeeCache::AddFee(const uint32_t &propertyId, int block, const int64_t 
     if (msc_debug_fees) PrintToLog("   Current cached amount %d\n", currentCachedAmount);
 
     // Add new fee and rewrite record
-    if ((currentCachedAmount > 0) && (amount > INT64_MAX - currentCachedAmount)) {
+    if ((currentCachedAmount > 0) && (amount > std::numeric_limits<int64_t>::max() - currentCachedAmount)) {
         // overflow - there is no way the fee cache should exceed the maximum possible number of tokens, not safe to continue
         const std::string& msg = strprintf("Shutting down due to fee cache overflow (block %d property %d current %d amount %d)\n", block, propertyId, currentCachedAmount, amount);
         PrintToLog(msg);

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -35,7 +35,6 @@ int64_t COmniFeeCache::GetCachedAmount(const uint32_t &propertyId)
     }
 }
 
-// Gets the current amount of the fee cache for a property
 // Adds a fee to the cache (eg on a completed trade)
 void COmniFeeCache::AddFee(const uint32_t &propertyId, int block, const uint64_t &amount)
 {
@@ -67,8 +66,6 @@ void COmniFeeCache::AddFee(const uint32_t &propertyId, int block, const uint64_t
 
 // Performs distribution of fees
 
-// Gets the current amount of the fee cache for a property
-// Adds a fee to the cache (eg on a completed trade)
 // Prunes entries over 50 blocks old from the entry for a property
 void COmniFeeCache::PruneCache(const uint32_t &propertyId, int block)
 {
@@ -101,19 +98,12 @@ void COmniFeeCache::PruneCache(const uint32_t &propertyId, int block)
     }
 }
 
-// Gets the current amount of the fee cache for a property
-// Adds a fee to the cache (eg on a completed trade)
-// Prunes entries over 50 blocks old from the entry for a property
 // Show Fee Cache DB statistics
 void COmniFeeCache::printStats()
 {
     PrintToLog("COmniFeeCache stats: nWritten= %d , nRead= %d\n", nWritten, nRead);
 }
 
-// Gets the current amount of the fee cache for a property
-// Adds a fee to the cache (eg on a completed trade)
-// Prunes entries over 50 blocks old from the entry for a property
-// Show Fee Cache DB statistics
 // Show Fee Cache DB records
 void COmniFeeCache::printAll()
 {
@@ -126,11 +116,6 @@ void COmniFeeCache::printAll()
     delete it;
 }
 
-// Gets the current amount of the fee cache for a property
-// Adds a fee to the cache (eg on a completed trade)
-// Prunes entries over 50 blocks old from the entry for a property
-// Show Fee Cache DB statistics
-// Show Fee Cache DB records
 // Return a set containing fee cache history items
 std::set<feeCacheItem> COmniFeeCache::GetCacheHistory(const uint32_t &propertyId)
 {

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -328,8 +328,7 @@ void COmniFeeHistory::printAll()
 // Count Fee History DB records
 int COmniFeeHistory::CountRecords()
 {
-    // TODO: research if there is a faster way to get the total number of records in levelDB
-
+    // No faster way to count than to iterate - "There is no way to implement Count more efficiently inside leveldb than outside."
     int count = 0;
     leveldb::Iterator* it = NewIterator();
     for(it->SeekToFirst(); it->Valid(); it->Next()) {

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file fees.cpp
+ *
+ * This file contains code for handling Omni fees.
+ */
+
+#include "omnicore/fees.h"
+
+#include "omnicore/omnicore.h"
+#include "omnicore/log.h"
+
+#include "leveldb/db.h"
+
+#include <stdint.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+// Arbitrary value used for testing - TODO: how are we calculating the threshold for distribution?
+int64_t feeDistributionThreshold = 1000000;
+
+// Gets the current amount of the fee cache for a property
+int64_t COmniFeeCache::GetCachedAmount(const uint32_t &propertyId)
+{
+    assert(pdb);
+
+    // Get the fee history, set is sorted by block so last entry is most recent
+    std::set<feeCacheItem> sCacheHistoryItems = GetCacheHistory(propertyId);
+    if (!sCacheHistoryItems.empty()) {
+        std::set<feeCacheItem>::iterator endIt = sCacheHistoryItems.end();
+        feeCacheItem mostRecentItem = *endIt;
+        return mostRecentItem.second;
+    } else {
+        return 0; // property has never generated a fee
+    }
+}
+
+// Gets the current amount of the fee cache for a property
+// Adds a fee to the cache (eg on a completed trade)
+void COmniFeeCache::AddFee(const uint32_t &propertyId, int block, const uint64_t &amount)
+{
+    // Get current cached fee
+    int64_t currentCachedAmount = GetCachedAmount(propertyId);
+
+    // Add new fee and rewrite record
+    int64_t newCachedAmount = currentCachedAmount + amount; // TODO: should be some overflow detection in here
+    const std::string key = strprintf("%010d", propertyId);
+    std::string oldValue;
+    leveldb::Status getStatus = pdb->Get(readoptions, key, &oldValue);
+    assert(getStatus.ok());
+    if (!oldValue.empty()) oldValue=+",";
+    const std::string newValue = strprintf("%s%d:%d", oldValue, block, newCachedAmount);
+    leveldb::Status putStatus = pdb->Put(writeoptions, key, newValue);
+    assert(putStatus.ok());
+    if (msc_debug_fees) PrintToLog("Adding fee %d to property %d (old=%s [%s], new=%s [%s])\n", amount, propertyId, oldValue, newValue, getStatus.ToString(), putStatus.ToString());
+    ++nWritten;
+
+    // Call for pruning (we only prune when we update a record)
+    PruneCache(propertyId, block);
+
+    return;
+}
+
+// Rolls back the cache to an earlier state (eg in event of a reorg)
+
+// Evaluates fee caches for all properties against threshold and executes distribution if threshold met
+
+// Performs distribution of fees
+
+// Gets the current amount of the fee cache for a property
+// Adds a fee to the cache (eg on a completed trade)
+// Prunes entries over 50 blocks old from the entry for a property
+void COmniFeeCache::PruneCache(const uint32_t &propertyId, int block)
+{
+    assert(pdb);
+
+    int pruneBlock = block-50;
+    const std::string key = strprintf("%010d", propertyId);
+    std::set<feeCacheItem> sCacheHistoryItems = GetCacheHistory(propertyId);
+    if (!sCacheHistoryItems.empty()) {
+        std::set<feeCacheItem>::iterator startIt = sCacheHistoryItems.begin();
+        feeCacheItem firstItem = *startIt;
+        if (firstItem.first >= pruneBlock) return; // all entries are above supplied block value, nothing to do
+        std::string newValue;
+        for (std::set<feeCacheItem>::iterator it = sCacheHistoryItems.begin(); it != sCacheHistoryItems.end(); it++) {
+            feeCacheItem tempItem = *it;
+            if (tempItem.first < pruneBlock) continue; // discard this entry
+            if (!newValue.empty()) newValue += ",";
+            newValue += strprintf("%d:%d", tempItem.first, tempItem.second);
+        }
+        // make sure the pruned cache isn't completely empty, if it is, prune down to just the most recent entry
+        if (newValue.empty()) {
+            std::set<feeCacheItem>::iterator mostRecentIt = sCacheHistoryItems.end();
+            feeCacheItem mostRecentItem = *mostRecentIt;
+            newValue = strprintf("%d:%d", mostRecentItem.first, mostRecentItem.second);
+        }
+        leveldb::Status status = pdb->Put(writeoptions, key, newValue);
+        if (msc_debug_fees) PrintToLog("Pruning fee cache for property %d, new=%s [%s])\n", propertyId, newValue, status.ToString());
+    } else {
+        return; // nothing to do
+    }
+}
+
+// Gets the current amount of the fee cache for a property
+// Adds a fee to the cache (eg on a completed trade)
+// Prunes entries over 50 blocks old from the entry for a property
+// Show Fee Cache DB statistics
+void COmniFeeCache::printStats()
+{
+    PrintToLog("COmniFeeCache stats: nWritten= %d , nRead= %d\n", nWritten, nRead);
+}
+
+// Gets the current amount of the fee cache for a property
+// Adds a fee to the cache (eg on a completed trade)
+// Prunes entries over 50 blocks old from the entry for a property
+// Show Fee Cache DB statistics
+// Show Fee Cache DB records
+void COmniFeeCache::printAll()
+{
+    int count = 0;
+    leveldb::Iterator* it = NewIterator();
+    for(it->SeekToFirst(); it->Valid(); it->Next()) {
+        ++count;
+        PrintToConsole("entry #%8d= %s:%s\n", count, it->key().ToString(), it->value().ToString());
+    }
+    delete it;
+}
+
+// Gets the current amount of the fee cache for a property
+// Adds a fee to the cache (eg on a completed trade)
+// Prunes entries over 50 blocks old from the entry for a property
+// Show Fee Cache DB statistics
+// Show Fee Cache DB records
+// Return a set containing fee cache history items
+std::set<feeCacheItem> COmniFeeCache::GetCacheHistory(const uint32_t &propertyId)
+{
+    assert(pdb);
+
+    const std::string key = strprintf("%010d", propertyId);
+
+    std::set<feeCacheItem> sCacheHistoryItems;
+    std::string strValue;
+    leveldb::Status status = pdb->Get(readoptions, key, &strValue);
+    assert(status.ok());
+    std::vector<std::string> vCacheHistoryItems;
+    boost::split(vCacheHistoryItems, strValue, boost::is_any_of(","), boost::token_compress_on);
+    for (std::vector<std::string>::iterator it = vCacheHistoryItems.begin(); it != vCacheHistoryItems.end(); ++it) {
+        std::vector<std::string> vCacheHistoryItem;
+        boost::split(vCacheHistoryItem, *it, boost::is_any_of(":"), boost::token_compress_on);
+        if (2 != vCacheHistoryItem.size()) {
+            PrintToConsole("ERROR: vCacheHistoryItem has unexpected number of elements: %d (raw %s)!\n", vCacheHistoryItem.size(), *it);
+            continue;
+        }
+        int64_t cacheItemBlock = boost::lexical_cast<int64_t>(vCacheHistoryItem[0]);
+        int64_t cacheItemAmount = boost::lexical_cast<int64_t>(vCacheHistoryItem[1]);
+        sCacheHistoryItems.insert(std::make_pair(cacheItemBlock, cacheItemAmount));
+        if (msc_debug_fees) PrintToConsole("Retrieved fee item (block %d, amount %d)\n", cacheItemBlock, cacheItemAmount);
+    }
+
+    return sCacheHistoryItems;
+}
+
+

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -8,6 +8,7 @@
 
 #include "omnicore/omnicore.h"
 #include "omnicore/log.h"
+#include "omnicore/sp.h"
 
 #include "leveldb/db.h"
 
@@ -28,6 +29,7 @@ int64_t COmniFeeCache::GetCachedAmount(const uint32_t &propertyId)
     std::set<feeCacheItem> sCacheHistoryItems = GetCacheHistory(propertyId);
     if (!sCacheHistoryItems.empty()) {
         std::set<feeCacheItem>::iterator endIt = sCacheHistoryItems.end();
+        --endIt;
         feeCacheItem mostRecentItem = *endIt;
         return mostRecentItem.second;
     } else {
@@ -38,21 +40,35 @@ int64_t COmniFeeCache::GetCachedAmount(const uint32_t &propertyId)
 // Adds a fee to the cache (eg on a completed trade)
 void COmniFeeCache::AddFee(const uint32_t &propertyId, int block, const uint64_t &amount)
 {
+    if (msc_debug_fees) PrintToLog("Starting AddFee for prop %d (block %d amount %d)...\n", propertyId, block, amount);
+
     // Get current cached fee
     int64_t currentCachedAmount = GetCachedAmount(propertyId);
+    if (msc_debug_fees) PrintToLog("   Current cached amount %d\n", currentCachedAmount);
 
     // Add new fee and rewrite record
     int64_t newCachedAmount = currentCachedAmount + amount; // TODO: should be some overflow detection in here
+    if (msc_debug_fees) PrintToLog("   New cached amount %d\n", newCachedAmount);
     const std::string key = strprintf("%010d", propertyId);
-    std::string oldValue;
-    leveldb::Status getStatus = pdb->Get(readoptions, key, &oldValue);
-    assert(getStatus.ok());
-    if (!oldValue.empty()) oldValue=+",";
-    const std::string newValue = strprintf("%s%d:%d", oldValue, block, newCachedAmount);
-    leveldb::Status putStatus = pdb->Put(writeoptions, key, newValue);
-    assert(putStatus.ok());
-    if (msc_debug_fees) PrintToLog("Adding fee %d to property %d (old=%s [%s], new=%s [%s])\n", amount, propertyId, oldValue, newValue, getStatus.ToString(), putStatus.ToString());
+    std::set<feeCacheItem> sCacheHistoryItems = GetCacheHistory(propertyId);
+    if (msc_debug_fees) PrintToLog("   Iterating cache history (%d items)...\n",sCacheHistoryItems.size());
+    std::string newValue;
+    if (!sCacheHistoryItems.empty()) {
+        for (std::set<feeCacheItem>::iterator it = sCacheHistoryItems.begin(); it != sCacheHistoryItems.end(); it++) {
+            feeCacheItem tempItem = *it;
+            if (tempItem.first == block) continue; // this is an older entry for the same block, discard it
+            if (!newValue.empty()) newValue += ",";
+            newValue += strprintf("%d:%d", tempItem.first, tempItem.second);
+            if (msc_debug_fees) PrintToLog("      Readding entry: block %d amount %d\n", tempItem.first, tempItem.second);
+        }
+        if (!newValue.empty()) newValue += ",";
+    }
+    if (msc_debug_fees) PrintToLog("   Adding requested entry: block %d new amount %d\n", block, newCachedAmount);
+    newValue += strprintf("%d:%d", block, newCachedAmount);
+    leveldb::Status status = pdb->Put(writeoptions, key, newValue);
+    assert(status.ok());
     ++nWritten;
+    if (msc_debug_fees) PrintToLog("AddFee completed for property %d (new=%s [%s])\n", propertyId, newValue, status.ToString());
 
     // Call for pruning (we only prune when we update a record)
     PruneCache(propertyId, block);
@@ -60,39 +76,95 @@ void COmniFeeCache::AddFee(const uint32_t &propertyId, int block, const uint64_t
     return;
 }
 
-// Rolls back the cache to an earlier state (eg in event of a reorg)
+// Rolls back the cache to an earlier state (eg in event of a reorg) - block is *inclusive* (ie entries=block will get deleted)
+void COmniFeeCache::RollBackCache(int block)
+{
+/*
+    !!draft code, not yet tested!!
+
+    assert(pdb);
+
+    for (uint8_t ecosystem = 1; ecosystem <= 2; ecosystem++) {
+        uint32_t startPropertyId = (ecosystem == 1) ? 1 : TEST_ECO_PROPERTY_1;
+        for (uint32_t propertyId = startPropertyId; propertyId < mastercore::_my_sps->peekNextSPID(ecosystem); propertyId++) {
+            const std::string key = strprintf("%010d", propertyId);
+            std::set<feeCacheItem> sCacheHistoryItems = GetCacheHistory(propertyId);
+            if (!sCacheHistoryItems.empty()) {
+                std::set<feeCacheItem>::iterator mostRecentIt = sCacheHistoryItems.end();
+                std::string newValue;
+                feeCacheItem mostRecentItem = *mostRecentIt;
+                if (mostRecentItem.first < block) return; // all entries are unaffected by this rollback, nothing to do
+                for (std::set<feeCacheItem>::iterator it = sCacheHistoryItems.begin(); it != sCacheHistoryItems.end(); it++) {
+                    feeCacheItem tempItem = *it;
+                    if (tempItem.first >= block) continue; // discard this entry
+                    if (!newValue.empty()) newValue += ",";
+                    newValue += strprintf("%d:%d", tempItem.first, tempItem.second);
+                }
+                leveldb::Status status = pdb->Put(writeoptions, key, newValue);
+                assert(status.ok());
+                if (msc_debug_fees) PrintToLog("Rolling back fee cache for property %d, new=%s [%s])\n", propertyId, newValue, status.ToString());
+            }
+        }
+    }
+*/
+}
 
 // Evaluates fee caches for all properties against threshold and executes distribution if threshold met
+void COmniFeeCache::EvalCache()
+{
+    for (uint8_t ecosystem = 1; ecosystem <= 2; ecosystem++) {
+        uint32_t startPropertyId = (ecosystem == 1) ? 1 : TEST_ECO_PROPERTY_1;
+        for (uint32_t propertyId = startPropertyId; propertyId < mastercore::_my_sps->peekNextSPID(ecosystem); propertyId++) {
+            if (GetCachedAmount(propertyId) > feeDistributionThreshold) {
+                // Execute distribution of fees for this property
+            }
+        }
+    }
+}
 
 // Performs distribution of fees
 
 // Prunes entries over 50 blocks old from the entry for a property
 void COmniFeeCache::PruneCache(const uint32_t &propertyId, int block)
 {
+    if (msc_debug_fees) PrintToLog("Starting PruneCache for prop %d block %d...\n", propertyId, block);
     assert(pdb);
 
     int pruneBlock = block-50;
+    if (msc_debug_fees) PrintToLog("Removing entries prior to block %d...\n", pruneBlock);
     const std::string key = strprintf("%010d", propertyId);
     std::set<feeCacheItem> sCacheHistoryItems = GetCacheHistory(propertyId);
+    if (msc_debug_fees) PrintToLog("   Iterating cache history (%d items)...\n",sCacheHistoryItems.size());
     if (!sCacheHistoryItems.empty()) {
         std::set<feeCacheItem>::iterator startIt = sCacheHistoryItems.begin();
         feeCacheItem firstItem = *startIt;
-        if (firstItem.first >= pruneBlock) return; // all entries are above supplied block value, nothing to do
+        if (firstItem.first >= pruneBlock) {
+            if (msc_debug_fees) PrintToLog("Endingg PruneCache - no matured entries found.\n");
+            return; // all entries are above supplied block value, nothing to do
+        }
         std::string newValue;
         for (std::set<feeCacheItem>::iterator it = sCacheHistoryItems.begin(); it != sCacheHistoryItems.end(); it++) {
             feeCacheItem tempItem = *it;
-            if (tempItem.first < pruneBlock) continue; // discard this entry
+            if (tempItem.first < pruneBlock) {
+                if (msc_debug_fees) {
+                    PrintToLog("      Skipping matured entry: block %d amount %d\n", tempItem.first, tempItem.second);
+                    continue; // discard this entry
+                }
+            }
             if (!newValue.empty()) newValue += ",";
             newValue += strprintf("%d:%d", tempItem.first, tempItem.second);
+            if (msc_debug_fees) PrintToLog("      Readding immature entry: block %d amount %d\n", tempItem.first, tempItem.second);
         }
         // make sure the pruned cache isn't completely empty, if it is, prune down to just the most recent entry
         if (newValue.empty()) {
             std::set<feeCacheItem>::iterator mostRecentIt = sCacheHistoryItems.end();
             feeCacheItem mostRecentItem = *mostRecentIt;
             newValue = strprintf("%d:%d", mostRecentItem.first, mostRecentItem.second);
+            if (msc_debug_fees) PrintToLog("   All entries matured and pruned - readding most recent entry: block %d amount %d\n", mostRecentItem.first, mostRecentItem.second);
         }
         leveldb::Status status = pdb->Put(writeoptions, key, newValue);
-        if (msc_debug_fees) PrintToLog("Pruning fee cache for property %d, new=%s [%s])\n", propertyId, newValue, status.ToString());
+        assert(status.ok());
+        if (msc_debug_fees) PrintToLog("PruneCache completed for property %d (new=%s [%s])\n", propertyId, newValue, status.ToString());
     } else {
         return; // nothing to do
     }
@@ -126,6 +198,9 @@ std::set<feeCacheItem> COmniFeeCache::GetCacheHistory(const uint32_t &propertyId
     std::set<feeCacheItem> sCacheHistoryItems;
     std::string strValue;
     leveldb::Status status = pdb->Get(readoptions, key, &strValue);
+    if (status.IsNotFound()) {
+        return sCacheHistoryItems; // no cache, return empty set
+    }
     assert(status.ok());
     std::vector<std::string> vCacheHistoryItems;
     boost::split(vCacheHistoryItems, strValue, boost::is_any_of(","), boost::token_compress_on);
@@ -139,7 +214,6 @@ std::set<feeCacheItem> COmniFeeCache::GetCacheHistory(const uint32_t &propertyId
         int64_t cacheItemBlock = boost::lexical_cast<int64_t>(vCacheHistoryItem[0]);
         int64_t cacheItemAmount = boost::lexical_cast<int64_t>(vCacheHistoryItem[1]);
         sCacheHistoryItems.insert(std::make_pair(cacheItemBlock, cacheItemAmount));
-        if (msc_debug_fees) PrintToConsole("Retrieved fee item (block %d, amount %d)\n", cacheItemBlock, cacheItemAmount);
     }
 
     return sCacheHistoryItems;

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -215,13 +215,13 @@ void COmniFeeCache::DistributeCache(const uint32_t &propertyId, int block)
     ClearCache(propertyId, block);
 }
 
-// Prunes entries over 50 blocks old from the entry for a property
+// Prunes entries over MAX_STATE_HISTORY blocks old from the entry for a property
 void COmniFeeCache::PruneCache(const uint32_t &propertyId, int block)
 {
     if (msc_debug_fees) PrintToLog("Starting PruneCache for prop %d block %d...\n", propertyId, block);
     assert(pdb);
 
-    int pruneBlock = block-50;
+    int pruneBlock = block - MAX_STATE_HISTORY;
     if (msc_debug_fees) PrintToLog("Removing entries prior to block %d...\n", pruneBlock);
     const std::string key = strprintf("%010d", propertyId);
     std::set<feeCacheItem> sCacheHistoryItems = GetCacheHistory(propertyId);

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -129,7 +129,7 @@ void COmniFeeCache::RollBackCache(int block)
 // Evaluates fee caches for the property against threshold and executes distribution if threshold met
 void COmniFeeCache::EvalCache(const uint32_t &propertyId)
 {
-    if (GetCachedAmount(propertyId) > feeDistributionThreshold) {
+    if (GetCachedAmount(propertyId) >= feeDistributionThreshold) {
         DistributeCache(propertyId);
     }
 }

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -183,7 +183,13 @@ void COmniFeeCache::DistributeCache(const uint32_t &propertyId, int block)
 
     int64_t cachedAmount = GetCachedAmount(propertyId);
 
-    OwnerAddrType receiversSet = STO_GetReceivers("FEEDISTRIBUTION", OMNI_PROPERTY_MSC, cachedAmount);
+    OwnerAddrType receiversSet;
+    if (isTestEcosystemProperty(propertyId)) {
+        receiversSet = STO_GetReceivers("FEEDISTRIBUTION", OMNI_PROPERTY_TMSC, cachedAmount);
+    } else {
+        receiversSet = STO_GetReceivers("FEEDISTRIBUTION", OMNI_PROPERTY_MSC, cachedAmount);
+    }
+
     uint64_t numberOfReceivers = receiversSet.size(); // there will always be addresses holding OMNI, so no need to check size>0
     PrintToLog("Starting fee distribution for property %d to %d recipients...\n", propertyId, numberOfReceivers);
 

--- a/src/omnicore/fees.h
+++ b/src/omnicore/fees.h
@@ -39,8 +39,12 @@ public:
     int64_t GetCachedAmount(const uint32_t &propertyId);
     // Prunes entries over 50 blocks old from the entry for a property
     void PruneCache(const uint32_t &propertyId, int block);
+    // Rolls back the cache to an earlier state (eg in event of a reorg) - block is *inclusive* (ie entries=block will get deleted)
+    void RollBackCache(int block);
     // Adds a fee to the cache (eg on a completed trade)
     void AddFee(const uint32_t &propertyId, int block, const uint64_t &amount);
+    // Evaluates fee caches for all properties against threshold and executes distribution if threshold met
+    void EvalCache();
 };
 
 namespace mastercore

--- a/src/omnicore/fees.h
+++ b/src/omnicore/fees.h
@@ -49,7 +49,7 @@ public:
     // Zeros a property in the fee cache
     void ClearCache(const uint32_t &propertyId, int block);
     // Adds a fee to the cache (eg on a completed trade)
-    void AddFee(const uint32_t &propertyId, int block, const uint64_t &amount);
+    void AddFee(const uint32_t &propertyId, int block, const int64_t &amount);
     // Evaluates fee caches for all properties against threshold and executes distribution if threshold met
     void EvalCache(const uint32_t &propertyId, int block);
     // Performs distribution of fees

--- a/src/omnicore/fees.h
+++ b/src/omnicore/fees.h
@@ -41,10 +41,14 @@ public:
     void PruneCache(const uint32_t &propertyId, int block);
     // Rolls back the cache to an earlier state (eg in event of a reorg) - block is *inclusive* (ie entries=block will get deleted)
     void RollBackCache(int block);
+    // Zeros a property in the fee cache
+    void ClearCache(const uint32_t &propertyId);
     // Adds a fee to the cache (eg on a completed trade)
     void AddFee(const uint32_t &propertyId, int block, const uint64_t &amount);
     // Evaluates fee caches for all properties against threshold and executes distribution if threshold met
-    void EvalCache();
+    void EvalCache(const uint32_t &propertyId);
+    // Performs distribution of fees
+    void DistributeCache(const uint32_t &propertyId);
 };
 
 namespace mastercore

--- a/src/omnicore/fees.h
+++ b/src/omnicore/fees.h
@@ -47,7 +47,7 @@ public:
     // Rolls back the cache to an earlier state (eg in event of a reorg) - block is *inclusive* (ie entries=block will get deleted)
     void RollBackCache(int block);
     // Zeros a property in the fee cache
-    void ClearCache(const uint32_t &propertyId);
+    void ClearCache(const uint32_t &propertyId, int block);
     // Adds a fee to the cache (eg on a completed trade)
     void AddFee(const uint32_t &propertyId, int block, const uint64_t &amount);
     // Evaluates fee caches for all properties against threshold and executes distribution if threshold met

--- a/src/omnicore/fees.h
+++ b/src/omnicore/fees.h
@@ -1,0 +1,51 @@
+#ifndef OMNICORE_FEES_H
+#define OMNICORE_FEES_H
+
+#include "leveldb/db.h"
+
+#include "omnicore/log.h"
+#include "omnicore/persistence.h"
+
+#include <set>
+#include <stdint.h>
+#include <boost/filesystem.hpp>
+
+typedef std::pair<int, int64_t> feeCacheItem;
+
+/** LevelDB based storage for the MetaDEx fee cache
+ */
+class COmniFeeCache : public CDBBase
+{
+public:
+    COmniFeeCache(const boost::filesystem::path& path, bool fWipe)
+    {
+        leveldb::Status status = Open(path, fWipe);
+        PrintToConsole("Loading fee cache database: %s\n", status.ToString());
+    }
+
+    virtual ~COmniFeeCache()
+    {
+        if (msc_debug_fees) PrintToLog("COmniFeeCache closed\n");
+    }
+
+    // Show Fee Cache DB statistics
+    void printStats();
+    // Show Fee Cache DB records
+    void printAll();
+
+    // Return a set containing fee cache history items
+    std::set<feeCacheItem> GetCacheHistory(const uint32_t &propertyId);
+    // Gets the current amount of the fee cache for a property
+    int64_t GetCachedAmount(const uint32_t &propertyId);
+    // Prunes entries over 50 blocks old from the entry for a property
+    void PruneCache(const uint32_t &propertyId, int block);
+    // Adds a fee to the cache (eg on a completed trade)
+    void AddFee(const uint32_t &propertyId, int block, const uint64_t &amount);
+};
+
+namespace mastercore
+{
+    extern COmniFeeCache *p_feecache;
+}
+
+#endif // OMNICORE_FEES_H

--- a/src/omnicore/fees.h
+++ b/src/omnicore/fees.h
@@ -11,6 +11,7 @@
 #include <boost/filesystem.hpp>
 
 typedef std::pair<int, int64_t> feeCacheItem;
+typedef std::pair<std::string, int64_t> feeHistoryItem;
 
 /** LevelDB based storage for the MetaDEx fee cache
  */
@@ -33,6 +34,10 @@ public:
     // Show Fee Cache DB records
     void printAll();
 
+    // Sets the distribution thresholds to total tokens for a property / OMNI_FEE_THRESHOLD
+    void UpdateDistributionThresholds();
+    // Returns the distribution threshold for a property
+    int64_t GetDistributionThreshold(const uint32_t &propertyId);
     // Return a set containing fee cache history items
     std::set<feeCacheItem> GetCacheHistory(const uint32_t &propertyId);
     // Gets the current amount of the fee cache for a property
@@ -46,14 +51,51 @@ public:
     // Adds a fee to the cache (eg on a completed trade)
     void AddFee(const uint32_t &propertyId, int block, const uint64_t &amount);
     // Evaluates fee caches for all properties against threshold and executes distribution if threshold met
-    void EvalCache(const uint32_t &propertyId);
+    void EvalCache(const uint32_t &propertyId, int block);
     // Performs distribution of fees
-    void DistributeCache(const uint32_t &propertyId);
+    void DistributeCache(const uint32_t &propertyId, int block);
+};
+
+/** LevelDB based storage for the MetaDEx fee distributions
+ */
+class COmniFeeHistory : public CDBBase
+{
+public:
+    COmniFeeHistory(const boost::filesystem::path& path, bool fWipe)
+    {
+        leveldb::Status status = Open(path, fWipe);
+        PrintToConsole("Loading fee history database: %s\n", status.ToString());
+    }
+
+    virtual ~COmniFeeHistory()
+    {
+        if (msc_debug_fees) PrintToLog("COmniFeeHistory closed\n");
+    }
+
+    // Show Fee History DB statistics
+    void printStats();
+    // Show Fee History DB records
+    void printAll();
+
+    // Roll back history in event of reorg
+    void RollBackHistory(int block);
+    // Count Fee History DB records
+    int CountRecords();
+    // Record a fee distribution
+    void RecordFeeDistribution(const uint32_t &propertyId, int block, int64_t total, std::set<feeHistoryItem> feeRecipients);
+    // Retrieve the recipients for a fee distribution
+    std::set<feeHistoryItem> GetFeeDistribution(int id);
+    // Retrieve fee distributions for a property
+    std::set<int> GetDistributionsForProperty(const uint32_t &propertyId);
+    // Populate data about a fee distribution
+    bool GetDistributionData(int id, uint32_t *propertyId, int *block, int64_t *total);
+    // Retrieve fee distribution receipts for an address
 };
 
 namespace mastercore
 {
     extern COmniFeeCache *p_feecache;
+    extern COmniFeeHistory *p_feehistory;
 }
 
 #endif // OMNICORE_FEES_H

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -63,6 +63,8 @@ bool msc_debug_consensus_hash_every_block = 0;
 bool msc_debug_alerts             = 1;
 //! Print consensus hashes for each transaction when parsing
 bool msc_debug_consensus_hash_every_transaction = 0;
+//! Debug fees
+bool msc_debug_fees               = 1;
 
 /**
  * LogPrintf() has been broken a couple of times now
@@ -263,6 +265,7 @@ void InitDebugLogLevels()
         if (*it == "consensus_hash_every_block") msc_debug_consensus_hash_every_block = true;
         if (*it == "alerts") msc_debug_alerts = true;
         if (*it == "consensus_hash_every_transaction") msc_debug_consensus_hash_every_transaction = true;
+        if (*it == "fees") msc_debug_fees = true;
         if (*it == "none" || *it == "all") {
             bool allDebugState = false;
             if (*it == "all") allDebugState = true;
@@ -298,6 +301,7 @@ void InitDebugLogLevels()
             msc_debug_consensus_hash_every_block = allDebugState;
             msc_debug_alerts = allDebugState;
             msc_debug_consensus_hash_every_transaction = allDebugState;
+            msc_debug_fees = allDebugState;
         }
     }
 }

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -51,6 +51,7 @@ extern bool msc_debug_consensus_hash;
 extern bool msc_debug_consensus_hash_every_block;
 extern bool msc_debug_alerts;
 extern bool msc_debug_consensus_hash_every_transaction;
+extern bool msc_debug_fees;
 
 /* When we switch to C++11, this can be switched to variadic templates instead
  * of this macro-based construction (see tinyformat.h).

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -262,14 +262,14 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
             int64_t tradingFee = seller_amountGot / feeDivider;
 
             // subtract the fee from the amount the seller will receive
-            int64_t seller_toGet = seller_amountGot - tradingFee;
+            int64_t seller_amountGotAfterFee = seller_amountGot - tradingFee;
 
             // add the fee to the fee cache
             p_feecache->AddFee(pold->getDesProperty(), pnew->getBlock(), tradingFee);
 
             // transfer the payment property from buyer to seller
             assert(update_tally_map(pnew->getAddr(), pnew->getProperty(), -seller_amountGot, BALANCE));
-            assert(update_tally_map(pold->getAddr(), pold->getDesProperty(), seller_toGet, BALANCE));
+            assert(update_tally_map(pold->getAddr(), pold->getDesProperty(), seller_amountGotAfterFee, BALANCE));
 
             // transfer the market (the one being sold) property from seller to buyer
             assert(update_tally_map(pold->getAddr(), pold->getProperty(), -buyer_amountGot, METADEX_RESERVE));
@@ -298,7 +298,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 
             // record the trade in MPTradeList
             t_tradelistdb->recordMatchedTrade(pold->getHash(), pnew->getHash(), // < might just pass pold, pnew
-                pold->getAddr(), pnew->getAddr(), pold->getDesProperty(), pnew->getDesProperty(), seller_amountGot, buyer_amountGot, pnew->getBlock());
+                pold->getAddr(), pnew->getAddr(), pold->getDesProperty(), pnew->getDesProperty(), seller_amountGotAfterFee, buyer_amountGot, pnew->getBlock(), tradingFee);
 
             if (msc_debug_metadex1) PrintToLog("++ erased old: %s\n", offerIt->ToString());
             // erase the old seller element

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -258,9 +258,8 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
             ///////////////////////////
 
             // strip a 0.05% fee from non-OMNI pairs (for testing, strip from everything)
-            rational_t rTradingFee(seller_amountGot/2000);
-            int128_t iTradingFee = numerator(rTradingFee) / denominator(rTradingFee);
-            int64_t tradingFee = iTradingFee.convert_to<int64_t>();
+            int64_t feeDivider = 2000;
+            int64_t tradingFee = seller_amountGot / feeDivider;
 
             // subtract the fee from the amount the seller will receive
             int64_t seller_toGet = seller_amountGot - tradingFee;

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -259,21 +259,21 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 
             // strip a 0.05% fee from non-OMNI pairs (for testing, strip from everything)
             int64_t feeDivider = 2000;
-            int64_t tradingFee = seller_amountGot / feeDivider;
+            int64_t tradingFee = buyer_amountGot / feeDivider;
 
             // subtract the fee from the amount the seller will receive
-            int64_t seller_amountGotAfterFee = seller_amountGot - tradingFee;
+            int64_t buyer_amountGotAfterFee = buyer_amountGot - tradingFee;
 
             // add the fee to the fee cache
-            p_feecache->AddFee(pold->getDesProperty(), pnew->getBlock(), tradingFee);
+            p_feecache->AddFee(pnew->getDesProperty(), pnew->getBlock(), tradingFee);
 
             // transfer the payment property from buyer to seller
             assert(update_tally_map(pnew->getAddr(), pnew->getProperty(), -seller_amountGot, BALANCE));
-            assert(update_tally_map(pold->getAddr(), pold->getDesProperty(), seller_amountGotAfterFee, BALANCE));
+            assert(update_tally_map(pold->getAddr(), pold->getDesProperty(), seller_amountGot, BALANCE));
 
             // transfer the market (the one being sold) property from seller to buyer
             assert(update_tally_map(pold->getAddr(), pold->getProperty(), -buyer_amountGot, METADEX_RESERVE));
-            assert(update_tally_map(pnew->getAddr(), pnew->getDesProperty(), buyer_amountGot, BALANCE));
+            assert(update_tally_map(pnew->getAddr(), pnew->getDesProperty(), buyer_amountGotAfterFee, BALANCE));
 
             NewReturn = TRADED;
 
@@ -298,7 +298,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 
             // record the trade in MPTradeList
             t_tradelistdb->recordMatchedTrade(pold->getHash(), pnew->getHash(), // < might just pass pold, pnew
-                pold->getAddr(), pnew->getAddr(), pold->getDesProperty(), pnew->getDesProperty(), seller_amountGotAfterFee, buyer_amountGot, pnew->getBlock(), tradingFee);
+                pold->getAddr(), pnew->getAddr(), pold->getDesProperty(), pnew->getDesProperty(), seller_amountGot, buyer_amountGotAfterFee, pnew->getBlock(), tradingFee);
 
             if (msc_debug_metadex1) PrintToLog("++ erased old: %s\n", offerIt->ToString());
             // erase the old seller element

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -257,15 +257,22 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 
             ///////////////////////////
 
-            // strip a 0.05% fee from non-OMNI pairs (for testing, strip from everything)
-            int64_t feeDivider = 2000;
-            int64_t tradingFee = buyer_amountGot / feeDivider;
+            int64_t buyer_amountGotAfterFee = buyer_amountGot;
+            int64_t tradingFee = 0;
 
-            // subtract the fee from the amount the seller will receive
-            int64_t buyer_amountGotAfterFee = buyer_amountGot - tradingFee;
+            // strip a 0.05% fee from non-OMNI pairs
+            if ( (pold->getProperty() != (OMNI_PROPERTY_MSC || OMNI_PROPERTY_TMSC)) || (pold->getDesProperty() != (OMNI_PROPERTY_MSC || OMNI_PROPERTY_TMSC)) ) {
+                int64_t feeDivider = 2000; // 0.05%
+                tradingFee = buyer_amountGot / feeDivider;
 
-            // add the fee to the fee cache
-            p_feecache->AddFee(pnew->getDesProperty(), pnew->getBlock(), tradingFee);
+                // subtract the fee from the amount the seller will receive
+                buyer_amountGotAfterFee = buyer_amountGot - tradingFee;
+
+                // add the fee to the fee cache
+                p_feecache->AddFee(pnew->getDesProperty(), pnew->getBlock(), tradingFee);
+            } else {
+                if (msc_debug_fees) PrintToLog("Skipping fee reduction for trade match %s:%s as one of the properties is Omni\n", pold->getHash().GetHex(), pnew->getHash().GetHex());
+            }
 
             // transfer the payment property from buyer to seller
             assert(update_tally_map(pnew->getAddr(), pnew->getProperty(), -seller_amountGot, BALANCE));

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -425,7 +425,6 @@ bool mastercore::update_tally_map(const std::string& who, uint32_t propertyId, i
  */
 static int64_t calculate_and_update_devmsc(unsigned int nTime)
 {
-return 0;
     // do nothing if before end of fundraiser
     if (nTime < 1377993874) return 0;
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -12,6 +12,7 @@
 #include "omnicore/dex.h"
 #include "omnicore/encoding.h"
 #include "omnicore/errors.h"
+#include "omnicore/fees.h"
 #include "omnicore/log.h"
 #include "omnicore/mdex.h"
 #include "omnicore/notifications.h"
@@ -135,6 +136,7 @@ CMPTxList *mastercore::p_txlistdb;
 CMPTradeList *mastercore::t_tradelistdb;
 CMPSTOList *mastercore::s_stolistdb;
 COmniTransactionDB *mastercore::p_OmniTXDB;
+COmniFeeCache *mastercore::p_feecache;
 
 // indicate whether persistence is enabled at this point, or not
 // used to write/read files, for breakout mode, debugging, etc.
@@ -2093,12 +2095,14 @@ int mastercore_init()
             boost::filesystem::path spPath = GetDataDir() / "MP_spinfo";
             boost::filesystem::path stoPath = GetDataDir() / "MP_stolist";
             boost::filesystem::path omniTXDBPath = GetDataDir() / "Omni_TXDB";
+            boost::filesystem::path feesPath = GetDataDir() / "OMNI_feecache";
             if (boost::filesystem::exists(persistPath)) boost::filesystem::remove_all(persistPath);
             if (boost::filesystem::exists(txlistPath)) boost::filesystem::remove_all(txlistPath);
             if (boost::filesystem::exists(tradePath)) boost::filesystem::remove_all(tradePath);
             if (boost::filesystem::exists(spPath)) boost::filesystem::remove_all(spPath);
             if (boost::filesystem::exists(stoPath)) boost::filesystem::remove_all(stoPath);
             if (boost::filesystem::exists(omniTXDBPath)) boost::filesystem::remove_all(omniTXDBPath);
+            if (boost::filesystem::exists(feesPath)) boost::filesystem::remove_all(feesPath);
             PrintToLog("Success clearing persistence files in datadir %s\n", GetDataDir().string());
             startClean = true;
         } catch (const boost::filesystem::filesystem_error& e) {
@@ -2112,6 +2116,7 @@ int mastercore_init()
     p_txlistdb = new CMPTxList(GetDataDir() / "MP_txlist", fReindex);
     _my_sps = new CMPSPInfo(GetDataDir() / "MP_spinfo", fReindex);
     p_OmniTXDB = new COmniTransactionDB(GetDataDir() / "Omni_TXDB", fReindex);
+    p_feecache = new COmniFeeCache(GetDataDir() / "OMNI_feecache", fReindex);
 
     MPPersistencePath = GetDataDir() / "MP_persist";
     TryCreateDirectory(MPPersistencePath);
@@ -2373,6 +2378,7 @@ int mastercore::ClassAgnosticWalletTXBuilder(const std::string& senderAddress, c
 #else
     return MP_ERR_WALLET_ACCESS;
 #endif
+
 }
 
 void COmniTransactionDB::RecordTransaction(const uint256& txid, uint32_t posInBlock)

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -424,6 +424,7 @@ bool mastercore::update_tally_map(const std::string& who, uint32_t propertyId, i
  */
 static int64_t calculate_and_update_devmsc(unsigned int nTime)
 {
+return 0;
     // do nothing if before end of fundraiser
     if (nTime < 1377993874) return 0;
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -425,6 +425,7 @@ bool mastercore::update_tally_map(const std::string& who, uint32_t propertyId, i
  */
 static int64_t calculate_and_update_devmsc(unsigned int nTime)
 {
+return 0;
     // do nothing if before end of fundraiser
     if (nTime < 1377993874) return 0;
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2046,6 +2046,7 @@ void clear_all_state()
     s_stolistdb->Clear();
     t_tradelistdb->Clear();
     p_OmniTXDB->Clear();
+    p_feecache->Clear();
     assert(p_txlistdb->setDBVersion() == DB_VERSION); // new set of databases, set DB version
     exodus_prev = 0;
 }
@@ -2217,6 +2218,10 @@ int mastercore_shutdown()
     if (p_OmniTXDB) {
         delete p_OmniTXDB;
         p_OmniTXDB = NULL;
+    }
+    if (p_feecache) {
+        delete p_feecache;
+        p_feecache = NULL;
     }
 
     PrintToLog("\nOmni Core shutdown completed\n");
@@ -3602,6 +3607,7 @@ int mastercore_handler_block_begin(int nBlockPrev, CBlockIndex const * pBlockInd
         p_txlistdb->isMPinBlockRange(pBlockIndex->nHeight, reorgRecoveryMaxHeight, true);
         t_tradelistdb->deleteAboveBlock(pBlockIndex->nHeight);
         s_stolistdb->deleteAboveBlock(pBlockIndex->nHeight);
+        p_feecache->RollBackCache(pBlockIndex->nHeight - 1);
         reorgRecoveryMaxHeight = 0;
 
         nWaterlineBlock = ConsensusParams().GENESIS_BLOCK - 1;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3274,7 +3274,7 @@ bool CMPTradeList::getMatchingTrades(const uint256& txid, uint32_t propertyId, A
 
       // ensure correct amount of tokens in value string
       boost::split(vstr, strValue, boost::is_any_of(":"), token_compress_on);
-      if (vstr.size() != 7) {
+      if (vstr.size() != 8) {
           PrintToLog("TRADEDB error - unexpected number of tokens in value (%s)\n", strValue);
           continue;
       }
@@ -3287,8 +3287,11 @@ bool CMPTradeList::getMatchingTrades(const uint256& txid, uint32_t propertyId, A
       int64_t amount1 = boost::lexical_cast<int64_t>(vstr[4]);
       int64_t amount2 = boost::lexical_cast<int64_t>(vstr[5]);
       int blockNum = atoi(vstr[6]);
+      int64_t tradingFee = boost::lexical_cast<int64_t>(vstr[7]);
+
       std::string strAmount1 = FormatMP(prop1, amount1);
       std::string strAmount2 = FormatMP(prop2, amount2);
+      std::string strTradingFee = FormatMP(prop1, tradingFee);
 
       // populate trade object and add to the trade array, correcting for orientation of trade
       Object trade;
@@ -3304,6 +3307,7 @@ bool CMPTradeList::getMatchingTrades(const uint256& txid, uint32_t propertyId, A
           trade.push_back(Pair("address", address2));
           trade.push_back(Pair("amountsold", strAmount2));
           trade.push_back(Pair("amountreceived", strAmount1));
+          trade.push_back(Pair("tradingfee", strTradingFee));
           totalReceived += amount1;
           totalSold += amount2;
       }
@@ -3340,7 +3344,7 @@ void CMPTradeList::getTradesForPair(uint32_t propertyIdSideA, uint32_t propertyI
       if (strKey.size() != 129) continue; // only interested in matches
       boost::split(vecKeys, strKey, boost::is_any_of("+"), boost::token_compress_on);
       boost::split(vecValues, strValue, boost::is_any_of(":"), boost::token_compress_on);
-      if (vecKeys.size() != 2 || vecValues.size() != 7) {
+      if (vecKeys.size() != 2 || vecValues.size() != 8) {
           PrintToLog("TRADEDB error - unexpected number of tokens (%s:%s)\n", strKey, strValue);
           continue;
       }
@@ -3450,11 +3454,11 @@ void CMPTradeList::recordNewTrade(const uint256& txid, const std::string& addres
   if (msc_debug_tradedb) PrintToLog("%s(): %s\n", __FUNCTION__, status.ToString());
 }
 
-void CMPTradeList::recordMatchedTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum)
+void CMPTradeList::recordMatchedTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum, int64_t fee)
 {
   if (!pdb) return;
   const string key = txid1.ToString() + "+" + txid2.ToString();
-  const string value = strprintf("%s:%s:%u:%u:%lu:%lu:%d", address1, address2, prop1, prop2, amount1, amount2, blockNum);
+  const string value = strprintf("%s:%s:%u:%u:%lu:%lu:%d:%d", address1, address2, prop1, prop2, amount1, amount2, blockNum, fee);
   Status status;
   if (pdb)
   {

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -222,7 +222,7 @@ public:
         if (msc_debug_persistence) PrintToLog("CMPTradeList closed\n");
     }
 
-    void recordMatchedTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum);
+    void recordMatchedTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum, int64_t fee);
     void recordNewTrade(const uint256& txid, const std::string& address, uint32_t propertyIdForSale, uint32_t propertyIdDesired, int blockNum, int blockIndex);
     int deleteAboveBlock(int blockNum);
     bool exists(const uint256 &txid);

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -342,34 +342,45 @@ Value omni_getfeetrigger(const Array& params, bool fHelp)
 // Provides the fee share the wallet (or specific address) will receive from fee distributions
 Value omni_getfeeshare(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
+    if (fHelp || params.size() > 2)
         throw runtime_error(
-            "omni_getfeeshare [ address ]\n"
+            "omni_getfeeshare [ address ] [ ecosystem ]\n"
             "\nReturns the percentage share of fees distribution applied to the wallet (default) or address (if supplied).\n"
             "\nArguments:\n"
             "1. address              (string, optional) retrieve the fee share for the supplied address\n"
+            "2. ecosystem            (number, optional) the ecosystem to check the fee share (1 for main ecosystem, 2 for test ecosystem)\n"
             "\nResult:\n"
             "[                       (array of JSON objects)\n"
             "  {\n"
-            "    \"propertyid\" : nnnnnnn,          (number) the property id\n"
-            "    \"cachedfees\" : \"n.nnnnnnnn\",   (string) the amount of fees cached for this property\n"
+            "    \"address\" : nnnnnnn,          (number) the property id\n"
+            "    \"feeshare\" : \"n.nnnnnnnn\",   (string) the percentage of fees this address will receive based on current state\n"
             "  },\n"
             "  ...\n"
             "]\n"
             "\nExamples:\n"
-            + HelpExampleCli("omni_getfeeshare", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\"")
-            + HelpExampleRpc("omni_getfeeshare", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\"")
+            + HelpExampleCli("omni_getfeeshare", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\" 1")
+            + HelpExampleRpc("omni_getfeeshare", "\"1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P\", 1")
         );
 
     std::string address;
+    uint8_t ecosystem = 1;
     if (0 < params.size()) {
         address = ParseAddress(params[0]);
+    }
+    if (1 < params.size()) {
+        ecosystem = ParseEcosystem(params[1]);
     }
 
     Array response;
     bool addObj = false;
 
-    OwnerAddrType receiversSet = STO_GetReceivers("FEEDISTRIBUTION", OMNI_PROPERTY_MSC, COIN);
+    OwnerAddrType receiversSet;
+    if (ecosystem == 1) {
+        receiversSet = STO_GetReceivers("FEEDISTRIBUTION", OMNI_PROPERTY_MSC, COIN);
+    } else {
+        receiversSet = STO_GetReceivers("FEEDISTRIBUTION", OMNI_PROPERTY_TMSC, COIN);
+    }
+
     for (OwnerAddrType::reverse_iterator it = receiversSet.rbegin(); it != receiversSet.rend(); ++it) {
         addObj = false;
         if (address.empty()) {

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -186,7 +186,7 @@ Value omni_getfeedistribution(const Array& params, bool fHelp)
 
     bool found = p_feehistory->GetDistributionData(id, &propertyId, &block, &total);
     if (!found) {
-        return response; // TODO: should we error here or just return empty?
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Fee distribution ID does not exist");
     }
     response.push_back(Pair("distributionid", id));
     response.push_back(Pair("propertyid", (uint64_t)propertyId));
@@ -257,7 +257,10 @@ Value omni_getfeedistributions(const Array& params, bool fHelp)
             int64_t total = 0;
             Object responseObj;
             bool found = p_feehistory->GetDistributionData(id, &propertyId, &block, &total);
-            if (!found) continue; // TODO: trap this error?
+            if (!found) {
+                PrintToLog("Fee History Error - Distribution data not found for distribution ID %d but it was included in GetDistributionsForProperty(prop %d)\n", id, prop);
+                continue;
+            }
             responseObj.push_back(Pair("distributionid", id));
             responseObj.push_back(Pair("propertyid", (uint64_t)propertyId));
             responseObj.push_back(Pair("block", block));

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -11,6 +11,7 @@
 #include "omnicore/convert.h"
 #include "omnicore/dex.h"
 #include "omnicore/errors.h"
+#include "omnicore/fees.h"
 #include "omnicore/fetchwallettx.h"
 #include "omnicore/log.h"
 #include "omnicore/mdex.h"
@@ -386,6 +387,13 @@ Value mscrpc(const Array& params, bool fHelp)
             break;
         }
 #endif
+        case 14:
+        {
+            LOCK(cs_tally);
+            p_feecache->printAll();
+            p_feecache->printStats();
+            break;
+        }
         default:
             break;
     }

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -294,7 +294,7 @@ Value omni_getfeetrigger(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() > 1)
         throw runtime_error(
-            "omni_getfeetrigger [ propertyid ]\n"
+            "omni_getfeetrigger ( propertyid )\n"
             "\nReturns the amount of fees required in the cache to trigger distribution.\n"
             "\nArguments:\n"
             "1. propertyid           (number, optional) filter the results on this property id\n"
@@ -344,7 +344,7 @@ Value omni_getfeeshare(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() > 2)
         throw runtime_error(
-            "omni_getfeeshare [ address ] [ ecosystem ]\n"
+            "omni_getfeeshare ( address ecosystem )\n"
             "\nReturns the percentage share of fees distribution applied to the wallet (default) or address (if supplied).\n"
             "\nArguments:\n"
             "1. address              (string, optional) retrieve the fee share for the supplied address\n"
@@ -365,7 +365,11 @@ Value omni_getfeeshare(const Array& params, bool fHelp)
     std::string address;
     uint8_t ecosystem = 1;
     if (0 < params.size()) {
-        address = ParseAddress(params[0]);
+        if ("*" != params[0].get_str()) { //ParseAddressOrEmpty doesn't take wildcards
+            address = ParseAddressOrEmpty(params[0]);
+        } else {
+            address = "*";
+        }
     }
     if (1 < params.size()) {
         ecosystem = ParseEcosystem(params[1]);
@@ -387,7 +391,7 @@ Value omni_getfeeshare(const Array& params, bool fHelp)
             if (IsMyAddress(it->second)) {
                 addObj = true;
             }
-        } else if (address == it->second) {
+        } else if (address == it->second || address == "*") {
             addObj = true;
         }
         if (addObj) {
@@ -411,7 +415,7 @@ Value omni_getfeecache(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() > 1)
         throw runtime_error(
-            "omni_getfeecache [ propertyid ]\n"
+            "omni_getfeecache ( propertyid )\n"
             "\nReturns the amount of fees cached for distribution.\n"
             "\nArguments:\n"
             "1. propertyid           (number, optional) filter the results on this property id\n"

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -392,6 +392,27 @@ Value mscrpc(const Array& params, bool fHelp)
             LOCK(cs_tally);
             p_feecache->printAll();
             p_feecache->printStats();
+
+            int64_t a = 1000;
+            int64_t b = 1999;
+            int64_t c = 2001;
+            int64_t d = 20001;
+            int64_t e = 19999;
+
+            int64_t z = 2000;
+
+            int64_t aa = a/z;
+            int64_t bb = b/z;
+            int64_t cc = c/z;
+            int64_t dd = d/z;
+            int64_t ee = e/z;
+
+            PrintToConsole("%d / %d = %d\n",a,z,aa);
+            PrintToConsole("%d / %d = %d\n",b,z,bb);
+            PrintToConsole("%d / %d = %d\n",c,z,cc);
+            PrintToConsole("%d / %d = %d\n",d,z,dd);
+            PrintToConsole("%d / %d = %d\n",e,z,ee);
+
             break;
         }
         default:

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -164,6 +164,7 @@ CMainConsensusParams::CMainConsensusParams()
     DEXMATH_FEATURE_BLOCK = 999999;
     SPCROWDCROSSOVER_FEATURE_BLOCK = 999999;
     TRADEALLPAIRS_FEATURE_BLOCK = 999999;
+    FEES_FEATURE_BLOCK = 999999;
 }
 
 /**
@@ -200,6 +201,7 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     DEXMATH_FEATURE_BLOCK = 999999;
     SPCROWDCROSSOVER_FEATURE_BLOCK = 999999;
     TRADEALLPAIRS_FEATURE_BLOCK = 999999;
+    FEES_FEATURE_BLOCK = 999999;
 }
 
 /**
@@ -236,6 +238,7 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     DEXMATH_FEATURE_BLOCK = 999999;
     SPCROWDCROSSOVER_FEATURE_BLOCK = 999999;
     TRADEALLPAIRS_FEATURE_BLOCK = 999999;
+    FEES_FEATURE_BLOCK = 999999;
 }
 
 //! Consensus parameters for mainnet
@@ -400,6 +403,10 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
             MutableConsensusParams().TRADEALLPAIRS_FEATURE_BLOCK = activationBlock;
             featureName = "Allow trading all pairs on the Distributed Exchange";
         break;
+        case FEATURE_FEES:
+            MutableConsensusParams().FEES_FEATURE_BLOCK = activationBlock;
+            featureName = "Fee system (inc 0.05% fee from trades of non-Omni pairs)";
+        break;
         default:
             featureName = "Unknown feature";
             supported = false;
@@ -452,6 +459,9 @@ bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
             break;
         case FEATURE_TRADEALLPAIRS:
             activationBlock = params.TRADEALLPAIRS_FEATURE_BLOCK;
+            break;
+        case FEATURE_FEES:
+            activationBlock = params.FEES_FEATURE_BLOCK;
             break;
         default:
             return false;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -30,6 +30,8 @@ const uint16_t FEATURE_SENDALL = 6;
 const uint16_t FEATURE_SPCROWDCROSSOVER = 7;
 //! Feature identifier to enable non-Omni pairs on the distributed exchange
 const uint16_t FEATURE_TRADEALLPAIRS = 8;
+//! Feature identifier to enable the fee cache and strip 0.05% fees from non-Omni pairs
+const uint16_t FEATURE_FEES = 9;
 
 //! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
 const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
@@ -118,6 +120,8 @@ public:
     int SPCROWDCROSSOVER_FEATURE_BLOCK;
     //! Block to enable trading of non-Omni pairs
     int TRADEALLPAIRS_FEATURE_BLOCK;
+    //! Block to enable the fee system & 0.05% fee for trading non-Omni pairs
+    int FEES_FEATURE_BLOCK;
 
     /** Returns a mapping of transaction types, and the blocks at which they are enabled. */
     virtual std::vector<TransactionRestriction> GetRestrictions() const;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -31,6 +31,9 @@ const uint16_t FEATURE_SPCROWDCROSSOVER = 7;
 //! Feature identifier to enable non-Omni pairs on the distributed exchange
 const uint16_t FEATURE_TRADEALLPAIRS = 8;
 
+//! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
+const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
+
 /** A structure to represent transaction restrictions.
  */
 struct TransactionRestriction

--- a/src/omnicore/tally.cpp
+++ b/src/omnicore/tally.cpp
@@ -84,6 +84,7 @@ bool CMPTally::updateMoney(uint32_t propertyId, int64_t amount, TallyType ttype)
         // NOTE:
         // Negative balances are only permitted for pending balances
     } else {
+
         now64 += amount;
         mp_token[propertyId].balance[ttype] = now64;
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -133,6 +133,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getseedblocks", 1 },
     { "omni_getmetadexhash", 0 },
     { "omni_getfeecache", 0 },
+    { "omni_getfeetrigger", 0 },
+    { "omni_getfeedistribution", 0 },
+    { "omni_getfeedistributions", 0 },
 
     /* Omni Core - transaction calls */
     { "omni_send", 2 },

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -132,6 +132,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getseedblocks", 0 },
     { "omni_getseedblocks", 1 },
     { "omni_getmetadexhash", 0 },
+    { "omni_getfeecache", 0 },
 
     /* Omni Core - transaction calls */
     { "omni_send", 2 },

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -133,6 +133,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getseedblocks", 1 },
     { "omni_getmetadexhash", 0 },
     { "omni_getfeecache", 0 },
+    { "omni_getfeeshare", 1 },
     { "omni_getfeetrigger", 0 },
     { "omni_getfeedistribution", 0 },
     { "omni_getfeedistributions", 0 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -381,6 +381,9 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_getseedblocks",              &omni_getseedblocks,              false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getmetadexhash",             &omni_getmetadexhash,             false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getfeecache",                &omni_getfeecache,                false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getfeetrigger",              &omni_getfeetrigger,              false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getfeedistribution",         &omni_getfeedistribution,         false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getfeedistributions",        &omni_getfeedistributions,        false,      true,       false },
 #ifdef ENABLE_WALLET
     { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
     { "omni layer (data retrieval)",         "omni_getfeeshare",                &omni_getfeeshare,                false,      true,       true },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -383,6 +383,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_getfeecache",                &omni_getfeecache,                false,      true,       false },
 #ifdef ENABLE_WALLET
     { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
+    { "omni layer (data retrieval)",         "omni_getfeeshare",                &omni_getfeeshare,                false,      true,       true },
 
     /* Omni Core configuration calls */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -380,6 +380,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_getpayload",                 &omni_getpayload,                 false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getseedblocks",              &omni_getseedblocks,              false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getmetadexhash",             &omni_getmetadexhash,             false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getfeecache",                &omni_getfeecache,                false,      true,       false },
 #ifdef ENABLE_WALLET
     { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -252,6 +252,7 @@ extern json_spirit::Value omni_getpayload(const json_spirit::Array& params, bool
 extern json_spirit::Value omni_getseedblocks(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getmetadexhash(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getfeecache(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeeshare(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -252,7 +252,10 @@ extern json_spirit::Value omni_getpayload(const json_spirit::Array& params, bool
 extern json_spirit::Value omni_getseedblocks(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getmetadexhash(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getfeecache(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeetrigger(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getfeeshare(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeedistribution(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeedistributions(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -251,6 +251,7 @@ extern json_spirit::Value omni_getcurrentconsensushash(const json_spirit::Array&
 extern json_spirit::Value omni_getpayload(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getseedblocks(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getmetadexhash(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeecache(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);

--- a/test/test_fees.sh
+++ b/test/test_fees.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-#########################################
-## DISABLE DEV OMNI FOR THESE TESTS!!! ##
-#########################################
+################################################################################################
+## PLEASE DISABLE DEV OMNI FOR THESE TESTS!!!                                                 ##
+##                                                                                            ##
+## The fee distribution tests require an exact amount of Omni in each address.  Dev Omni will ##
+## skew these tests by increasing the amount of Omni in the Exodus Address.                   ##
+## To use this script in regtest mode, temporarily disable Dev Omni and recompile by adding:  ##
+##    return 0;                                                                               ##
+## as the first line of the function calculate_and_update_devmsc in omnicore.cpp.  This line  ##
+## must be removed and Omni Core recompiled to use on mainnet.                                ##
+################################################################################################
+
 
 PASS=0
 FAIL=0

--- a/test/test_fees.sh
+++ b/test/test_fees.sh
@@ -4,6 +4,8 @@
 ## DISABLE DEV OMNI FOR THESE TESTS!!! ##
 #########################################
 
+PASS=0
+FAIL=0
 clear
 printf "Preparing a test environment...\n"
 printf "   * Starting a fresh regtest daemon\n"
@@ -25,7 +27,7 @@ printf "   * Creating an indivisible test property\n"
 ./src/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 1 0 "Z_TestCat" "Z_TestSubCat" "Z_IndivisTestProperty" "Z_TestURL" "Z_TestData" 10000000 >null
 ./src/omnicore-cli --regtest setgenerate true 1 >null
 printf "   * Creating a divisible test property\n"
-./src/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 2 0 "Z_TestCat" "Z_TestSubCat" "Z_DivisTestProperty" "Z_TestURL" "Z_TestData" 100 >null
+./src/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 2 0 "Z_TestCat" "Z_TestSubCat" "Z_DivisTestProperty" "Z_TestURL" "Z_TestData" 10000 >null
 ./src/omnicore-cli --regtest setgenerate true 1 >null
 printf "   * Generating addresses to use as fee recipients (OMNI holders)\n"
 ADDRESS=()
@@ -52,40 +54,50 @@ FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[1]} | grep fe
 if [ $FEESHARE == "5.0000%" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $FEESHARE
+    FAIL=$((FAIL+1))
 fi
 printf "   * Checking %s has a 10 percent share of fees... " ${ADDRESS[2]}
 FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[2]} | grep feeshare | cut -d '"' -f4)
 if [ $FEESHARE == "10.0000%" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $FEESHARE
+    FAIL=$((FAIL+1))
 fi
 printf "   * Checking %s has a 15 percent share of fees... " ${ADDRESS[3]}
 FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[3]} | grep feeshare | cut -d '"' -f4)
 if [ $FEESHARE == "15.0000%" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $FEESHARE
+    FAIL=$((FAIL+1))
 fi
 printf "   * Checking %s has a 20 percent share of fees... " ${ADDRESS[4]}
 FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[4]} | grep feeshare | cut -d '"' -f4)
 if [ $FEESHARE == "20.0000%" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $FEESHARE
+    FAIL=$((FAIL+1))
 fi
 printf "   * Checking %s has a 50 percent share of fees... " $ADDR
 FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare $ADDR | grep feeshare | cut -d '"' -f4)
 if [ $FEESHARE == "50.0000%" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $FEESHARE
+    FAIL=$((FAIL+1))
 fi
 printf "\nTesting a trade against self that results in a 1 willet fee for property 3 (1.0 OMNI for 2000 #3)\n"
 printf "   * Executing the trade\n"
@@ -99,16 +111,20 @@ CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 3 | grep cachedfee | c
 if [ $CACHEDFEE == "1" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
 fi
 printf "      # Checking the trading address now owns 9999999 of property 3..."
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 3 | grep balance | cut -d '"' -f4)
 if [ $BALANCE == "9999999" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "\nTesting another trade against self that results in a 5 willet fee for property 3 (1.0 OMNI for 10000 #3)\n"
 printf "   * Executing the trade\n"
@@ -122,16 +138,20 @@ CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 3 | grep cachedfee | c
 if [ $CACHEDFEE == "6" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
 fi
 printf "      # Checking the trading address now owns 9999994 instead of property 3... "
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 3 | grep balance | cut -d '"' -f4)
 if [ $BALANCE == "9999994" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "\nTesting a trade against self that results in a 1 willet fee for property 4 (1.0 OMNI for 0.00002 #4)\n"
 printf "   * Executing the trade\n"
@@ -145,16 +165,20 @@ CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | c
 if [ $CACHEDFEE == "0.00000001" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
 fi
-printf "      # Checking the trading address now owns 99.99999999 of property 4... "
+printf "      # Checking the trading address now owns 9999.99999999 of property 4... "
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
-if [ $BALANCE == "99.99999999" ]
+if [ $BALANCE == "9999.99999999" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "\nTesting a trade against self that results in a 5000 willet fee for property 4 (1.0 OMNI for 0.1 #4)\n"
 printf "   * Executing the trade\n"
@@ -168,16 +192,20 @@ CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | c
 if [ $CACHEDFEE == "0.00005001" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
 fi
-printf "      # Checking the trading address now owns 99.99994999 of property 4... "
+printf "      # Checking the trading address now owns 9999.99994999 of property 4... "
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
-if [ $BALANCE == "99.99994999" ]
+if [ $BALANCE == "9999.99994999" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "\nIncreasing volume to get close to 10000000 fee trigger point for property 4\n"
 printf "   * Executing the trades\n"
@@ -194,16 +222,20 @@ CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | c
 if [ $CACHEDFEE == "0.09995001" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
 fi
-printf "      # Checking the trading address now owns 99.90004999 of property 4... "
+printf "      # Checking the trading address now owns 9999.90004999 of property 4... "
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
-if [ $BALANCE == "99.90004999" ]
+if [ $BALANCE == "9999.90004999" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "\nPerforming a small trade to take fee cache to 0.1 and trigger distribution for property 4\n"
 printf "   * Executing the trade\n"
@@ -217,49 +249,208 @@ CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | c
 if [ $CACHEDFEE == "0.00000000" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
 fi
 printf "      # Checking %s received 0.00500000 fee share... " ${ADDRESS[1]}
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[1]} 4 | grep balance | cut -d '"' -f4)
 if [ $BALANCE == "0.00500000" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "      # Checking %s received 0.01000000 fee share... " ${ADDRESS[2]}
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[2]} 4 | grep balance | cut -d '"' -f4)
 if [ $BALANCE == "0.01000000" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "      # Checking %s received 0.01500000 fee share... " ${ADDRESS[3]}
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[3]} 4 | grep balance | cut -d '"' -f4)
 if [ $BALANCE == "0.01500000" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "      # Checking %s received 0.02000000 fee share... " ${ADDRESS[4]}
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[4]} 4 | grep balance | cut -d '"' -f4)
 if [ $BALANCE == "0.02000000" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
 printf "      # Checking %s received 0.05000000 fee share... " $ADDR
 BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
-if [ $BALANCE == "99.95000000" ]
+if [ $BALANCE == "9999.95000000" ]
   then
     printf "PASS\n"
+    PASS=$((PASS+1))
   else
     printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
 fi
+printf "\nTesting a trade against self that results in a 1 willet fee for property 4 (1.0 OMNI for 0.00002 #4)\n"
+printf "   * Executing the trade\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 0.00002000 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 4 0.00002000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache now has 0.00000001 fee cached for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000001" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "\nTesting another trade against self that results in a 1 willet fee for property 4 (1.0 OMNI for 0.00002 #4)\n"
+printf "   * Executing the trade\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 0.00002000 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 4 0.00002000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache now has 0.00000002 fee cached for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000002" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "\nRolling back the chain to orphan a block (disconnecting 1 block from tip and mining a replacement)\n"
+printf "   * Executing the rollback\n"
+BLOCK=$(./src/omnicore-cli --regtest getblockcount)
+BLOCKHASH=$(./src/omnicore-cli --regtest getblockhash $(($BLOCK)))
+./src/omnicore-cli --regtest invalidateblock $BLOCKHASH >null
+PREVBLOCK=$(./src/omnicore-cli --regtest getblockcount)
+printf "   * Clearing the mempool\n"
+./src/omnicore-cli --regtest clearmempool >null
+printf "   * Verifiying the results\n"
+printf "      # Checking the block count has been reduced by 1... "
+EXPBLOCK=$((BLOCK-1))
+if [ $EXPBLOCK == $PREVBLOCK ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $PREVBLOCK
+    FAIL=$((FAIL+1))
+fi
+printf "   * Mining a replacement block\n"
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+NEWBLOCK=$(./src/omnicore-cli --regtest getblockcount)
+NEWBLOCKHASH=$(./src/omnicore-cli --regtest getblockhash $(($BLOCK)))
+printf "      # Checking the block count is the same as before the rollback... "
+if [ $BLOCK == $NEWBLOCK ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $NEWBLOCK
+    FAIL=$((FAIL+1))
+fi
+printf "      # Checking the block hash is different from before the rollback... "
+if [ $BLOCKHASH == $NEWBLOCKHASH ]
+  then
+    printf "FAIL (result:%s)\n" $NEWBLOCKHASH
+    FAIL=$((FAIL+1))
+  else
+    printf "PASS\n"
+    PASS=$((PASS+1))
+fi
+printf "      # Checking the fee cache has been rolled back to 0.00000001 for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000001" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "\nMining 51 blocks to test that fee cache is not affected by fee pruning\n"
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache is 0.00000001 for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000001" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "   * Mining the blocks...\n"
+./src/omnicore-cli --regtest setgenerate true 51 >null
+printf "      # Checking the fee cache is still 0.00000001 for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000001" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "   * Executing a trade to generate 1 willet fee\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 0.00002000 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 4 0.00002000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "      # Checking the fee cache now has 0.00000002 fee cached for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000002" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "   * Executing a trade to generate 1 willet fee\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 0.00002000 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 4 0.00002000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "      # Checking the fee cache now has 0.00000003 fee cached for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000003" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "\n"
+printf "####################\n"
+printf "#  Summary:        #\n"
+printf "#    Passed = %d   #\n" $PASS
+printf "#    Failed = %d    #\n" $FAIL
+printf "####################\n"
+printf "\n"
 
 ./src/omnicore-cli --regtest stop
 

--- a/test/test_fees.sh
+++ b/test/test_fees.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+
+#########################################
+## DISABLE DEV OMNI FOR THESE TESTS!!! ##
+#########################################
+
+clear
+printf "Preparing a test environment...\n"
+printf "   * Starting a fresh regtest daemon\n"
+rm -r ~/.bitcoin/regtest
+./src/omnicored --regtest --server --daemon >nul
+sleep 3
+printf "   * Preparing some mature testnet BTC\n"
+./src/omnicore-cli --regtest setgenerate true 102 >null
+printf "   * Obtaining a master address to work with\n"
+ADDR=$(./src/omnicore-cli --regtest getnewaddress OMNIAccount)
+printf "   * Funding the address with some testnet BTC for fees\n"
+./src/omnicore-cli --regtest sendtoaddress $ADDR 20 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Participating in the Exodus crowdsale to obtain some OMNI\n"
+JSON="{\"moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP\":10,\""$ADDR"\":4}"
+./src/omnicore-cli --regtest sendmany OMNIAccount $JSON >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Creating an indivisible test property\n"
+./src/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 1 0 "Z_TestCat" "Z_TestSubCat" "Z_IndivisTestProperty" "Z_TestURL" "Z_TestData" 10000000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Creating a divisible test property\n"
+./src/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 2 0 "Z_TestCat" "Z_TestSubCat" "Z_DivisTestProperty" "Z_TestURL" "Z_TestData" 100 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Generating addresses to use as fee recipients (OMNI holders)\n"
+ADDRESS=()
+for i in {1..6}
+do
+   ADDRESS=("${ADDRESS[@]}" $(./src/omnicore-cli --regtest getnewaddress))
+done
+printf "   * Using a total of 1000 OMNI\n"
+printf "   * Seeding %s with 50.00 OMNI\n" ${ADDRESS[1]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[1]} 1 50.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 100.00 OMNI\n" ${ADDRESS[2]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[2]} 1 100.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 150.00 OMNI\n" ${ADDRESS[3]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[3]} 1 150.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 200.00 OMNI\n" ${ADDRESS[4]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[4]} 1 200.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "\nChecking share of fees for recipients...\n"
+printf "   * Checking %s has a 5 percent share of fees... " ${ADDRESS[1]}
+FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[1]} | grep feeshare | cut -d '"' -f4)
+if [ $FEESHARE == "5.0000%" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $FEESHARE
+fi
+printf "   * Checking %s has a 10 percent share of fees... " ${ADDRESS[2]}
+FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[2]} | grep feeshare | cut -d '"' -f4)
+if [ $FEESHARE == "10.0000%" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $FEESHARE
+fi
+printf "   * Checking %s has a 15 percent share of fees... " ${ADDRESS[3]}
+FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[3]} | grep feeshare | cut -d '"' -f4)
+if [ $FEESHARE == "15.0000%" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $FEESHARE
+fi
+printf "   * Checking %s has a 20 percent share of fees... " ${ADDRESS[4]}
+FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare ${ADDRESS[4]} | grep feeshare | cut -d '"' -f4)
+if [ $FEESHARE == "20.0000%" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $FEESHARE
+fi
+printf "   * Checking %s has a 50 percent share of fees... " $ADDR
+FEESHARE=$(./src/omnicore-cli --regtest omni_getfeeshare $ADDR | grep feeshare | cut -d '"' -f4)
+if [ $FEESHARE == "50.0000%" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $FEESHARE
+fi
+printf "\nTesting a trade against self that results in a 1 willet fee for property 3 (1.0 OMNI for 2000 #3)\n"
+printf "   * Executing the trade\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 3 2000 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 3 2000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache now has 1 fee cached for property 3..."
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 3 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "1" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+fi
+printf "      # Checking the trading address now owns 9999999 of property 3..."
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 3 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "9999999" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "\nTesting another trade against self that results in a 5 willet fee for property 3 (1.0 OMNI for 10000 #3)\n"
+printf "   * Executing the trade\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 3 10000 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 3 10000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache now has 6 fee cached for property 3... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 3 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "6" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+fi
+printf "      # Checking the trading address now owns 9999994 instead of property 3... "
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 3 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "9999994" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "\nTesting a trade against self that results in a 1 willet fee for property 4 (1.0 OMNI for 0.00002 #4)\n"
+printf "   * Executing the trade\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 0.00002000 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 4 0.00002000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache now has 0.00000001 fee cached for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000001" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+fi
+printf "      # Checking the trading address now owns 99.99999999 of property 4... "
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "99.99999999" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "\nTesting a trade against self that results in a 5000 willet fee for property 4 (1.0 OMNI for 0.1 #4)\n"
+printf "   * Executing the trade\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 0.1 1 1.0 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 4 0.1 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache now has 0.00005001 fee cached for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00005001" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+fi
+printf "      # Checking the trading address now owns 99.99994999 of property 4... "
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "99.99994999" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "\nIncreasing volume to get close to 10000000 fee trigger point for property 4\n"
+printf "   * Executing the trades\n"
+for i in {1..5}
+do
+    ./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 39.96 1 1.0 >null
+    ./src/omnicore-cli --regtest setgenerate true 1 >null
+    ./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 1.0 4 39.96 >null
+    ./src/omnicore-cli --regtest setgenerate true 1 >null
+done
+printf "   * Verifiying the results\n"
+printf "      # Checking the fee cache now has 0.09995001 fee cached for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.09995001" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+fi
+printf "      # Checking the trading address now owns 99.90004999 of property 4... "
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "99.90004999" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "\nPerforming a small trade to take fee cache to 0.1 and trigger distribution for property 4\n"
+printf "   * Executing the trade\n"
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 4 0.09999999 1 0.8 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+./src/omnicore-cli --regtest omni_sendtrade $ADDR 1 0.8 4 0.09999999 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "      # Checking distribution was triggered and the fee cache is now empty for property 4... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 4 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000000" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+fi
+printf "      # Checking %s received 0.00500000 fee share... " ${ADDRESS[1]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[1]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "0.00500000" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "      # Checking %s received 0.01000000 fee share... " ${ADDRESS[2]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[2]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "0.01000000" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "      # Checking %s received 0.01500000 fee share... " ${ADDRESS[3]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[3]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "0.01500000" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "      # Checking %s received 0.02000000 fee share... " ${ADDRESS[4]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[4]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "0.02000000" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+printf "      # Checking %s received 0.05000000 fee share... " $ADDR
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance $ADDR 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "99.95000000" ]
+  then
+    printf "PASS\n"
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+fi
+
+./src/omnicore-cli --regtest stop
+
+
+
+


### PR DESCRIPTION
This PR serves to add the concept of fees to the Omni Layer.  

The main additions are:
* A fee caching system to enable an accumulation of fees within the protocol but not held by any address until such time as a distribution is triggered
* A fee distribution system to distribute the contents of a fee cache proportionally amongst all holders of the Omni token
* A fee history system to enable data retrieval about completed fee distributions

The main consensus affecting changes are:
* Code to slice 0.05% of trades of non-Omni pairs and move the tokens to the fee cache
* Code to trigger fee distribution once the fee cache reaches 0.001% of the total tokens for that property (arbitrary value, we can change with ```OMNICORE_FEE_THRESHOLD``` in ```rules.h```)

The testing is done via a regtest script (```test/test_fees.sh```) however this requires disabling Dev Omni and recompiling to run the tests.  I was hoping the testing guys (@msgilligan @dexX7) might be able to advise on converting to the boost unit test framework instead.

**Please note:  this is not yet ready for merging, there are still a few TODOs left including setting this up for activation, it's primarily to start the review process**

The RPC calls made available with this PR are as follows:

**omni_getfeeshare**
Use this call to query what percentage of fees a particular address will receive at that time.  Supply an address parameter to query any address, or do not supply parameters to query the wallet.
```
omni_getfeeshare [ address ]

Returns the percentage share of fees distribution applied to the wallet (default) or address (if supplied).

Arguments:
1. address              (string, optional) retrieve the fee share for the supplied address

Result:
[                       (array of JSON objects)
  {
    "propertyid" : nnnnnnn,        (number) the property id
    "cachedfees" : "n.nnnnnnnn",   (string) the amount of fees cached for this property
  },
  ...
]
```

**omni_getfeecache**
Use this call to determine the current value of the fee cache.  Without parameters it will display all properties with non-zero fee caches.  Supply a property ID to display the fee cache for a specific property.

```
omni_getfeecache [ propertyid ]

Returns the amount of fees cached for distribution.

Arguments:
1. propertyid           (number, optional) filter the results on this property id

Result:
[                       (array of JSON objects)
  {
    "propertyid" : nnnnnnn,        (number) the property id
    "cachedfees" : "n.nnnnnnnn",   (string) the amount of fees cached for this property
  },
...
]
```

**omni_getfeetrigger**
Use this call to query at what value the fee cache will trigger distribution for a given property.  Supply a property ID to filter on a specific ID.

```
omni_getfeetrigger [ propertyid ]

Returns the amount of fees required in the cache to trigger distribution.

Arguments:
1. propertyid           (number, optional) filter the results on this property id

Result:
[                       (array of JSON objects)
  {
    "propertyid" : nnnnnnn,        (number) the property id
    "feetrigger" : "n.nnnnnnnn",   (string) the amount of fees required to trigger distribution
  },
  ...
]
```

**omni_getfeedistribution**
Use this call to obtain specifics about a particular fee distribution.  Supply the fee distribution ID as parameter (note: each time a fee distribution is triggered, it is given a unique ID).

```
omni_getfeedistribution distributionid

Get the details for a fee distribution.

Arguments:
1. distributionid           (number, required) the distribution to obtain details for

Result:
{
  "distributionid" : n,          (number) the distribution id
  "propertyid" : n,              (number) the property id of the distributed tokens
  "block" : n,                   (number) the block the distribution occurred
  "amount" : "n.nnnnnnnn",       (string) the amount that was distributed
  "recipients": [                (array of JSON objects) a list of recipients
    {
      "address" : "address",          (string) the address of the recipient
      "amount" : "n.nnnnnnnn"         (string) the amount of fees received by the recipient
    },
    ...
  ]
}
```

**omni_getfeedistributions**
Use this call to list all the fee distributions that have been executed for a given property.
```
omni_getfeedistributions propertyid

Get the details of all fee distributions for a property.

Arguments:
1. propertyid           (number, required) the property id to retrieve distributions for

Result:
[                       (array of JSON objects)
  {
    "distributionid" : n,          (number) the distribution id
    "propertyid" : n,              (number) the property id of the distributed tokens
    "block" : n,                   (number) the block the distribution occurred
    "amount" : "n.nnnnnnnn",       (string) the amount that was distributed
    "recipients": [                (array of JSON objects) a list of recipients
      {
        "address" : "address",          (string) the address of the recipient
        "amount" : "n.nnnnnnnn"         (string) the amount of fees received by the recipient
      },
      ...
    ]
  },
  ...
]
 ```