### PR TITLE
Fix syntax error in walletdb key parser

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -199,7 +199,7 @@ bool CDBEnv::Salvage(std::string strFile, bool fAggressive, std::vector<CDBEnv::
     std::string keyHex, valueHex;
     while (!strDump.eof() && keyHex != "DATA=END") {
         getline(strDump, keyHex);
-        if (keyHex != "DATA_END") {
+        if (keyHex != "DATA=END") {
             getline(strDump, valueHex);
             vResult.push_back(make_pair(ParseHex(keyHex), ParseHex(valueHex)));
         }


### PR DESCRIPTION
These commit is cherry-picked from the [upstream 0.10 branch](https://github.com/OmniLayer/omnicore/compare/omnicore-0.0.10...bitcoin:0.10), to fix an error in the key parser of the walletdb.