### PR TITLE
Add cross-property (v1) Send To Owners

### DIFF
--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -100,11 +100,12 @@ std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount)
+std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty)
 {
     std::vector<unsigned char> payload;
+
     uint16_t messageType = 3;
-    uint16_t messageVer = 0;
+    uint16_t messageVer = (distributionProperty == 0) ? 0 : 1;
     mastercore::swapByteOrder16(messageType);
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder32(propertyId);
@@ -114,6 +115,10 @@ std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint6
     PUSH_BACK_BYTES(payload, messageType);
     PUSH_BACK_BYTES(payload, propertyId);
     PUSH_BACK_BYTES(payload, amount);
+    if (distributionProperty != 0) {
+        mastercore::swapByteOrder32(distributionProperty);
+        PUSH_BACK_BYTES(payload, distributionProperty);
+    }
 
     return payload;
 }

--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -102,10 +102,12 @@ std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t
 
 std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty)
 {
+    bool v0 = (propertyId == distributionProperty) ? true : false;
+
     std::vector<unsigned char> payload;
 
     uint16_t messageType = 3;
-    uint16_t messageVer = (distributionProperty == 0 || propertyId == distributionProperty) ? 0 : 1;
+    uint16_t messageVer = (v0) ? 0 : 1;
     mastercore::swapByteOrder16(messageType);
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder32(propertyId);
@@ -115,7 +117,7 @@ std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint6
     PUSH_BACK_BYTES(payload, messageType);
     PUSH_BACK_BYTES(payload, propertyId);
     PUSH_BACK_BYTES(payload, amount);
-    if (distributionProperty != 0 && propertyId != distributionProperty) {
+    if (!v0) {
         mastercore::swapByteOrder32(distributionProperty);
         PUSH_BACK_BYTES(payload, distributionProperty);
     }

--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -105,7 +105,7 @@ std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint6
     std::vector<unsigned char> payload;
 
     uint16_t messageType = 3;
-    uint16_t messageVer = (distributionProperty == 0) ? 0 : 1;
+    uint16_t messageVer = (distributionProperty == 0 || propertyId == distributionProperty) ? 0 : 1;
     mastercore::swapByteOrder16(messageType);
     mastercore::swapByteOrder16(messageVer);
     mastercore::swapByteOrder32(propertyId);
@@ -115,7 +115,7 @@ std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint6
     PUSH_BACK_BYTES(payload, messageType);
     PUSH_BACK_BYTES(payload, propertyId);
     PUSH_BACK_BYTES(payload, amount);
-    if (distributionProperty != 0) {
+    if (distributionProperty != 0 && propertyId != distributionProperty) {
         mastercore::swapByteOrder32(distributionProperty);
         PUSH_BACK_BYTES(payload, distributionProperty);
     }

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -9,7 +9,7 @@ std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_
 std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem);
 std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction);
 std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount);
-std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty = 0);
+std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty);
 std::vector<unsigned char> CreatePayload_IssuanceFixed(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
                                                        std::string subcategory, std::string name, std::string url, std::string data, uint64_t amount);
 std::vector<unsigned char> CreatePayload_IssuanceVariable(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -9,7 +9,7 @@ std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_
 std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem);
 std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction);
 std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount);
-std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount);
+std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty = 0);
 std::vector<unsigned char> CreatePayload_IssuanceFixed(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
                                                        std::string subcategory, std::string name, std::string url, std::string data, uint64_t amount);
 std::vector<unsigned char> CreatePayload_IssuanceVariable(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,

--- a/src/omnicore/doc/release-notes.md
+++ b/src/omnicore/doc/release-notes.md
@@ -18,6 +18,7 @@ Table of contents
 - [Consensus affecting changes](#consensus-affecting-changes)
   - [Trading of all pairs on the Distributed Exchange](#trading-of-all-pairs-on-the-distributed-exchange)
   - [Fee distribution system on the Distributed Exchange](#fee-distribution-system-on-the-distributed-exchange)
+  - [Send to Owners cross property suport](#send-to-owners-cross-property-support)
 - [Other notable changes](#other-notable-changes)
   - [Raw payload creation API](#raw-payload-creation-api)
   - [Other API extensions](#other-api-extensions)
@@ -82,6 +83,18 @@ See also [fee system JSON-RPC API documentation](https://github.com/OmniLayer/om
 
 This change is identified by `"featureid": 9` and labeled by the GUI as `"Fee system (inc 0.05% fee from trades of non-Omni pairs)"`.
 
+Send To Owners cross property support
+-------------------------------------
+
+Once activated distributing tokens via the Send To Owners transaction will be permitted to cross properties if using version 1 of the transaction.
+
+Tokens of property X then may be distributed to holders of property Y.
+
+There is a significantly increased fee (0.00001000 per recipient) for using version 1 of the STO transaction.  The fee remains the same (0.00000001) per recipient for using version 0 of the STO transaction.
+
+Sending an STO transaction via Omni Core that distributes tokens to holders of the same property will automatically be sent as version 0, and sending a cross-property STO will automatically be sent as version 1.
+
+This change is identified by `"featureid": 10` and labeled by the GUI as `"Cross-property Send To Owners"`.
 
 Other notable changes
 =====================

--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -215,12 +215,13 @@ Create and broadcast a send-to-owners transaction.
 
 **Arguments:**
 
-| Name                | Type    | Presence | Description                                                                                  |
-|---------------------|---------|----------|----------------------------------------------------------------------------------------------|
-| `fromaddress`       | string  | required | the address to send from                                                                     |
-| `propertyid`        | number  | required | the identifier of the tokens to distribute                                                   |
-| `amount`            | string  | required | the amount to distribute                                                                     |
-| `redeemaddress`     | string  | optional | an address that can spend the transaction dust (sender by default)                           |
+| Name                   | Type    | Presence | Description                                                                                  |
+|------------------------|---------|----------|----------------------------------------------------------------------------------------------|
+| `fromaddress`          | string  | required | the address to send from                                                                     |
+| `propertyid`           | number  | required | the identifier of the tokens to distribute                                                   |
+| `amount`               | string  | required | the amount to distribute                                                                     |
+| `redeemaddress`        | string  | optional | an address that can spend the transaction dust (sender by default)                           |
+| `distributionproperty` | number  | optional | the identifier of the property holders to distribute to                                      |
 
 **Result:**
 ```js
@@ -1721,10 +1722,11 @@ Creates the payload for a send-to-owners transaction.
 
 **Arguments:**
 
-| Name                | Type    | Presence | Description                                                                                  |
-|---------------------|---------|----------|----------------------------------------------------------------------------------------------|
-| `propertyid`        | number  | required | the identifier of the token to distribute                                                    |
-| `amount`            | string  | required | the amount to distribute                                                                     |
+| Name                   | Type    | Presence | Description                                                                                  |
+|------------------------|---------|----------|----------------------------------------------------------------------------------------------|
+| `propertyid`           | number  | required | the identifier of the token to distribute                                                    |
+| `amount`               | string  | required | the amount to distribute                                                                     |
+| `distributionproperty` | number  | optional | the identifier of the property holders to distribute to                                      |
 
 **Result:**
 ```js

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3052,7 +3052,7 @@ std::string CMPSTOList::getMySTOReceipts(string filterAddress)
   return mySTOReceipts;
 }
 
-void CMPSTOList::getRecipients(const uint256 txid, string filterAddress, Array *recipientArray, uint64_t *total, uint64_t *stoFee)
+void CMPSTOList::getRecipients(const uint256 txid, string filterAddress, Array *recipientArray, uint64_t *total, uint64_t *numRecipients)
 {
   if (!pdb) return;
 
@@ -3066,9 +3066,8 @@ void CMPSTOList::getRecipients(const uint256 txid, string filterAddress, Array *
   // iterate through SDB, dropping all records where key is not filterAddress (if filtering)
   int count = 0;
 
-  // ugly way to do this, really we should store the fee used but for now since we know it is
-  // always num_addresses * 0.00000001 MSC we can recalculate it on the fly
-  *stoFee = 0;
+  // the fee is variable based on version of STO - provide number of recipients and allow calling function to work out fee
+  *numRecipients = 0;
 
   Slice skey, svalue;
   Iterator* it = NewIterator();
@@ -3082,7 +3081,7 @@ void CMPSTOList::getRecipients(const uint256 txid, string filterAddress, Array *
       size_t txidMatch = strValue.find(txid.ToString());
       if(txidMatch!=std::string::npos)
       {
-          ++*stoFee;
+          ++*numRecipients;
           // the txid exists inside the data, this address was a recipient of this STO, check filter and add the details
           if(filter)
           {

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -197,7 +197,7 @@ public:
         if (msc_debug_persistence) PrintToLog("CMPSTOList closed\n");
     }
 
-    void getRecipients(const uint256 txid, string filterAddress, Array *recipientArray, uint64_t *total, uint64_t *stoFee);
+    void getRecipients(const uint256 txid, string filterAddress, Array *recipientArray, uint64_t *total, uint64_t *numRecipients);
     std::string getMySTOReceipts(string filterAddress);
     int deleteAboveBlock(int blockNum);
     void printStats();

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -148,16 +148,16 @@ Value omni_createpayload_dexaccept(const Array& params, bool fHelp)
 
 Value omni_createpayload_sto(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 2)
+    if (fHelp || params.size() < 2 || params.size() > 3)
         throw runtime_error(
             "omni_createpayload_sto propertyid \"amount\"\n"
 
             "\nCreates the payload for a send-to-owners transaction.\n"
 
             "\nArguments:\n"
-            "1. propertyid           (number, required) the identifier of the tokens to distribute\n"
-            "2. amount               (string, required) the amount to distribute\n"
-
+            "1. propertyid             (number, required) the identifier of the tokens to distribute\n"
+            "2. amount                 (string, required) the amount to distribute\n"
+            "3. distributionproperty   (number, optional) the identifier of the property holders to distribute to\n"
             "\nResult:\n"
             "\"payload\"             (string) the hex-encoded payload\n"
 
@@ -169,8 +169,9 @@ Value omni_createpayload_sto(const Array& params, bool fHelp)
     uint32_t propertyId = ParsePropertyId(params[0]);
     RequireExistingProperty(propertyId);
     int64_t amount = ParseAmount(params[1], isPropertyDivisible(propertyId));
+    uint32_t distributionPropertyId = (params.size() > 2) ? ParsePropertyId(params[2]) : 0;
 
-    std::vector<unsigned char> payload = CreatePayload_SendToOwners(propertyId, amount);
+    std::vector<unsigned char> payload = CreatePayload_SendToOwners(propertyId, amount, distributionPropertyId);
 
     return HexStr(payload.begin(), payload.end());
 }

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -150,7 +150,7 @@ Value omni_createpayload_sto(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 2 || params.size() > 3)
         throw runtime_error(
-            "omni_createpayload_sto propertyid \"amount\"\n"
+            "omni_createpayload_sto propertyid \"amount\" ( distributionproperty )\n"
 
             "\nCreates the payload for a send-to-owners transaction.\n"
 

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -169,7 +169,7 @@ Value omni_createpayload_sto(const Array& params, bool fHelp)
     uint32_t propertyId = ParsePropertyId(params[0]);
     RequireExistingProperty(propertyId);
     int64_t amount = ParseAmount(params[1], isPropertyDivisible(propertyId));
-    uint32_t distributionPropertyId = (params.size() > 2) ? ParsePropertyId(params[2]) : 0;
+    uint32_t distributionPropertyId = (params.size() > 2) ? ParsePropertyId(params[2]) : propertyId;
 
     std::vector<unsigned char> payload = CreatePayload_SendToOwners(propertyId, amount, distributionPropertyId);
 

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -552,7 +552,7 @@ Value omni_sendsto(const Array& params, bool fHelp)
     uint32_t propertyId = ParsePropertyId(params[1]);
     int64_t amount = ParseAmount(params[2], isPropertyDivisible(propertyId));
     std::string redeemAddress = (params.size() > 3 && !ParseText(params[3]).empty()) ? ParseAddress(params[3]): "";
-    uint32_t distributionPropertyId = (params.size() > 4) ? ParsePropertyId(params[4]) : 0;
+    uint32_t distributionPropertyId = (params.size() > 4) ? ParsePropertyId(params[4]) : propertyId;
 
     // perform checks
     RequireBalance(fromAddress, propertyId, amount);

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -526,17 +526,18 @@ Value omni_sendissuancemanaged(const Array& params, bool fHelp)
 // omni_sendsto - Send to owners
 Value omni_sendsto(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 3 || params.size() > 4)
+    if (fHelp || params.size() < 3 || params.size() > 5)
         throw runtime_error(
-            "omni_sendsto \"fromaddress\" propertyid \"amount\" ( \"redeemaddress\" )\n"
+            "omni_sendsto \"fromaddress\" propertyid \"amount\" ( \"redeemaddress\" distributionproperty )\n"
 
             "\nCreate and broadcast a send-to-owners transaction.\n"
 
             "\nArguments:\n"
-            "1. fromaddress          (string, required) the address to send from\n"
-            "2. propertyid           (number, required) the identifier of the tokens to distribute\n"
-            "3. amount               (string, required) the amount to distribute\n"
-            "4. redeemaddress        (string, optional) an address that can spend the transaction dust (sender by default)\n"
+            "1. fromaddress            (string, required) the address to send from\n"
+            "2. propertyid             (number, required) the identifier of the tokens to distribute\n"
+            "3. amount                 (string, required) the amount to distribute\n"
+            "4. redeemaddress          (string, optional) an address that can spend the transaction dust (sender by default)\n"
+            "5. distributionproperty   (number, required) the identifier of the property holders to distribute to\n"
 
             "\nResult:\n"
             "\"hash\"                  (string) the hex-encoded transaction hash\n"
@@ -551,12 +552,13 @@ Value omni_sendsto(const Array& params, bool fHelp)
     uint32_t propertyId = ParsePropertyId(params[1]);
     int64_t amount = ParseAmount(params[2], isPropertyDivisible(propertyId));
     std::string redeemAddress = (params.size() > 3 && !ParseText(params[3]).empty()) ? ParseAddress(params[3]): "";
+    uint32_t distributionPropertyId = (params.size() > 4) ? ParsePropertyId(params[4]) : 0;
 
     // perform checks
     RequireBalance(fromAddress, propertyId, amount);
 
     // create a payload for the transaction
-    std::vector<unsigned char> payload = CreatePayload_SendToOwners(propertyId, amount);
+    std::vector<unsigned char> payload = CreatePayload_SendToOwners(propertyId, amount, distributionPropertyId);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -537,7 +537,7 @@ Value omni_sendsto(const Array& params, bool fHelp)
             "2. propertyid             (number, required) the identifier of the tokens to distribute\n"
             "3. amount                 (string, required) the amount to distribute\n"
             "4. redeemaddress          (string, optional) an address that can spend the transaction dust (sender by default)\n"
-            "5. distributionproperty   (number, required) the identifier of the property holders to distribute to\n"
+            "5. distributionproperty   (number, optional) the identifier of the property holders to distribute to\n"
 
             "\nResult:\n"
             "\"hash\"                  (string) the hex-encoded transaction hash\n"

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -13,6 +13,7 @@
 #include "omnicore/pending.h"
 #include "omnicore/rpctxobject.h"
 #include "omnicore/sp.h"
+#include "omnicore/sto.h"
 #include "omnicore/tx.h"
 #include "omnicore/utilsbitcoin.h"
 #include "omnicore/wallettxs.h"
@@ -500,13 +501,15 @@ void populateRPCTypeActivation(CMPTransaction& omniObj, Object& txobj)
 void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, Object& txobj, uint16_t version)
 {
     Array receiveArray;
-    uint64_t tmpAmount = 0, stoFee = 0;
+    uint64_t tmpAmount = 0, stoFee = 0, numRecipients = 0;
     LOCK(cs_tally);
-    s_stolistdb->getRecipients(txid, extendedDetailsFilter, &receiveArray, &tmpAmount, &stoFee);
-    if (version > MP_TX_PKT_V0) {
-        stoFee = stoFee * 100; // just awful, but until we start storing the fee somewhere it's a workaround
+    s_stolistdb->getRecipients(txid, extendedDetailsFilter, &receiveArray, &tmpAmount, &numRecipients);
+    if (version == MP_TX_PKT_V0) {
+        stoFee = numRecipients * TRANSFER_FEE_PER_OWNER;
+    } else {
+        stoFee = numRecipients * TRANSFER_FEE_PER_OWNER_V1;
     }
-    txobj.push_back(Pair("totalstofee", FormatDivisibleMP(stoFee))); // fee always MSC so always divisible
+    txobj.push_back(Pair("totalstofee", FormatDivisibleMP(stoFee))); // fee always OMNI so always divisible
     txobj.push_back(Pair("recipients", receiveArray));
 }
 

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -274,7 +274,7 @@ void populateRPCTypeSendToOwners(CMPTransaction& omniObj, Object& txobj, bool ex
     txobj.push_back(Pair("propertyid", (uint64_t)propertyId));
     txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
     txobj.push_back(Pair("amount", FormatMP(propertyId, omniObj.getAmount())));
-    if (extendedDetails) populateRPCExtendedTypeSendToOwners(omniObj.getHash(), extendedDetailsFilter, txobj);
+    if (extendedDetails) populateRPCExtendedTypeSendToOwners(omniObj.getHash(), extendedDetailsFilter, txobj, omniObj.getVersion());
 }
 
 void populateRPCTypeSendAll(CMPTransaction& omniObj, Object& txobj)
@@ -497,12 +497,15 @@ void populateRPCTypeActivation(CMPTransaction& omniObj, Object& txobj)
     txobj.push_back(Pair("minimumversion", (uint64_t) omniObj.getMinClientVersion()));
 }
 
-void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, Object& txobj)
+void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, Object& txobj, uint16_t version)
 {
     Array receiveArray;
     uint64_t tmpAmount = 0, stoFee = 0;
     LOCK(cs_tally);
     s_stolistdb->getRecipients(txid, extendedDetailsFilter, &receiveArray, &tmpAmount, &stoFee);
+    if (version > MP_TX_PKT_V0) {
+        stoFee = stoFee * 100; // just awful, but until we start storing the fee somewhere it's a workaround
+    }
     txobj.push_back(Pair("totalstofee", FormatDivisibleMP(stoFee))); // fee always MSC so always divisible
     txobj.push_back(Pair("recipients", receiveArray));
 }

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -31,7 +31,7 @@ void populateRPCTypeRevoke(CMPTransaction& omniOobj, json_spirit::Object& txobj)
 void populateRPCTypeChangeIssuer(CMPTransaction& omniObj, json_spirit::Object& txobj);
 void populateRPCTypeActivation(CMPTransaction& omniObj, json_spirit::Object& txobj);
 
-void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, json_spirit::Object& txobj);
+void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, json_spirit::Object& txobj, uint16_t version);
 void populateRPCExtendedTypeMetaDExTrade(const uint256& txid, uint32_t propertyIdForSale, int64_t amountForSale, json_spirit::Object& txobj);
 void populateRPCExtendedTypeMetaDExCancel(const uint256& txid, json_spirit::Object& txobj);
 

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -58,6 +58,7 @@ std::vector<TransactionRestriction> CConsensusParams::GetRestrictions() const
         { MSC_TYPE_CHANGE_ISSUER_ADDRESS,     MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK },
 
         { MSC_TYPE_SEND_TO_OWNERS,            MP_TX_PKT_V0,  false,   MSC_STO_BLOCK      },
+        { MSC_TYPE_SEND_TO_OWNERS,            MP_TX_PKT_V1,  false,   MSC_STOV1_BLOCK    },
 
         { MSC_TYPE_METADEX_TRADE,             MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
         { MSC_TYPE_METADEX_CANCEL_PRICE,      MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
@@ -163,6 +164,7 @@ CMainConsensusParams::CMainConsensusParams()
     MSC_METADEX_BLOCK = 999999;
     MSC_SEND_ALL_BLOCK = 999999;
     MSC_BET_BLOCK = 999999;
+    MSC_STOV1_BLOCK = 999999;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 999999;
     DEXMATH_FEATURE_BLOCK = 999999;
@@ -200,6 +202,7 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     MSC_METADEX_BLOCK = 0;
     MSC_SEND_ALL_BLOCK = 0;
     MSC_BET_BLOCK = 999999;
+    MSC_STOV1_BLOCK = 0;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 999999;
     DEXMATH_FEATURE_BLOCK = 999999;
@@ -237,6 +240,7 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     MSC_METADEX_BLOCK = 0;
     MSC_SEND_ALL_BLOCK = 0;
     MSC_BET_BLOCK = 999999;
+    MSC_STOV1_BLOCK = 999999;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 999999;
     DEXMATH_FEATURE_BLOCK = 999999;
@@ -411,6 +415,10 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
             MutableConsensusParams().FEES_FEATURE_BLOCK = activationBlock;
             featureName = "Fee system (inc 0.05% fee from trades of non-Omni pairs)";
         break;
+        case FEATURE_STOV1:
+            MutableConsensusParams().MSC_STOV1_BLOCK = activationBlock;
+            featureName = "Cross-property Send To Owners";
+        break;
         default:
             featureName = "Unknown feature";
             supported = false;
@@ -466,6 +474,9 @@ bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
             break;
         case FEATURE_FEES:
             activationBlock = params.FEES_FEATURE_BLOCK;
+            break;
+        case FEATURE_STOV1:
+            activationBlock = params.MSC_STOV1_BLOCK;
             break;
         default:
             return false;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -32,6 +32,8 @@ const uint16_t FEATURE_SPCROWDCROSSOVER = 7;
 const uint16_t FEATURE_TRADEALLPAIRS = 8;
 //! Feature identifier to enable the fee cache and strip 0.05% fees from non-Omni pairs
 const uint16_t FEATURE_FEES = 9;
+//! Feature identifier to enable cross property (v1) Send To Owners
+const uint16_t FEATURE_STOV1 = 10;
 
 //! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
 const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
@@ -111,6 +113,8 @@ public:
     int MSC_SEND_ALL_BLOCK;
     //! Block to enable betting transactions
     int MSC_BET_BLOCK;
+    //! Block to enable cross property STO (v1)
+    int MSC_STOV1_BLOCK;
 
     //! Block to deactivate crowdsale participations when "granting tokens"
     int GRANTEFFECTS_FEATURE_BLOCK;

--- a/src/omnicore/sto.h
+++ b/src/omnicore/sto.h
@@ -16,7 +16,7 @@ struct SendToOwners_compare
 
 //! Fee required to be paid per owner/receiver, nominated in willets
 const int64_t TRANSFER_FEE_PER_OWNER = 1;
-const int64_t TRANSFER_FEE_PER_OWNER_V1 = 100;
+const int64_t TRANSFER_FEE_PER_OWNER_V1 = 1000;
 
 //! Set of owner/receivers, sorted by amount they own or might receive
 typedef std::set<std::pair<int64_t, std::string>, SendToOwners_compare> OwnerAddrType;

--- a/src/omnicore/sto.h
+++ b/src/omnicore/sto.h
@@ -16,6 +16,7 @@ struct SendToOwners_compare
 
 //! Fee required to be paid per owner/receiver, nominated in willets
 const int64_t TRANSFER_FEE_PER_OWNER = 1;
+const int64_t TRANSFER_FEE_PER_OWNER_V1 = 100;
 
 //! Set of owner/receivers, sorted by amount they own or might receive
 typedef std::set<std::pair<int64_t, std::string>, SendToOwners_compare> OwnerAddrType;

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -22,12 +22,24 @@ BOOST_AUTO_TEST_CASE(payload_simple_send)
 
 BOOST_AUTO_TEST_CASE(payload_send_to_owners)
 {
-    // Send to owners [type 3, version 0]
+    // Send to owners [type 3, version 0] (same property)
     std::vector<unsigned char> vch = CreatePayload_SendToOwners(
-        static_cast<uint32_t>(1),          // property: MSC
-        static_cast<int64_t>(100000000));  // amount to transfer: 1.0 MSC (in willets)
+        static_cast<uint32_t>(1),          // property: OMNI
+        static_cast<int64_t>(100000000),   // amount to transfer: 1.0 OMNI (in willets)
+        static_cast<uint32_t>(1));         // property: OMNI
 
     BOOST_CHECK_EQUAL(HexStr(vch), "00000003000000010000000005f5e100");
+}
+
+BOOST_AUTO_TEST_CASE(payload_send_to_owners_v1)
+{
+    // Send to owners [type 3, version 1] (cross property)
+    std::vector<unsigned char> vch = CreatePayload_SendToOwners(
+        static_cast<uint32_t>(1),          // property: OMNI
+        static_cast<int64_t>(100000000),   // amount to transfer: 1.0 OMNI (in willets)
+        static_cast<uint32_t>(3));         // property: SP#3
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "00010003000000010000000005f5e10000000003");
 }
 
 BOOST_AUTO_TEST_CASE(payload_send_all)

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -224,7 +224,7 @@ bool CMPTransaction::interpret_SendToOwners()
         PrintToLog("\t             property: %d (%s)\n", property, strMPProperty(property));
         PrintToLog("\t                value: %s\n", FormatMP(property, nValue));
         if (version > MP_TX_PKT_V1) {
-            PrintToLog("\t distributionproperty: %s\n", FormatMP(distribution_property, nValue));
+            PrintToLog("\t distributionproperty: %d (%s)\n", distribution_property, strMPProperty(distribution_property));
         }
     }
 

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -54,6 +54,9 @@ private:
     // CreatePropertyMananged, GrantTokens, RevokeTokens, ChangeIssuer
     unsigned int property;
 
+    // SendToOwners v1
+    unsigned int distribution_property;
+
     // CreatePropertyFixed, CreatePropertyVariable, CreatePropertyMananged, MetaDEx, SendAll
     unsigned char ecosystem;
 
@@ -196,6 +199,7 @@ public:
     uint32_t getActivationBlock() const { return activation_block; }
     uint32_t getMinClientVersion() const { return min_client_version; }
     unsigned int getIndexInBlock() const { return tx_idx; }
+    uint32_t getDistributionProperty() const { return distribution_property; }
 
     /** Creates a new CMPTransaction object. */
     CMPTransaction()
@@ -246,6 +250,7 @@ public:
         feature_id = 0;
         activation_block = 0;
         min_client_version = 0;
+        distribution_property = 0;
     }
 
     /** Sets the given values. */

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -141,6 +141,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     /* Omni Core - transaction calls */
     { "omni_send", 2 },
     { "omni_sendsto", 1 },
+    { "omni_sendsto", 4 },
     { "omni_sendall", 2 },
     { "omni_sendtrade", 1 },
     { "omni_sendtrade", 3 },
@@ -194,6 +195,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_createpayload_dexsell", 5 },
     { "omni_createpayload_dexaccept", 0 },
     { "omni_createpayload_sto", 0 },
+    { "omni_createpayload_sto", 2 },
     { "omni_createpayload_issuancefixed", 0 },
     { "omni_createpayload_issuancefixed", 1 },
     { "omni_createpayload_issuancefixed", 2 },

--- a/test/test_stov1.sh
+++ b/test/test_stov1.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+PASS=0
+FAIL=0
+clear
+printf "Preparing a test environment...\n"
+printf "   * Starting a fresh regtest daemon\n"
+rm -r ~/.bitcoin/regtest
+./src/omnicored --regtest --server --daemon --omniactivationallowsender=any >nul
+sleep 10
+printf "   * Preparing some mature testnet BTC\n"
+./src/omnicore-cli --regtest setgenerate true 102 >null
+printf "   * Obtaining a master address to work with\n"
+ADDR=$(./src/omnicore-cli --regtest getnewaddress OMNIAccount)
+printf "   * Funding the address with some testnet BTC for fees\n"
+./src/omnicore-cli --regtest sendtoaddress $ADDR 20 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Participating in the Exodus crowdsale to obtain some OMNI\n"
+JSON="{\"moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP\":10,\""$ADDR"\":4}"
+./src/omnicore-cli --regtest sendmany OMNIAccount $JSON >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Creating an indivisible test property\n"
+./src/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 1 0 "Z_TestCat" "Z_TestSubCat" "Z_IndivisTestProperty" "Z_TestURL" "Z_TestData" 100 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Creating a divisible test property\n"
+./src/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 2 0 "Z_TestCat" "Z_TestSubCat" "Z_DivisTestProperty" "Z_TestURL" "Z_TestData" 10000 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Generating addresses to use as STO recipients\n"
+ADDRESS=()
+for i in {1..11}
+do
+   ADDRESS=("${ADDRESS[@]}" $(./src/omnicore-cli --regtest getnewaddress))
+done
+printf "   * Seeding a total of 100 SP#3\n"
+printf "   * Seeding %s with 5%% = 5 SP#3\n" ${ADDRESS[1]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[1]} 3 5 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 10%% = 10 SP#3\n" ${ADDRESS[2]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[2]} 3 10 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 15%% = 15 SP#3\n" ${ADDRESS[3]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[3]} 3 15 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 20%% = 20 SP#3\n" ${ADDRESS[4]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[4]} 3 20 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 25%% = 25 SP#3\n" ${ADDRESS[5]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[5]} 3 25 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Seeding %s with 25%% = 25 SP#3\n" ${ADDRESS[6]}
+./src/omnicore-cli --regtest omni_send $ADDR ${ADDRESS[6]} 3 25 >null
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "\nTesting a cross property (v1) STO, distributing 1000.00 SPT #4 to holders of SPT #3\n"
+printf "   * Executing the transaction\n"
+TXID=$(./src/omnicore-cli --regtest omni_sendsto $ADDR 4 1000 "" 3)
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "     # Checking the STO transaction was invalid (feature not yet activated)... "
+RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+if [ $RESULT == "false," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "\nActivating cross property (v1) Send To Owners...\n"
+printf "   * Sending the activation\n"
+BLOCKS=$(./src/omnicore-cli --regtest getblockcount)
+TXID=$(./src/omnicore-cli --regtest omni_sendactivation $ADDR 10 $(($BLOCKS + 8)) 999)
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "     # Checking the activation transaction was valid... "
+RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   * Mining 10 blocks to forward past the activation block\n"
+./src/omnicore-cli --regtest setgenerate true 10 >null
+printf "     # Checking the activation went live as expected... "
+FEATUREID=$(./src/omnicore-cli --regtest omni_getactivations | grep -A 10 completed | grep featureid | cut -c27-28)
+if [ $FEATUREID == "10" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $FEATUREID
+    FAIL=$((FAIL+1))
+fi
+printf "\nTesting a cross property (v1) STO, distributing 1000.00 SPT #4 to holders of SPT #3\n"
+printf "   * Executing the transaction\n"
+TXID=$(./src/omnicore-cli --regtest omni_sendsto $ADDR 4 1000 "" 3)
+./src/omnicore-cli --regtest setgenerate true 1 >null
+printf "   * Verifiying the results\n"
+printf "     # Checking the STO transaction was valid... "
+RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking the fee cache now has 0.00000600 fee cached for OMNI... "
+CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 1 | grep cachedfee | cut -d '"' -f4)
+if [ $CACHEDFEE == "0.00000600" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $CACHEDFEE
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking %s received 5%% of the distribution (50.00 SPT #4)... " ${ADDRESS[1]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[1]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "50.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking %s received 10%% of the distribution (100.00 SPT #4)... " ${ADDRESS[2]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[2]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "100.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking %s received 15%% of the distribution (150.00 SPT #4)... " ${ADDRESS[3]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[3]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "150.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking %s received 20%% of the distribution (200.00 SPT #4)... " ${ADDRESS[4]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[4]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "200.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking %s received 25%% of the distribution (250.00 SPT #4)... " ${ADDRESS[5]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[5]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "250.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking %s received 25%% of the distribution (250.00 SPT #4)... " ${ADDRESS[6]}
+BALANCE=$(./src/omnicore-cli --regtest omni_getbalance ${ADDRESS[6]} 4 | grep balance | cut -d '"' -f4)
+if [ $BALANCE == "250.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $BALANCE
+    FAIL=$((FAIL+1))
+fi
+
+printf "\n"
+printf "####################\n"
+printf "#  Summary:        #\n"
+printf "#    Passed = %d   #\n" $PASS
+printf "#    Failed = %d    #\n" $FAIL
+printf "####################\n"
+printf "\n"
+
+./src/omnicore-cli --regtest stop
+
+
+
+

--- a/test/test_stov1.sh
+++ b/test/test_stov1.sh
@@ -107,9 +107,9 @@ if [ $RESULT == "true," ]
     printf "FAIL (result:%s)\n" $RESULT
     FAIL=$((FAIL+1))
 fi
-printf "     # Checking the fee cache now has 0.00000600 fee cached for OMNI... "
+printf "     # Checking the fee cache now has 0.00006000 fee cached for OMNI... "
 CACHEDFEE=$(./src/omnicore-cli --regtest omni_getfeecache 1 | grep cachedfee | cut -d '"' -f4)
-if [ $CACHEDFEE == "0.00000600" ]
+if [ $CACHEDFEE == "0.00006000" ]
   then
     printf "PASS\n"
     PASS=$((PASS+1))


### PR DESCRIPTION
This pull request adds a new version of the Send To Owners transaction, whereby cross-property distribution is permitted.

For example, I may wish to distribute 3000 ZathrasTokens to all holders of SomeOtherCoin.  v0 Send To Owners does not permit this, primarily for anti-spam purposes.

The v1 transaction has an additional field, ```distributionproperty``` which specifies the property to use for the receiver set.

For clarity, examples:
```
v0 : SendToOwners 4 1000      = Distribute 1000 SPT#4 between holders of SPT#4
v1 : SendToOwners 4 1000 3    = Distribute 1000 SPT#4 between holders of SPT#3
```

As requested by @patrickdugan

Due to the potential for increased spam usage, the fee is increased to 0.00000100 OMNI per recipient and is no longer 'burned', it is instead added to the fee cache for distribution to OMNI holders along with any other fees collected (eg from MetaDEx trading).

This change is needed by Patrick for a project he's working on, but since this makes spamming "easy" I'd like to ask that we revisit the anti-spam discussion (eg providing the option to hide tokens in OmniWallet and OmniCore etc), ideally before we merge this.  Calling @marv-engine @CraigSellars @dexX7 @patrickdugan @achamely @msgilligan for feedback on how we can protect against using STO to distribute spam tokens.


I've created & run simple testing on it (test is in ```test/test_stov1.sh```), results below. @dexX7 how should we expand this testing to be more thorough?

```
Preparing a test environment...
   * Starting a fresh regtest daemon
   * Preparing some mature testnet BTC
   * Obtaining a master address to work with
   * Funding the address with some testnet BTC for fees
   * Participating in the Exodus crowdsale to obtain some OMNI
   * Creating an indivisible test property
   * Creating a divisible test property
   * Generating addresses to use as STO recipients
   * Seeding a total of 100 SP#3
   * Seeding mqqfJZaivqE6dx26ahNaVshu6p6yF4eNUn with 5% = 5 SP#3
   * Seeding mpxmoppAURfV45APogm4a75pEbsjsZVfjw with 10% = 10 SP#3
   * Seeding myZm5zvFTPqP1izo9CoTz2av8X4j25mm6H with 15% = 15 SP#3
   * Seeding mzcwwvb3ddNHbYZdJJCS7BUtR7n9uCfC7Y with 20% = 20 SP#3
   * Seeding mr6GaTFWf2jpRtMBgL1qGAXyUHUqcdjrtr with 25% = 25 SP#3
   * Seeding mnE43h5caZDYYBMn5oc9zzWd4pPMn3ADCF with 25% = 25 SP#3

Testing a cross property (v1) STO, distributing 1000.00 SPT #4 to holders of SPT #3
   * Executing the transaction
   * Verifiying the results
     # Checking the STO transaction was invalid (feature not yet activated)... PASS

Activating cross property (v1) Send To Owners...
   * Sending the activation
     # Checking the activation transaction was valid... PASS
   * Mining 10 blocks to forward past the activation block
     # Checking the activation went live as expected... PASS

Testing a cross property (v1) STO, distributing 1000.00 SPT #4 to holders of SPT #3
   * Executing the transaction
   * Verifiying the results
     # Checking the STO transaction was valid... PASS
     # Checking the fee cache now has 0.00000600 fee cached for OMNI... PASS
     # Checking mqqfJZaivqE6dx26ahNaVshu6p6yF4eNUn received 5% of the distribution (50.00 SPT #4)... PASS
     # Checking mpxmoppAURfV45APogm4a75pEbsjsZVfjw received 10% of the distribution (100.00 SPT #4)... PASS
     # Checking myZm5zvFTPqP1izo9CoTz2av8X4j25mm6H received 15% of the distribution (150.00 SPT #4)... PASS
     # Checking mzcwwvb3ddNHbYZdJJCS7BUtR7n9uCfC7Y received 20% of the distribution (200.00 SPT #4)... PASS
     # Checking mr6GaTFWf2jpRtMBgL1qGAXyUHUqcdjrtr received 25% of the distribution (250.00 SPT #4)... PASS
     # Checking mnE43h5caZDYYBMn5oc9zzWd4pPMn3ADCF received 25% of the distribution (250.00 SPT #4)... PASS

####################
#  Summary:        #
#    Passed = 11   #
#    Failed = 0    #
####################
```

