### PR TITLE
Add 'Publish Feed' feature

### DIFF
--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -444,6 +444,24 @@ std::vector<unsigned char> CreatePayload_OmniCoreAlert(uint16_t alertType, uint3
     return payload;
 }
 
+std::vector<unsigned char> CreatePayload_PublishFeed(uint16_t feedRef, uint64_t feedValue)
+{
+    std::vector<unsigned char> payload;
+    uint16_t messageType = 31;
+    uint16_t messageVer = 0;
+    mastercore::swapByteOrder16(messageVer);
+    mastercore::swapByteOrder16(messageType);
+    mastercore::swapByteOrder16(feedRef);
+    mastercore::swapByteOrder64(feedValue);
+
+    PUSH_BACK_BYTES(payload, messageVer);
+    PUSH_BACK_BYTES(payload, messageType);
+    PUSH_BACK_BYTES(payload, feedRef);
+    PUSH_BACK_BYTES(payload, feedValue);
+
+    return payload;
+}
+
 #undef PUSH_BACK_BYTES
 #undef PUSH_BACK_BYTES_PTR
 

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -27,5 +27,6 @@ std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdFo
 std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem);
 std::vector<unsigned char> CreatePayload_OmniCoreAlert(uint16_t alertType, uint32_t expiryValue, const std::string& alertMessage);
 std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock, uint32_t minClientVersion);
+std::vector<unsigned char> CreatePayload_PublishFeed(uint16_t feedRef, uint64_t feedValue);
 
 #endif // OMNICORE_CREATEPAYLOAD_H

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -201,7 +201,7 @@ public:
     bool GetFeedValue(const std::string& address, uint16_t feedRef, int64_t *feedValue, int *feedBlock, uint256 *feedTXID, int maxBlock=9999999);
     std::set<uint16_t> GetAddressFeeds(const std::string& address);
     std::set<std::pair<int,int64_t> > GetFeedHistory(const std::string& address, uint16_t feedRef);
-    void DeleteAboveBlock(int blocknum);
+    int DeleteAboveBlock(int blocknum);
     void PrintAll();
 };
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -77,7 +77,7 @@ enum TransactionType {
   MSC_TYPE_METADEX_CANCEL_PRICE     = 26,
   MSC_TYPE_METADEX_CANCEL_PAIR      = 27,
   MSC_TYPE_METADEX_CANCEL_ECOSYSTEM = 28,
-  MSC_TYPE_NOTIFICATION             = 31,
+  MSC_TYPE_PUBLISH_FEED             = 31,
   MSC_TYPE_OFFER_ACCEPT_A_BET       = 40,
   MSC_TYPE_CREATE_PROPERTY_FIXED    = 50,
   MSC_TYPE_CREATE_PROPERTY_VARIABLE = 51,
@@ -179,6 +179,30 @@ public:
      */
     void RecordTransaction(const uint256& txid, uint32_t posInBlock);
     uint32_t FetchTransactionPosition(const uint256& txid);
+};
+
+/** LevelDB based storage for the feed database (contains all published feeds).
+ */
+class COmniFeedDB : public CDBBase
+{
+public:
+    COmniFeedDB(const boost::filesystem::path& path, bool fWipe)
+    {
+        leveldb::Status status = Open(path, fWipe);
+        PrintToConsole("Loading feed database: %s\n", status.ToString());
+    }
+
+    virtual ~COmniFeedDB()
+    {
+        PrintToLog("COmniFeedDB closed\n");
+    }
+
+    void RecordFeedValue(const std::string& address, uint16_t feedRef, int64_t feedValue, int block, int index, const uint256& txid);
+    bool GetFeedValue(const std::string& address, uint16_t feedRef, int64_t *feedValue, int *feedBlock, uint256 *feedTXID, int maxBlock=9999999);
+    std::set<uint16_t> GetAddressFeeds(const std::string& address);
+    std::set<std::pair<int,int64_t> > GetFeedHistory(const std::string& address, uint16_t feedRef);
+    void DeleteAboveBlock(int blocknum);
+    void PrintAll();
 };
 
 /** LevelDB based storage for STO recipients.
@@ -316,6 +340,7 @@ extern CMPTxList *p_txlistdb;
 extern CMPTradeList *t_tradelistdb;
 extern CMPSTOList *s_stolistdb;
 extern COmniTransactionDB *p_OmniTXDB;
+extern COmniFeedDB *p_feeddb;
 
 // TODO: move, rename
 extern CCoinsView viewDummy;

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -566,3 +566,30 @@ Value omni_createpayload_cancelalltrades(const Array& params, bool fHelp)
     return HexStr(payload.begin(), payload.end());
 }
 
+Value omni_createpayload_publishfeed(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 3)
+        throw runtime_error(
+            "omni_createpayload_publishfeed feedreference feedvalue\n"
+
+            "\nCreate the payload for a publish feed transaction.\n"
+
+            "\nArguments:\n"
+            "2. feedreference        (number, required) the feed reference\n"
+            "3. feedvalue            (number, required) the value to publish\n"
+
+            "\nResult:\n"
+            "\"payload\"             (string) the hex-encoded payload\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("omni_createpayload_publishfeed", "1 \"100\"")
+            + HelpExampleRpc("omni_createpayload_publishfeed", "1, \"100\"")
+        );
+
+    uint16_t feedRef = ParseFeedReference(params[0]);
+    int64_t feedValue = ParseAmount(params[1], false);
+
+    std::vector<unsigned char> payload = CreatePayload_PublishFeed(feedRef, feedValue);
+
+    return HexStr(payload.begin(), payload.end());
+}

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -93,6 +93,49 @@ Value omni_send(const Array& params, bool fHelp)
     }
 }
 
+// omni_sendpublishfeed - publish feed
+Value omni_sendpublishfeed(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 3)
+        throw runtime_error(
+            "omni_sendpublishfeed \"fromaddress\" feedreference feedvalue\n"
+
+            "\nCreate and broadcast a publish feed transaction.\n"
+
+            "\nArguments:\n"
+            "1. fromaddress          (string, required) the address to send from\n"
+            "2. feedreference        (number, required) the feed reference\n"
+            "3. feedvalue            (number, required) the value to publish\n"
+
+            "\nResult:\n"
+            "\"hash\"                  (string) the hex-encoded transaction hash\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("omni_sendpublishfeed", "\"3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY\" 1 100")
+            + HelpExampleRpc("omni_sendpublishfeed", "\"3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY\", 1, 100")
+        );
+
+    std::string fromAddress = ParseAddress(params[0]);
+    uint16_t feedRef = ParseFeedReference(params[1]);
+    int64_t feedValue = ParseAmount(params[2], false);
+
+    std::vector<unsigned char> payload = CreatePayload_PublishFeed(feedRef, feedValue);
+
+    uint256 txid;
+    std::string rawHex;
+    int result = WalletTxBuilder(fromAddress, "", fromAddress, 0, payload, txid, rawHex, autoCommit);
+
+    if (result != 0) {
+        throw JSONRPCError(result, error_str(result));
+    } else {
+        if (!autoCommit) {
+            return rawHex;
+        } else {
+            return txid.GetHex();
+        }
+    }
+}
+
 // omni_sendall - send all
 Value omni_sendall(const Array& params, bool fHelp)
 {

--- a/src/omnicore/rpcvalues.cpp
+++ b/src/omnicore/rpcvalues.cpp
@@ -171,6 +171,15 @@ uint8_t ParseMetaDExAction(const json_spirit::Value& value)
     return static_cast<uint8_t>(action);
 }
 
+uint16_t ParseFeedReference(const json_spirit::Value& value)
+{
+    int64_t feedRef = value.get_int64();
+    if (feedRef < 0 || 65535 < feedRef) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Feed reference must be in the range of 0-65535");
+    }
+    return static_cast<uint16_t>(feedRef);
+}
+
 CTransaction ParseTransaction(const json_spirit::Value& value)
 {
     CTransaction tx;

--- a/src/omnicore/rpcvalues.h
+++ b/src/omnicore/rpcvalues.h
@@ -29,6 +29,7 @@ int64_t ParseDeadline(const json_spirit::Value& value);
 uint8_t ParseEarlyBirdBonus(const json_spirit::Value& value);
 uint8_t ParseIssuerBonus(const json_spirit::Value& value);
 uint8_t ParseMetaDExAction(const json_spirit::Value& value);
+uint16_t ParseFeedReference(const json_spirit::Value& value);
 CTransaction ParseTransaction(const json_spirit::Value& value);
 CMutableTransaction ParseMutableTransaction(const json_spirit::Value& value);
 CPubKey ParsePubKeyOrAddress(const json_spirit::Value& value);

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -38,36 +38,38 @@ std::vector<TransactionRestriction> CConsensusParams::GetRestrictions() const
     const TransactionRestriction vTxRestrictions[] =
     { //  transaction type                    version        allow 0  activation block
       //  ----------------------------------  -------------  -------  ------------------
-        { OMNICORE_MESSAGE_TYPE_ALERT,        0xFFFF,        true,    MSC_ALERT_BLOCK    },
-        { OMNICORE_MESSAGE_TYPE_ACTIVATION,   0xFFFF,        true,    MSC_ALERT_BLOCK    },
+        { OMNICORE_MESSAGE_TYPE_ALERT,        0xFFFF,        true,    MSC_ALERT_BLOCK         },
+        { OMNICORE_MESSAGE_TYPE_ACTIVATION,   0xFFFF,        true,    MSC_ALERT_BLOCK         },
 
-        { MSC_TYPE_SIMPLE_SEND,               MP_TX_PKT_V0,  false,   MSC_SEND_BLOCK     },
+        { MSC_TYPE_SIMPLE_SEND,               MP_TX_PKT_V0,  false,   MSC_SEND_BLOCK          },
 
-        { MSC_TYPE_TRADE_OFFER,               MP_TX_PKT_V0,  false,   MSC_DEX_BLOCK      },
-        { MSC_TYPE_TRADE_OFFER,               MP_TX_PKT_V1,  false,   MSC_DEX_BLOCK      },
-        { MSC_TYPE_ACCEPT_OFFER_BTC,          MP_TX_PKT_V0,  false,   MSC_DEX_BLOCK      },
+        { MSC_TYPE_TRADE_OFFER,               MP_TX_PKT_V0,  false,   MSC_DEX_BLOCK           },
+        { MSC_TYPE_TRADE_OFFER,               MP_TX_PKT_V1,  false,   MSC_DEX_BLOCK           },
+        { MSC_TYPE_ACCEPT_OFFER_BTC,          MP_TX_PKT_V0,  false,   MSC_DEX_BLOCK           },
 
-        { MSC_TYPE_CREATE_PROPERTY_FIXED,     MP_TX_PKT_V0,  false,   MSC_SP_BLOCK       },
-        { MSC_TYPE_CREATE_PROPERTY_VARIABLE,  MP_TX_PKT_V0,  false,   MSC_SP_BLOCK       },
-        { MSC_TYPE_CREATE_PROPERTY_VARIABLE,  MP_TX_PKT_V1,  false,   MSC_SP_BLOCK       },
-        { MSC_TYPE_CLOSE_CROWDSALE,           MP_TX_PKT_V0,  false,   MSC_SP_BLOCK       },
+        { MSC_TYPE_CREATE_PROPERTY_FIXED,     MP_TX_PKT_V0,  false,   MSC_SP_BLOCK            },
+        { MSC_TYPE_CREATE_PROPERTY_VARIABLE,  MP_TX_PKT_V0,  false,   MSC_SP_BLOCK            },
+        { MSC_TYPE_CREATE_PROPERTY_VARIABLE,  MP_TX_PKT_V1,  false,   MSC_SP_BLOCK            },
+        { MSC_TYPE_CLOSE_CROWDSALE,           MP_TX_PKT_V0,  false,   MSC_SP_BLOCK            },
 
-        { MSC_TYPE_CREATE_PROPERTY_MANUAL,    MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK },
-        { MSC_TYPE_GRANT_PROPERTY_TOKENS,     MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK },
-        { MSC_TYPE_REVOKE_PROPERTY_TOKENS,    MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK },
-        { MSC_TYPE_CHANGE_ISSUER_ADDRESS,     MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK },
+        { MSC_TYPE_CREATE_PROPERTY_MANUAL,    MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK      },
+        { MSC_TYPE_GRANT_PROPERTY_TOKENS,     MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK      },
+        { MSC_TYPE_REVOKE_PROPERTY_TOKENS,    MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK      },
+        { MSC_TYPE_CHANGE_ISSUER_ADDRESS,     MP_TX_PKT_V0,  false,   MSC_MANUALSP_BLOCK      },
 
-        { MSC_TYPE_SEND_TO_OWNERS,            MP_TX_PKT_V0,  false,   MSC_STO_BLOCK      },
-        { MSC_TYPE_SEND_TO_OWNERS,            MP_TX_PKT_V1,  false,   MSC_STOV1_BLOCK    },
+        { MSC_TYPE_SEND_TO_OWNERS,            MP_TX_PKT_V0,  false,   MSC_STO_BLOCK           },
+        { MSC_TYPE_SEND_TO_OWNERS,            MP_TX_PKT_V1,  false,   MSC_STOV1_BLOCK         },
 
-        { MSC_TYPE_METADEX_TRADE,             MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
-        { MSC_TYPE_METADEX_CANCEL_PRICE,      MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
-        { MSC_TYPE_METADEX_CANCEL_PAIR,       MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
-        { MSC_TYPE_METADEX_CANCEL_ECOSYSTEM,  MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK  },
+        { MSC_TYPE_METADEX_TRADE,             MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK       },
+        { MSC_TYPE_METADEX_CANCEL_PRICE,      MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK       },
+        { MSC_TYPE_METADEX_CANCEL_PAIR,       MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK       },
+        { MSC_TYPE_METADEX_CANCEL_ECOSYSTEM,  MP_TX_PKT_V0,  false,   MSC_METADEX_BLOCK       },
 
-        { MSC_TYPE_SEND_ALL,                  MP_TX_PKT_V0,  false,   MSC_SEND_ALL_BLOCK },
+        { MSC_TYPE_SEND_ALL,                  MP_TX_PKT_V0,  false,   MSC_SEND_ALL_BLOCK      },
 
-        { MSC_TYPE_OFFER_ACCEPT_A_BET,        MP_TX_PKT_V0,  false,   MSC_BET_BLOCK      },
+        { MSC_TYPE_PUBLISH_FEED,              MP_TX_PKT_V0,  true,    MSC_PUBLISH_FEED_BLOCK  },
+
+        { MSC_TYPE_OFFER_ACCEPT_A_BET,        MP_TX_PKT_V0,  false,   MSC_BET_BLOCK           },
     };
 
     const size_t nSize = sizeof(vTxRestrictions) / sizeof(vTxRestrictions[0]);
@@ -167,6 +169,7 @@ CMainConsensusParams::CMainConsensusParams()
     MSC_SEND_ALL_BLOCK = 999999;
     MSC_BET_BLOCK = 999999;
     MSC_STOV1_BLOCK = 999999;
+    MSC_PUBLISH_FEED_BLOCK = 999999;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 999999;
     DEXMATH_FEATURE_BLOCK = 999999;
@@ -205,6 +208,7 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     MSC_SEND_ALL_BLOCK = 0;
     MSC_BET_BLOCK = 999999;
     MSC_STOV1_BLOCK = 0;
+    MSC_PUBLISH_FEED_BLOCK = 0;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 999999;
     DEXMATH_FEATURE_BLOCK = 999999;
@@ -243,6 +247,7 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     MSC_SEND_ALL_BLOCK = 0;
     MSC_BET_BLOCK = 999999;
     MSC_STOV1_BLOCK = 999999;
+    MSC_PUBLISH_FEED_BLOCK = 999999;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 999999;
     DEXMATH_FEATURE_BLOCK = 999999;
@@ -421,6 +426,10 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
             MutableConsensusParams().MSC_STOV1_BLOCK = activationBlock;
             featureName = "Cross-property Send To Owners";
         break;
+        case FEATURE_PUBLISHFEED:
+            MutableConsensusParams().MSC_PUBLISH_FEED_BLOCK = activationBlock;
+            featureName = "Publish feed transactions";
+        break;
         default:
             featureName = "Unknown feature";
             supported = false;
@@ -479,6 +488,9 @@ bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
             break;
         case FEATURE_STOV1:
             activationBlock = params.MSC_STOV1_BLOCK;
+            break;
+        case FEATURE_PUBLISHFEED:
+            activationBlock = params.MSC_PUBLISH_FEED_BLOCK;
             break;
         default:
             return false;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -34,6 +34,8 @@ const uint16_t FEATURE_TRADEALLPAIRS = 8;
 const uint16_t FEATURE_FEES = 9;
 //! Feature identifier to enable cross property (v1) Send To Owners
 const uint16_t FEATURE_STOV1 = 10;
+//! Feature identifier to enable publish feed transactions
+const uint16_t FEATURE_PUBLISHFEED = 12;
 
 //! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
 const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
@@ -115,6 +117,8 @@ public:
     int MSC_BET_BLOCK;
     //! Block to enable cross property STO (v1)
     int MSC_STOV1_BLOCK;
+    //! Block to enable Publish Feed
+    int MSC_PUBLISH_FEED_BLOCK;
 
     //! Block to deactivate crowdsale participations when "granting tokens"
     int GRANTEFFECTS_FEATURE_BLOCK;

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -93,6 +93,9 @@ private:
     uint32_t activation_block;
     uint32_t min_client_version;
 
+    // Publish Feed
+    uint16_t feed_reference;
+
     // Indicates whether the transaction can be used to execute logic
     bool rpcOnly;
 
@@ -121,6 +124,7 @@ private:
     bool interpret_ChangeIssuer();
     bool interpret_Activation();
     bool interpret_Alert();
+    bool interpret_PublishFeed();
 
     /**
      * Logic and "effects"
@@ -143,6 +147,7 @@ private:
     int logicMath_ChangeIssuer();
     int logicMath_Activation();
     int logicMath_Alert();
+    int logicMath_PublishFeed();
 
     /**
      * Logic helpers
@@ -251,6 +256,7 @@ public:
         activation_block = 0;
         min_client_version = 0;
         distribution_property = 0;
+        feed_reference = 0;
     }
 
     /** Sets the given values. */

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -137,6 +137,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getfeetrigger", 0 },
     { "omni_getfeedistribution", 0 },
     { "omni_getfeedistributions", 0 },
+    { "omni_getfeed", 1 },
+    { "omni_getfeed", 2 },
+    { "omni_getfeedhistory", 1 },
 
     /* Omni Core - transaction calls */
     { "omni_send", 2 },
@@ -177,6 +180,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendactivation", 3 },
     { "omni_sendalert", 1 },
     { "omni_sendalert", 2 },
+    { "omni_sendpublishfeed", 1 },
 
     /* Omni Core - raw transaction calls */
     { "omni_decodetransaction", 1 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -384,6 +384,10 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (data retrieval)",         "omni_getfeetrigger",              &omni_getfeetrigger,              false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getfeedistribution",         &omni_getfeedistribution,         false,      true,       false },
     { "omni layer (data retrieval)",         "omni_getfeedistributions",        &omni_getfeedistributions,        false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getfeed",                    &omni_getfeed,                    false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getfeeds",                   &omni_getfeeds,                   false,      true,       false },
+    { "omni layer (data retrieval)",         "omni_getfeedhistory",             &omni_getfeedhistory,             false,      true,       false },
+
 #ifdef ENABLE_WALLET
     { "omni layer (data retrieval)",         "omni_listtransactions",           &omni_listtransactions,           false,      true,       true },
     { "omni layer (data retrieval)",         "omni_getfeeshare",                &omni_getfeeshare,                false,      true,       true },
@@ -411,6 +415,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (transaction creation)",   "omni_sendclosecrowdsale",         &omni_sendclosecrowdsale,         false,      true,       true },
     { "omni layer (transaction creation)",   "omni_sendchangeissuer",           &omni_sendchangeissuer,           false,      true,       true },
     { "omni layer (transaction creation)",   "omni_sendall",                    &omni_sendall,                    false,      true,       true },
+    { "omni layer (transaction creation)",   "omni_sendpublishfeed",            &omni_sendpublishfeed,            false,      true,       true },
 
     /* Omni Core hidden calls - development usage (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */
@@ -446,6 +451,7 @@ static const CRPCCommand vRPCCommands[] =
     { "omni layer (payload creation)",       "omni_createpayload_canceltradesbyprice", &omni_createpayload_canceltradesbyprice, true, true, false },
     { "omni layer (payload creation)",       "omni_createpayload_canceltradesbypair",  &omni_createpayload_canceltradesbypair,  true, true, false },
     { "omni layer (payload creation)",       "omni_createpayload_cancelalltrades",     &omni_createpayload_cancelalltrades,     true, true, false },
+    { "omni layer (payload creation)",       "omni_createpayload_publishfeed",  &omni_createpayload_publishfeed,  true,       true,       false },
 
     /* Omni Core hidden calls - aliased calls for backwards compatibiltiy - to be depreciated (not shown in help) */
     /* CATEGORY                              NAME                               ACTOR (FUNCTION)                  OKSAFEMODE  THREADSAFE  REQWALLET */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -256,6 +256,9 @@ extern json_spirit::Value omni_getfeetrigger(const json_spirit::Array& params, b
 extern json_spirit::Value omni_getfeeshare(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getfeedistribution(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_getfeedistributions(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeed(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeeds(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_getfeedhistory(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core configuration calls */
 extern json_spirit::Value omni_setautocommit(const json_spirit::Array& params, bool fHelp);
@@ -278,6 +281,7 @@ extern json_spirit::Value omni_sendrevoke(const json_spirit::Array& params, bool
 extern json_spirit::Value omni_sendclosecrowdsale(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_sendchangeissuer(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_sendall(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_sendpublishfeed(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core payload creation calls */
 extern json_spirit::Value omni_createpayload_simplesend(const json_spirit::Array& params, bool fHelp);
@@ -296,6 +300,7 @@ extern json_spirit::Value omni_createpayload_trade(const json_spirit::Array& par
 extern json_spirit::Value omni_createpayload_canceltradesbyprice(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_createpayload_canceltradesbypair(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value omni_createpayload_cancelalltrades(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value omni_createpayload_publishfeed(const json_spirit::Array& params, bool fHelp);
 
 /* Omni Core hidden calls - development usage (not shown in help) */
 extern json_spirit::Value mscrpc(const json_spirit::Array& params, bool fHelp);

--- a/test/test_publishfeed.sh
+++ b/test/test_publishfeed.sh
@@ -1,42 +1,44 @@
 #!/bin/bash
 
+SRCDIR=./src/
+NUL=/dev/null
 PASS=0
 FAIL=0
 clear
 printf "Preparing a test environment...\n"
 printf "   * Starting a fresh regtest daemon\n"
 rm -r ~/.bitcoin/regtest
-./src/omnicored --regtest --server --daemon --omniactivationallowsender=any >/dev/null
+$SRCDIR/omnicored --regtest --server --daemon --omniactivationallowsender=any >$NUL
 sleep 10
 printf "   * Preparing some mature testnet BTC\n"
-./src/omnicore-cli --regtest setgenerate true 102 >/dev/null
+$SRCDIR/omnicore-cli --regtest setgenerate true 102 >$NUL
 printf "   * Obtaining a master address to work with\n"
-ADDR=$(./src/omnicore-cli --regtest getnewaddress OMNIAccount)
+ADDR=$($SRCDIR/omnicore-cli --regtest getnewaddress OMNIAccount)
 printf "   * Funding the address with some testnet BTC for fees\n"
-./src/omnicore-cli --regtest sendtoaddress $ADDR 0.001 >/dev/null
-./src/omnicore-cli --regtest sendtoaddress $ADDR 0.002 >/dev/null
-./src/omnicore-cli --regtest sendtoaddress $ADDR 0.003 >/dev/null
-./src/omnicore-cli --regtest sendtoaddress $ADDR 0.004 >/dev/null
-./src/omnicore-cli --regtest sendtoaddress $ADDR 0.005 >/dev/null
-./src/omnicore-cli --regtest sendtoaddress $ADDR 10.005 >/dev/null
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 0.001 >$NUL
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 0.002 >$NUL
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 0.003 >$NUL
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 0.004 >$NUL
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 0.005 >$NUL
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 10.005 >$NUL
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "   * Participating in the Exodus crowdsale to obtain some OMNI\n"
 JSON="{\"moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP\":10,\""$ADDR"\":0.0002}"
-./src/omnicore-cli --regtest sendmany OMNIAccount $JSON >/dev/null
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+$SRCDIR/omnicore-cli --regtest sendmany OMNIAccount $JSON >$NUL
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "   * Master address is %s\n" $ADDR
 printf "   * Generating addresses to use\n"
 ADDRESS=()
 for i in {1..6}
 do
-   ADDRESS=("${ADDRESS[@]}" $(./src/omnicore-cli --regtest getnewaddress))
+   ADDRESS=("${ADDRESS[@]}" $($SRCDIR/omnicore-cli --regtest getnewaddress))
 done
 printf "Confirming publish feed transactions are invalidated before activation...\n"
 printf "   * Sending a Publish Feed transaction\n"
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 1000)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 1000)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "     # Checking the transaction was invalid... "
-RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
 if [ $RESULT == "false," ]
   then
     printf "PASS\n"
@@ -47,11 +49,11 @@ if [ $RESULT == "false," ]
 fi
 printf "Activating the publish feed transaction...\n"
 printf "   * Sending the activation\n"
-BLOCKS=$(./src/omnicore-cli --regtest getblockcount)
-TXID=$(./src/omnicore-cli --regtest omni_sendactivation $ADDR 12 $(($BLOCKS + 8)) 1100001)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+BLOCKS=$($SRCDIR/omnicore-cli --regtest getblockcount)
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendactivation $ADDR 12 $(($BLOCKS + 8)) 1100001)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "     # Checking the activation transaction was valid... "
-RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
 if [ $RESULT == "true," ]
   then
     printf "PASS\n"
@@ -61,9 +63,9 @@ if [ $RESULT == "true," ]
     FAIL=$((FAIL+1))
 fi
 printf "   * Mining 10 blocks to forward past the activation block\n"
-./src/omnicore-cli --regtest setgenerate true 10 >/dev/null
+$SRCDIR/omnicore-cli --regtest setgenerate true 10 >$NUL
 printf "     # Checking the activation went live as expected... "
-FEATUREID=$(./src/omnicore-cli --regtest omni_getactivations | grep -A 10 completed | grep featureid | cut -c27-28)
+FEATUREID=$($SRCDIR/omnicore-cli --regtest omni_getactivations | grep -A 10 completed | grep featureid | cut -c27-28)
 if [ $FEATUREID == "12" ]
   then
     printf "PASS\n"
@@ -74,10 +76,10 @@ if [ $FEATUREID == "12" ]
 fi
 printf "Testing Publish Feed...\n"
 printf "   * Sending a Publish Feed transaction (feed 1, value 1000)\n"
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 1000)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 1000)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "     # Checking the transaction was valid... "
-RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
 if [ $RESULT == "true," ]
   then
     printf "PASS\n"
@@ -87,7 +89,7 @@ if [ $RESULT == "true," ]
     FAIL=$((FAIL+1))
 fi
 printf "     # Checking the value for feed 1 at address is now 1000... "
-RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
 if [ $RESULT == "1000" ]
   then
     printf "PASS\n"
@@ -97,18 +99,18 @@ if [ $RESULT == "1000" ]
     FAIL=$((FAIL+1))
 fi
 printf "     # Getting the block number to use later...\n"
-BLOCKS=$(./src/omnicore-cli --regtest getblockcount)
+BLOCKS=$($SRCDIR/omnicore-cli --regtest getblockcount)
 printf "   * Sending several Publish Feed transactions for feed 1, (highest will be 5000 but latest 3000)\n"
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 2000)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 4000)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 5000)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 3000)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 2000)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 4000)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 5000)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 3000)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "     # Checking the value for feed 1 at address is now at latest (3000)... "
-RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
 if [ $RESULT == "3000" ]
   then
     printf "PASS\n"
@@ -118,7 +120,7 @@ if [ $RESULT == "3000" ]
     FAIL=$((FAIL+1))
 fi
 printf "     # Checking the value for feed 1 at address is 1000 at block %d... " $BLOCKS
-RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 1 $BLOCKS | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 1 $BLOCKS | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
 if [ $RESULT == "1000" ]
   then
     printf "PASS\n"
@@ -128,12 +130,12 @@ if [ $RESULT == "1000" ]
     FAIL=$((FAIL+1))
 fi
 printf "   * Sending Publish Feed transactions for feed refernces 2 and 65\n"
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 2 200)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
-TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 65 6500)
-./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 2 200)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 65 6500)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "     # Checking the value for feed 2 at address is now 200... "
-RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 2 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 2 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
 if [ $RESULT == "200" ]
   then
     printf "PASS\n"
@@ -143,7 +145,7 @@ if [ $RESULT == "200" ]
     FAIL=$((FAIL+1))
 fi
 printf "     # Checking the value for feed 65 at address is now 6500... "
-RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 65 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 65 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
 if [ $RESULT == "6500" ]
   then
     printf "PASS\n"
@@ -153,7 +155,7 @@ if [ $RESULT == "6500" ]
     FAIL=$((FAIL+1))
 fi
 printf "     # Checking that feeds 1, 2 and 65 are returned in omni_getfeeds... "
-RESULT=$(./src/omnicore-cli --regtest omni_getfeeds $ADDR | grep reference | cut -d ':' -f2 | tr -d '[[:space:]]')
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeeds $ADDR | grep reference | cut -d ':' -f2 | tr -d '[[:space:]]')
 if [ $RESULT == "1,2,65," ]
   then
     printf "PASS\n"
@@ -164,7 +166,7 @@ if [ $RESULT == "1,2,65," ]
 fi
 printf "   * Checking feed history for feed ref 1\n"
 printf "     # Checking that values 1000, 2000, 4000, 5000 & 3000 exist in history... "
-RESULT=$(./src/omnicore-cli --regtest omni_getfeedhistory $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeedhistory $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
 if [ $RESULT == "10002000400050003000" ]
   then
     printf "PASS\n"
@@ -174,11 +176,86 @@ if [ $RESULT == "10002000400050003000" ]
     FAIL=$((FAIL+1))
 fi
 printf "   * Committing feed database to log\n"
-./src/omnicore-cli --regtest mscrpc 15
-
-
-# TODO - reorg
-
+$SRCDIR/omnicore-cli --regtest mscrpc 15 >$NUL
+printf "Orphaning a block to test Feed DB reorg protection (disconnecting 1 block from tip and mining a replacement)\n"
+printf "     # Checking the value for feed 1 at address is still at 3000... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "3000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   * Updating the feed to 9000\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 9000)
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
+printf "     # Checking the value for feed 1 at address is now at 9000... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "9000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   * Committing feed database to log\n"
+$SRCDIR/omnicore-cli --regtest mscrpc 15 >$NUL
+printf "   * Executing the rollback\n"
+BLOCK=$($SRCDIR/omnicore-cli --regtest getblockcount)
+BLOCKHASH=$($SRCDIR/omnicore-cli --regtest getblockhash $(($BLOCK)))
+$SRCDIR/omnicore-cli --regtest invalidateblock $BLOCKHASH >$NUL
+PREVBLOCK=$($SRCDIR/omnicore-cli --regtest getblockcount)
+printf "   * Clearing the mempool\n"
+$SRCDIR/omnicore-cli --regtest clearmempool >$NUL
+printf "   * Verifiying the results\n"
+printf "      # Checking the block count has been reduced by 1... "
+EXPBLOCK=$((BLOCK-1))
+if [ $EXPBLOCK == $PREVBLOCK ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $PREVBLOCK
+    FAIL=$((FAIL+1))
+fi
+printf "   * Mining a replacement block\n"
+$SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
+printf "   * Committing feed database to log\n"
+$SRCDIR/omnicore-cli --regtest mscrpc 15 >$NUL
+printf "   * Verifiying the results\n"
+NEWBLOCK=$($SRCDIR/omnicore-cli --regtest getblockcount)
+NEWBLOCKHASH=$($SRCDIR/omnicore-cli --regtest getblockhash $(($BLOCK)))
+printf "      # Checking the block count is the same as before the rollback... "
+if [ $BLOCK == $NEWBLOCK ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $NEWBLOCK
+    FAIL=$((FAIL+1))
+fi
+printf "      # Checking the block hash is different from before the rollback... "
+if [ $BLOCKHASH == $NEWBLOCKHASH ]
+  then
+    printf "FAIL (result:%s)\n" $NEWBLOCKHASH
+    FAIL=$((FAIL+1))
+  else
+    printf "PASS\n"
+    PASS=$((PASS+1))
+fi
+printf "     # Checking the value for feed 1 at address has been rolled back to 3000... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "3000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
 
 printf "\n"
 printf "####################\n"
@@ -188,7 +265,6 @@ printf "#    Failed = %d    #\n" $FAIL
 printf "####################\n"
 printf "\n"
 
-./src/omnicore-cli --regtest stop
-
+$SRCDIR/omnicore-cli --regtest stop
 
 

--- a/test/test_publishfeed.sh
+++ b/test/test_publishfeed.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+PASS=0
+FAIL=0
+clear
+printf "Preparing a test environment...\n"
+printf "   * Starting a fresh regtest daemon\n"
+rm -r ~/.bitcoin/regtest
+./src/omnicored --regtest --server --daemon --omniactivationallowsender=any >/dev/null
+sleep 10
+printf "   * Preparing some mature testnet BTC\n"
+./src/omnicore-cli --regtest setgenerate true 102 >/dev/null
+printf "   * Obtaining a master address to work with\n"
+ADDR=$(./src/omnicore-cli --regtest getnewaddress OMNIAccount)
+printf "   * Funding the address with some testnet BTC for fees\n"
+./src/omnicore-cli --regtest sendtoaddress $ADDR 0.001 >/dev/null
+./src/omnicore-cli --regtest sendtoaddress $ADDR 0.002 >/dev/null
+./src/omnicore-cli --regtest sendtoaddress $ADDR 0.003 >/dev/null
+./src/omnicore-cli --regtest sendtoaddress $ADDR 0.004 >/dev/null
+./src/omnicore-cli --regtest sendtoaddress $ADDR 0.005 >/dev/null
+./src/omnicore-cli --regtest sendtoaddress $ADDR 10.005 >/dev/null
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+printf "   * Participating in the Exodus crowdsale to obtain some OMNI\n"
+JSON="{\"moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP\":10,\""$ADDR"\":0.0002}"
+./src/omnicore-cli --regtest sendmany OMNIAccount $JSON >/dev/null
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+printf "   * Master address is %s\n" $ADDR
+printf "   * Generating addresses to use\n"
+ADDRESS=()
+for i in {1..6}
+do
+   ADDRESS=("${ADDRESS[@]}" $(./src/omnicore-cli --regtest getnewaddress))
+done
+printf "Confirming publish feed transactions are invalidated before activation...\n"
+printf "   * Sending a Publish Feed transaction\n"
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 1000)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+printf "     # Checking the transaction was invalid... "
+RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+if [ $RESULT == "false," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "Activating the publish feed transaction...\n"
+printf "   * Sending the activation\n"
+BLOCKS=$(./src/omnicore-cli --regtest getblockcount)
+TXID=$(./src/omnicore-cli --regtest omni_sendactivation $ADDR 12 $(($BLOCKS + 8)) 1100001)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+printf "     # Checking the activation transaction was valid... "
+RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   * Mining 10 blocks to forward past the activation block\n"
+./src/omnicore-cli --regtest setgenerate true 10 >/dev/null
+printf "     # Checking the activation went live as expected... "
+FEATUREID=$(./src/omnicore-cli --regtest omni_getactivations | grep -A 10 completed | grep featureid | cut -c27-28)
+if [ $FEATUREID == "12" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $FEATUREID
+    FAIL=$((FAIL+1))
+fi
+printf "Testing Publish Feed...\n"
+printf "   * Sending a Publish Feed transaction (feed 1, value 1000)\n"
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 1000)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+printf "     # Checking the transaction was valid... "
+RESULT=$(./src/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c15-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking the value for feed 1 at address is now 1000... "
+RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "1000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "     # Getting the block number to use later...\n"
+BLOCKS=$(./src/omnicore-cli --regtest getblockcount)
+printf "   * Sending several Publish Feed transactions for feed 1, (highest will be 5000 but latest 3000)\n"
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 2000)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 4000)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 5000)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 1 3000)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+printf "     # Checking the value for feed 1 at address is now at latest (3000)... "
+RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "3000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking the value for feed 1 at address is 1000 at block %d... " $BLOCKS
+RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 1 $BLOCKS | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "1000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   * Sending Publish Feed transactions for feed refernces 2 and 65\n"
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 2 200)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+TXID=$(./src/omnicore-cli --regtest omni_sendpublishfeed $ADDR 65 6500)
+./src/omnicore-cli --regtest setgenerate true 1 >/dev/null
+printf "     # Checking the value for feed 2 at address is now 200... "
+RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 2 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "200" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking the value for feed 65 at address is now 6500... "
+RESULT=$(./src/omnicore-cli --regtest omni_getfeed $ADDR 65 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "6500" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "     # Checking that feeds 1, 2 and 65 are returned in omni_getfeeds... "
+RESULT=$(./src/omnicore-cli --regtest omni_getfeeds $ADDR | grep reference | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "1,2,65," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   * Checking feed history for feed ref 1\n"
+printf "     # Checking that values 1000, 2000, 4000, 5000 & 3000 exist in history... "
+RESULT=$(./src/omnicore-cli --regtest omni_getfeedhistory $ADDR 1 | grep value | cut -d ':' -f2 | tr -d '[[:space:]]')
+if [ $RESULT == "10002000400050003000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   * Committing feed database to log\n"
+./src/omnicore-cli --regtest mscrpc 15
+
+
+# TODO - reorg
+
+
+printf "\n"
+printf "####################\n"
+printf "#  Summary:        #\n"
+printf "#    Passed = %d   #\n" $PASS
+printf "#    Failed = %d    #\n" $FAIL
+printf "####################\n"
+printf "\n"
+
+./src/omnicore-cli --regtest stop
+
+
+


### PR DESCRIPTION
This PR adds the 'Publish Feed' feature to Omni Core.

_This is currently a prototype for review, and may need changes or updates depending on whether I've understood the requirements for publishing a feed correctly._

**In summary, the feed system allows an address to publish a value (a feed) which may be later referenced.**

The feature has been simplified from the original concept of publishing data described in the Omni spec.  There appears no need to 'setup' a feed, we are able to simply publish values as needed.

Feeds are identified by two attributes; the publishing address and a feed reference.  A feed reference is used to allow an address to publish multiple disparate feeds if so desired.

A new `Publish Feed` transaction is used to publish.  This transaction can be described as follows:

---
#### Publish Feed

Transaction type 31 publishes a value which may be later referenced by Omni transactions and exposed by the RPC-API.

Multiple `Publish Feed` transactions from the same address using the same feed reference may be used to form a feed history.  

There are no additional validity constraints other than the the message field datatypes.

| **Field** | **Type** | **Example Value** |
| --- | --- | --- |
| Transaction version | 16 bit unsigned int | 31 |
| Transaction type | 16 bit unsigned int | 0 |
| Feed reference | 16 bit unsigned int | 1 |
| Feed Value | 64 bit signed int | 5000 |

---

No transactions currently reference this data, but it is exposed via the RPC-API interface.

Initially supported functions via the RPC-API are:
- Get the current value of a feed (`omni_getfeed address feedref`)
- Get the value of a feed as at block N (`omni_getfeed address feedref block`)
- Get the past values (history) of a feed (`omni_getfeedhistory address feedref`)
- Get the feeds an address has published (`omni_getfeeds address`)

Respective internal functions grab this data from the feed database (leveldb), it may be likely that the most useful in the context of smart contracts would be retrieving the value at block N (assuming contracts are settled based on the price at block N).

A set of basic tests is included to validate functionality - these results (included below) can be checked by running the bash script `test/test_publishfeed.sh`.  Note these tests demonstrate basic functionality only and do not look for problems with edge cases etc, that likely needs more thorough testing.

```
Preparing a test environment...
   * Starting a fresh regtest daemon
   * Preparing some mature testnet BTC
   * Obtaining a master address to work with
   * Funding the address with some testnet BTC for fees
   * Participating in the Exodus crowdsale to obtain some OMNI
   * Master address is mumET8Stvkjsdd16ys8v6v4jyy9gRcJ9y1
   * Generating addresses to use
Confirming publish feed transactions are invalidated before activation...
   * Sending a Publish Feed transaction
     # Checking the transaction was invalid... PASS
Activating the publish feed transaction...
   * Sending the activation
     # Checking the activation transaction was valid... PASS
   * Mining 10 blocks to forward past the activation block
     # Checking the activation went live as expected... PASS
Testing Publish Feed...
   * Sending a Publish Feed transaction (feed 1, value 1000)
     # Checking the transaction was valid... PASS
     # Checking the value for feed 1 at address is now 1000... PASS
     # Getting the block number to use later...
   * Sending several Publish Feed transactions for feed 1, (highest will be 5000 but latest 3000)
     # Checking the value for feed 1 at address is now at latest (3000)... PASS
     # Checking the value for feed 1 at address is 1000 at block 117... PASS
   * Sending Publish Feed transactions for feed refernces 2 and 65
     # Checking the value for feed 2 at address is now 200... PASS
     # Checking the value for feed 65 at address is now 6500... PASS
     # Checking that feeds 1, 2 and 65 are returned in omni_getfeeds... PASS
   * Checking feed history for feed ref 1
     # Checking that values 1000, 2000, 4000, 5000 & 3000 exist in history... PASS
   * Committing feed database to log
Orphaning a block to test Feed DB reorg protection (disconnecting 1 block from tip and mining a replacement)
     # Checking the value for feed 1 at address is still at 3000... PASS
   * Updating the feed to 9000
     # Checking the value for feed 1 at address is now at 9000... PASS
   * Committing feed database to log
   * Executing the rollback
   * Clearing the mempool
   * Verifiying the results
      # Checking the block count has been reduced by 1... PASS
   * Mining a replacement block
   * Committing feed database to log
   * Verifiying the results
      # Checking the block count is the same as before the rollback... PASS
      # Checking the block hash is different from before the rollback... PASS
     # Checking the value for feed 1 at address has been rolled back to 3000... PASS

####################
#  Summary:        #
#    Passed = 17   #
#    Failed = 0    #
####################
```
