### PR TITLE
Use uint256 when calculating desired BTC for DEx 1

### DIFF
--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -123,7 +123,13 @@ int64_t calculateDesiredBTC(const int64_t amountOffered, const int64_t amountDes
         return 0; // divide by null protection
     }
 
-    return legacy::calculateDesiredBTC(amountOffered, amountDesired, amountAvailable);
+    uint256 amountOffered256 = ConvertTo256(amountOffered);
+    uint256 amountDesired256 = ConvertTo256(amountDesired);
+    uint256 amountAvailable256 = ConvertTo256(amountAvailable);
+
+    amountDesired256 = DivideAndRoundUp((amountDesired256 * amountAvailable256), amountOffered256);
+
+    return ConvertTo64(amountDesired256);
 }
 
 /**
@@ -175,7 +181,7 @@ int DEx_offerCreate(const std::string& addressSeller, uint32_t propertyId, int64
                         FormatDivisibleMP(balanceReallyAvailable), strMPProperty(propertyId));
 
         // AND we must also re-adjust the BTC desired in this case...
-        amountDesired = calculateDesiredBTC(amountOffered, amountDesired, balanceReallyAvailable);
+        amountDesired = legacy::calculateDesiredBTC(amountOffered, amountDesired, balanceReallyAvailable);
         amountOffered = balanceReallyAvailable;
         if (nAmended) *nAmended = amountOffered;
 


### PR DESCRIPTION
The [legacy calculation](https://github.com/dexX7/bitcoin/blob/aad2d7fb50e318ff9bf4c64dd9b004ac18faffb3/src/omnicore/dex.cpp#L98-L111) of the desired BTC amount for DEx 1 was not suitable for larger numbers, resulting in bad data on the RPC layer.

The legacy calculation is part of the [consensus code](https://github.com/dexX7/bitcoin/blob/aad2d7fb50e318ff9bf4c64dd9b004ac18faffb3/src/omnicore/dex.cpp#L178), and was used when calculating the updated desired amount, in case a seller offered more than available. This is [no longer possible](https://github.com/dexX7/bitcoin/blob/aad2d7fb50e318ff9bf4c64dd9b004ac18faffb3/src/omnicore/dex.cpp#L160-L172) since 0.0.10, but the code is still needed for historical transactions.

The [updated version](https://github.com/dexX7/bitcoin/blob/0a5194ea2840fe3057e1d5b49a3c6eca8784a38c/src/omnicore/dex.cpp#L120-L133) uses plain integer math. The function is used on the RPC layer for [omni_gettransaction](https://github.com/dexX7/bitcoin/blob/0a5194ea2840fe3057e1d5b49a3c6eca8784a38c/src/omnicore/rpctxobject.cpp#L313) and [omni_getactivedexsells](https://github.com/dexX7/bitcoin/blob/0a5194ea2840fe3057e1d5b49a3c6eca8784a38c/src/omnicore/rpc.cpp#L1600).

Note that there is some explicit rounding involved now, and the desired amount is rounded up, to ensure a payment really covers the whole amount.

The submission is tagged with "consensus", because it touches consensus code, but the change is not consensus affecting.