### PR TITLE
Add consensus hash for block 420,000

### DIFF
--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -128,6 +128,8 @@ std::vector<ConsensusCheckpoint> CMainConsensusParams::GetCheckpoints() const
                   uint256("1e8949f29a5250c5819d96fd46e632d145e0c667dafd4478598ebb2bb1d5ba84") },
         { 410000, uint256("0000000000000000060d7ea100ecb75c0a4dc482d05ff19ddaa8046b4b80a458"),
                   uint256("428a0cce4fe10f2e9874aba3882729149ef1db6e721e16204f65ba5ffb727827") },
+        { 420000, uint256("000000000000000002cce816c0ab2c5c269cb081896b7dcb34b8422d6b74ffa1"),
+                  uint256("1ca6c6f7f31ff7705a0336140485338abcbadf27e4bfdb3484b900b0b4673bba") },
     };
 
     const size_t nSize = sizeof(vCheckpoints) / sizeof(vCheckpoints[0]);


### PR DESCRIPTION
This PR adds the consensus hash for block 420,000.

To test, run Omni Core with seed block filtering disabled (```--omniseedblockfilter=false```) and debug option ```--omnidebug=consensus_hash_every_block``` set. then check the consensus hash for block 420,000 in ```omnicore.log```.

Note this test can be done much faster if done with a code edit; remove the ```consensus_hash_every_block``` debug option noted above and instead modify the source file ```omnicore.cpp``` line 3727 to add the condition ```nBlockNow == 420000``` to the ```if``` statement:
```
  if (msc_debug_consensus_hash_every_block || nBlockNow == 420000) {
```

