### PR TITLE
Fix several bugs in fee system

### DIFF
--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -263,7 +263,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 
             // strip a 0.05% fee from non-OMNI pairs if fees are activated
             if (IsFeatureActivated(FEATURE_FEES, pnew->getBlock())) {
-                if ( (pold->getProperty() != (OMNI_PROPERTY_MSC || OMNI_PROPERTY_TMSC)) || (pold->getDesProperty() != (OMNI_PROPERTY_MSC || OMNI_PROPERTY_TMSC)) ) {
+                if (pold->getProperty() > OMNI_PROPERTY_TMSC && pold->getDesProperty() > OMNI_PROPERTY_TMSC) {
                     int64_t feeDivider = 2000; // 0.05%
                     tradingFee = buyer_amountGot / feeDivider;
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -425,6 +425,7 @@ bool mastercore::update_tally_map(const std::string& who, uint32_t propertyId, i
  */
 static int64_t calculate_and_update_devmsc(unsigned int nTime)
 {
+return 0;
     // do nothing if before end of fundraiser
     if (nTime < 1377993874) return 0;
 
@@ -3328,7 +3329,8 @@ bool CMPTradeList::getMatchingTrades(const uint256& txid, uint32_t propertyId, A
 
       std::string strAmount1 = FormatMP(prop1, amount1);
       std::string strAmount2 = FormatMP(prop2, amount2);
-      std::string strTradingFee = FormatMP(prop1, tradingFee);
+      std::string strTradingFee = FormatMP(prop2, tradingFee);
+      std::string strAmount2PlusFee = FormatMP(prop2, amount2+tradingFee);
 
       // populate trade object and add to the trade array, correcting for orientation of trade
       Object trade;
@@ -3338,13 +3340,14 @@ bool CMPTradeList::getMatchingTrades(const uint256& txid, uint32_t propertyId, A
           trade.push_back(Pair("address", address1));
           trade.push_back(Pair("amountsold", strAmount1));
           trade.push_back(Pair("amountreceived", strAmount2));
+          trade.push_back(Pair("tradingfee", strTradingFee));
           totalReceived += amount2;
           totalSold += amount1;
       } else {
           trade.push_back(Pair("address", address2));
-          trade.push_back(Pair("amountsold", strAmount2));
+          trade.push_back(Pair("amountsold", strAmount2PlusFee));
           trade.push_back(Pair("amountreceived", strAmount1));
-          trade.push_back(Pair("tradingfee", strTradingFee));
+          trade.push_back(Pair("tradingfee", FormatMP(prop1, 0))); // not the liquidity taker so no fee for this participant - include attribute for standardness
           totalReceived += amount1;
           totalSold += amount2;
       }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -425,7 +425,6 @@ bool mastercore::update_tally_map(const std::string& who, uint32_t propertyId, i
  */
 static int64_t calculate_and_update_devmsc(unsigned int nTime)
 {
-return 0;
     // do nothing if before end of fundraiser
     if (nTime < 1377993874) return 0;
 


### PR DESCRIPTION
This PR fixes several bugs in the fee system, specifically:
* Bad data shown at the RPC layer for amounts sold and trading fees charged
* Incorrect code causing bad application of "Omni-based trades are free" rule (all trades charged a fee)
* Test script uses OMNI & TOMNI to run the test cases, but these trades should be free.

My own output of the updated test script is below for those who don't want to recompile with dev Omni disabled.

Feedback welcomed :)

Thanks
Z

```
Preparing a test environment...
   * Starting a fresh regtest daemon
   * Preparing some mature testnet BTC
   * Obtaining a master address to work with
   * Funding the address with some testnet BTC for fees
   * Participating in the Exodus crowdsale to obtain some OMNI
   * Creating an indivisible test property
   * Creating a second indivisible test property
   * Creating a divisible test property
   * Creating a second divisible test property
   * Creating an indivisible test property in the test ecosystem
   * Creating a divisible test property in the test ecosystem
   * Generating addresses to use as fee recipients (OMNI holders)
   * Using a total of 1000 OMNI
   * Seeding mqTy5mTSx9Y8Kx6ED6fajJisVwpuy35ocD with 50.00 OMNI
   * Seeding mk1obB7ry6bhLwF28XW1hh4PY3U4FVgM6h with 100.00 OMNI
   * Seeding myQbFLf2d5Hk1fbRVCRwhSAg7pQn968T3H with 150.00 OMNI
   * Seeding ms6P6kf8X9K9VrH6kUTQzAhSa3joksnS8g with 200.00 OMNI

Activating the fee system...
   * Sending the activation
     # Checking the activation transaction was valid... PASS
   * Mining 10 blocks to forward past the activation block
     # Checking the activation went live as expected... PASS

Checking share of fees for recipients...
   * Checking mqTy5mTSx9Y8Kx6ED6fajJisVwpuy35ocD has a 5 percent share of fees... PASS
   * Checking mk1obB7ry6bhLwF28XW1hh4PY3U4FVgM6h has a 10 percent share of fees... PASS
   * Checking myQbFLf2d5Hk1fbRVCRwhSAg7pQn968T3H has a 15 percent share of fees... PASS
   * Checking ms6P6kf8X9K9VrH6kUTQzAhSa3joksnS8g has a 20 percent share of fees... PASS
   * Checking mwHMAVekCeibdAkXUTJNuJk3ZgpxR6jLQi has a 50 percent share of fees... PASS
   * Checking mwHMAVekCeibdAkXUTJNuJk3ZgpxR6jLQi has a 100 percent share of fees in the test ecosystem... PASS

Testing a trade against self where the first token is OMNI
   * Executing the trade
   * Verifiying the results
      # Checking no fee was taken...
        * Checking the original trade matches to confirm trading fee was 0... PASS
        * Checking the new trade matches to confirm trading fee was 0... PASS
        * Checking the fee cache is empty for property 1... PASS
        * Checking the fee cache is empty for property 3... PASS
        * Checking the trading address didn't lose any #1 tokens after trade... PASS
        * Checking the trading address didn't lose any #3 tokens after trade... PASS

Activating all pair trading...
   * Sending the activation
     # Checking the activation transaction was valid... PASS
   * Mining 10 blocks to forward past the activation block

Testing a trade against self that results in a 1 willet fee for property 3 (1.0 #5 for 2000 #3)
   * Executing the trade
   * Verifiying the results
      # Checking the original trade matches to confirm trading fee was 0... PASS
      # Checking the new trade matches to confirm trading fee was 1... PASS
      # Checking the fee cache now has 1 fee cached for property 3... PASS
      # Checking the trading address now owns 9999999 of property 3... PASS

Testing another trade against self that results in a 5 willet fee for property 3 (1.0 #5 for 10000 #3)
   * Executing the trade
   * Verifiying the results
      # Checking the original trade matches to confirm trading fee was 0... PASS
      # Checking the new trade matches to confirm trading fee was 5... PASS
      # Checking the fee cache now has 6 fee cached for property 3... PASS
      # Checking the trading address now owns 9999994 instead of property 3... PASS

Testing a trade against self that results in a 1 willet fee for property 6 (1.0 #5 for 0.00002 #6)
   * Executing the trade
   * Verifiying the results
      # Checking the original trade matches to confirm trading fee was 0... PASS
      # Checking the new trade matches to confirm trading fee was 0.00000001... PASS
      # Checking the fee cache now has 0.00000001 fee cached for property 6... PASS
      # Checking the trading address now owns 9999.99999999 of property 6... PASS

Testing a trade against self that results in a 5000 willet fee for property 6 (1.0 #5 for 0.1 #6)
   * Executing the trade
   * Verifiying the results
      # Checking the original trade matches to confirm trading fee was 0... PASS
      # Checking the new trade matches to confirm trading fee was 0.00005000... PASS
      # Checking the fee cache now has 0.00005001 fee cached for property 6... PASS
      # Checking the trading address now owns 9999.99994999 of property 6... PASS

Increasing volume to get close to 10000000 fee trigger point for property 6
   * Executing the trades
   * Verifiying the results
      # Checking the fee cache now has 0.09995001 fee cached for property 6... PASS
      # Checking the trading address now owns 9999.90004999 of property 6... PASS

Performing a small trade to take fee cache to 0.1 and trigger distribution for property 6
   * Executing the trade
   * Verifiying the results
      # Checking distribution was triggered and the fee cache is now empty for property 6... PASS
      # Checking mqTy5mTSx9Y8Kx6ED6fajJisVwpuy35ocD received 0.00500000 fee share... PASS
      # Checking mk1obB7ry6bhLwF28XW1hh4PY3U4FVgM6h received 0.01000000 fee share... PASS
      # Checking myQbFLf2d5Hk1fbRVCRwhSAg7pQn968T3H received 0.01500000 fee share... PASS
      # Checking ms6P6kf8X9K9VrH6kUTQzAhSa3joksnS8g received 0.02000000 fee share... PASS
      # Checking mwHMAVekCeibdAkXUTJNuJk3ZgpxR6jLQi received 0.05000000 fee share... PASS

Rolling back the chain to test ability to roll back a distribution during reorg (disconnecting 1 block from tip and mining a replacement)
   * Executing the rollback
   * Clearing the mempool
   * Verifiying the results
      # Checking the block count has been reduced by 1... PASS
   * Mining a replacement block
   * Verifiying the results
      # Checking the block count is the same as before the rollback... PASS
      # Checking the block hash is different from before the rollback... PASS
      # Checking the fee cache now again has 0.09995001 fee cached for property 6... PASS
      # Checking mqTy5mTSx9Y8Kx6ED6fajJisVwpuy35ocD balance has been rolled back to 0... PASS
      # Checking mk1obB7ry6bhLwF28XW1hh4PY3U4FVgM6h balance has been rolled back to 0... PASS
      # Checking myQbFLf2d5Hk1fbRVCRwhSAg7pQn968T3H balance has been rolled back to 0... PASS
      # Checking ms6P6kf8X9K9VrH6kUTQzAhSa3joksnS8g balance has been rolled back to 0... PASS
      # Checking mwHMAVekCeibdAkXUTJNuJk3ZgpxR6jLQi balance has been rolled back to 9999.90004999... PASS
   * Performing a small trade to take fee cache to 0.1 and retrigger distribution for property 6
      # Executing the trade
      # Verifiying the results
        * Checking distribution was triggered again and the fee cache is now empty for property 6... PASS
        * Checking mqTy5mTSx9Y8Kx6ED6fajJisVwpuy35ocD received 0.00500000 fee share... PASS
        * Checking mk1obB7ry6bhLwF28XW1hh4PY3U4FVgM6h received 0.01000000 fee share... PASS
        * Checking myQbFLf2d5Hk1fbRVCRwhSAg7pQn968T3H received 0.01500000 fee share... PASS
        * Checking ms6P6kf8X9K9VrH6kUTQzAhSa3joksnS8g received 0.02000000 fee share... PASS
        * Checking mwHMAVekCeibdAkXUTJNuJk3ZgpxR6jLQi received 0.05000000 fee share... PASS

Rolling back the chain to test ability to roll back a fee cache change during reorg
   # Testing a trade against self that results in a 1 willet fee for property 6 (1.0 #6 for 0.00002 #5)
      * Executing the trade
      * Verifiying the results
         # Checking the fee cache now has 0.00000001 fee cached for property 6... PASS
   # Testing another trade against self that results in a 1 willet fee for property 6 (1.0 #6 for 0.00002 #5)
      * Executing the trade
      * Verifiying the results
         # Checking the fee cache now has 0.00000002 fee cached for property 6... PASS
   # Rolling back the chain to orphan a block (disconnecting 1 block from tip and mining a replacement)
      * Executing the rollback
      * Clearing the mempool
      * Verifiying the results
         # Checking the block count has been reduced by 1... PASS
      * Mining a replacement block
      * Verifiying the results
         # Checking the block count is the same as before the rollback... PASS
         # Checking the block hash is different from before the rollback... PASS
         # Checking the fee cache has been rolled back to 0.00000001 for property 6... PASS

Mining 51 blocks to test that fee cache is not affected by fee pruning
   * Verifiying the results
      # Checking the fee cache is 0.00000001 for property 6... PASS
   * Mining the blocks...
      # Checking the fee cache is still 0.00000001 for property 6... PASS
   * Executing a trade to generate 1 willet fee
      # Checking the fee cache now has 0.00000002 fee cached for property 6... PASS

Adding some test ecosystem volume to trigger distribution
   * Executing the trades
   * Verifiying the results
      # Checking the fee cache now has 90 fee cached for property 2147483651... PASS
      # Checking the trading address now owns 9999910 of property 2147483651... PASS

Triggering distribution in the test ecosystem for property 2147483651
   * Executing the trade
   * Verifiying the results
      # Checking distribution was triggered and the fee cache is now empty for property 2147483651... PASS
      # Checking mwHMAVekCeibdAkXUTJNuJk3ZgpxR6jLQi received 100 fee share... PASS

####################
#  Summary:        #
#    Passed = 67   #
#    Failed = 0    #
####################
```