### PR TITLE
Change default confirm target to 15 blocks

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -43,7 +43,7 @@ static const CAmount nHighTransactionFeeWarning = 0.01 * COIN;
 //! -maxtxfee default
 static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
 //! -txconfirmtarget default
-static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
+static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 15;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 static const CAmount nHighTransactionMaxFeeWarning = 100 * nHighTransactionFeeWarning;
 //! Largest (in bytes) free transaction we're willing to create


### PR DESCRIPTION
This submission updates the default confirm target for wallet created transactions to 15 blocks.

The new default value currently results in a fee of nearly 60 satoshis per kB, which should result in reasonably fast confirmations.