### PR TITLE
Fix Travis builds without cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # - A travis bug causes caches to trample eachother when using the same
 #   compiler key (which we don't use anyway). This is worked around for now by
 #   replacing the "compilers" with a build name prefixed by the no-op ":"
-#   command. See: https://github.com/travis-ci/casher/issues/6
+#   command. See: https://github.com/travis-ci/travis-ci/issues/4393
 
 os: linux
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ matrix:
 
 before_install:
     - mkdir -p depends/SDKs depends/sdk-sources
-    - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then wget $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -O depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
+    - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - unset CC; unset CXX; unset CCACHE_DISABLE
     - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -6,6 +6,7 @@ suites:
 architectures:
 - "amd64"
 packages: 
+- "curl"
 - "g++-multilib"
 - "git-core"
 - "pkg-config"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -7,6 +7,7 @@ architectures:
 - "amd64"
 packages: 
 - "g++-multilib"
+- "curl"
 - "git-core"
 - "pkg-config"
 - "autoconf2.13"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -6,6 +6,7 @@ suites:
 architectures:
 - "amd64"
 packages: 
+- "curl"
 - "g++"
 - "git-core"
 - "pkg-config"

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -7,7 +7,7 @@ build_darwin_OTOOL: = $(shell xcrun -f otool)
 build_darwin_NM: = $(shell xcrun -f nm)
 build_darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
 build_darwin_SHA256SUM = shasum -a 256
-build_darwin_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o
+build_darwin_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
 darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION)

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -7,7 +7,7 @@ build_darwin_OTOOL: = $(shell xcrun -f otool)
 build_darwin_NM: = $(shell xcrun -f nm)
 build_darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
 build_darwin_SHA256SUM = shasum -a 256
-build_darwin_DOWNLOAD = curl --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o
+build_darwin_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
 darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION)

--- a/depends/builders/linux.mk
+++ b/depends/builders/linux.mk
@@ -1,2 +1,2 @@
 build_linux_SHA256SUM = sha256sum
-build_linux_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o
+build_linux_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o

--- a/depends/builders/linux.mk
+++ b/depends/builders/linux.mk
@@ -1,2 +1,2 @@
 build_linux_SHA256SUM = sha256sum
-build_linux_DOWNLOAD = wget --timeout=$(DOWNLOAD_CONNECT_TIMEOUT) --tries=$(DOWNLOAD_RETRIES) -nv -O
+build_linux_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o


### PR DESCRIPTION
These commits are cherry-picked from the [upstream 0.10 branch](https://github.com/OmniLayer/omnicore/compare/omnicore-0.0.10...bitcoin:0.10), to fix the Travis build without cache.