### PR TITLE
Temporarily disable the trading UI

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -100,7 +100,21 @@ WalletView::WalletView(QWidget *parent):
     exTabHolder->addTab(tradeHistoryTab,tr("Trade History"));
     exTabHolder->addTab(cancelTab,tr("Cancel Orders"));
     exvbox->addWidget(exTabHolder);
+
+    /* - temporarily disable the MetaDEx UI
     exchangePage->setLayout(exvbox);
+    */
+    QVBoxLayout *tmpVLayout = new QVBoxLayout();
+    QLabel *tmpLabelA = new QLabel(this);
+    QLabel *tmpLabelB = new QLabel(this);
+    tmpLabelA->setText("Please note:");
+    tmpLabelB->setText("The UI trading interface is disabled in this release and will be reactivated in a future release.  RPC calls are still available.");
+    tmpVLayout->addWidget(tmpLabelA);
+    tmpVLayout->addWidget(tmpLabelB);
+    tmpVLayout->addStretch();
+    exchangePage->setLayout(tmpVLayout);
+    /* - end temporarily disable MetaDEx UI
+    */
 
     // toolbox page
     toolboxPage = new QWidget(this);


### PR DESCRIPTION
The current MetaDEx UI in Omni Core was designed for trading where one side of the pair is always Omni.  As such it takes several actions and makes several coding assumptions based on knowledge that one side of the trade will always be Omni.

Since 0.11 provides the ability to trade all pairs once activated, this changes the rules and makes the current UI a risk.

This PR thus disables the current trading interface, and leaves the rest of the UI as is.

This PR may seem a bit extreme, but rather no trading interface than something with potentially unexpected behavior.

We would then include the trading interfacce again in 0.11.1 once you guys have tested the changes I'm making.

Thoughts?