### PR TITLE
Disable alert system as per default

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -55,7 +55,7 @@ static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** Default for accepting alerts from the P2P network. */
-static const bool DEFAULT_ALERTS = true;
+static const bool DEFAULT_ALERTS = false;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** The maximum allowed number of signature check operations in a block (network rule) */


### PR DESCRIPTION
This pull request disables the alert system as per default.

Adopted from https://github.com/bitcoin/bitcoin/pull/7741.