### PR TITLE
Port Auditor to latest 0.0.11.2

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -1,5 +1,6 @@
 OMNICORE_H = \
   omnicore/activation.h \
+  omnicore/auditor.h \
   omnicore/consensushash.h \
   omnicore/convert.h \
   omnicore/createpayload.h \
@@ -40,6 +41,7 @@ OMNICORE_H = \
 
 OMNICORE_CPP = \
   omnicore/activation.cpp \
+  omnicore/auditor.cpp \
   omnicore/consensushash.cpp \
   omnicore/convert.cpp \
   omnicore/createpayload.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -220,6 +220,7 @@ void HandleSIGHUP(int)
 {
     fReopenDebugLog = true;
     fReopenOmniCoreLog = true;
+    fReopenAuditLog = true;
 }
 
 bool static InitError(const std::string &str)

--- a/src/omnicore/auditor.cpp
+++ b/src/omnicore/auditor.cpp
@@ -1,0 +1,413 @@
+/**
+ * @file auditor.cpp
+ *
+ * This file contains code for the auditor module.
+ */
+
+#include "omnicore/auditor.h"
+#include "omnicore/fees.h"
+#include "omnicore/log.h"
+#include "omnicore/mdex.h"
+#include "omnicore/omnicore.h"
+#include "omnicore/sp.h"
+#include "main.h"
+
+#include <boost/lexical_cast.hpp>
+
+using namespace mastercore;
+
+bool auditorEnabled = false; // enable with --enableauditor
+bool auditBalanceChanges = false; // enable with --auditbalancechanges
+bool auditDevOmni = false; // enable with --auditdevomni
+
+std::map<uint32_t, int64_t> mapPropertyTotals;
+std::map<string, CMPTally> mapBalancesCache;
+
+uint32_t auditorPropertyCountMainEco = 0;
+uint32_t auditorPropertyCountTestEco = 0;
+int64_t lastBlockProcessed = -1;
+
+/* This function initializes the auditor
+ */
+void mastercore::Auditor_Initialize()
+{
+    // Log auditor startup
+    PrintToAuditLog("##################################################################################\n");
+    PrintToAuditLog("Auditor initializing...\n");
+
+    // Initialize property totals map
+    unsigned int propertyId;
+    unsigned int nextPropIdMainEco = GetNextPropertyId(true);
+    unsigned int nextPropIdTestEco = GetNextPropertyId(false);
+    for (propertyId = 1; propertyId < nextPropIdMainEco; propertyId++) {
+        mapPropertyTotals.insert(std::pair<uint32_t,int64_t>(propertyId,SafeGetTotalTokens(propertyId)));
+    }
+    for (propertyId = 2147483650; propertyId < nextPropIdTestEco; propertyId++) {
+        mapPropertyTotals.insert(std::pair<uint32_t,int64_t>(propertyId,SafeGetTotalTokens(propertyId)));
+    }
+
+    // Initialize property counts
+    auditorPropertyCountMainEco = nextPropIdMainEco - 1;
+    auditorPropertyCountTestEco = nextPropIdTestEco - 1;
+
+    // Audit the MetaDEx after loading from persistence (nothing to audit for fresh parse)
+    for (int i = 1; i<100; ++i) { // stop after 100 bad trades - indicates significant bug
+        uint256 badTrade = SearchForBadTrades();
+        if (badTrade == 0) {
+            break;
+        } else {
+            AuditFail(strprintf("Auditor has detected an invalid trade (txid: %s) present in the MetaDEx during initialization\n", badTrade.GetHex().c_str()));
+        }
+    }
+
+    // If balance change auditing is enabled (--auditbalancechanges) populate the balances cache
+    if (auditBalanceChanges) {
+        PrintToAuditLog("Balance auditing is enabled.\n");
+        mapBalancesCache = mp_tally_map;
+    } else {
+        PrintToAuditLog("Balance auditing is disabled.\n");
+    }
+
+    PrintToAuditLog("Auditor initialized\n");
+}
+
+/* This function reinitializes the auditor after a chain reorg/orphan
+ */
+void mastercore::Auditor_NotifyChainReorg(int nWaterlineBlock)
+{
+    PrintToAuditLog("Auditor was notified that the state has been rolled back to block %d due to a reorg/orphan. The auditor will now restart\n", nWaterlineBlock);
+    // reset auditor state and reinitialize
+    auditorPropertyCountMainEco = 0;
+    auditorPropertyCountTestEco = 0;
+    lastBlockProcessed = -1;
+    mapPropertyTotals.clear();
+    mapBalancesCache.clear();
+    Auditor_Initialize();
+}
+
+/* This function handles notification of a balance change
+ */
+void mastercore::Auditor_NotifyBalanceChangeRequested(const std::string& address, int64_t amount, uint32_t propertyId, TallyType tallyType, const std::string& type, uint256 txid, const std::string& caller, bool processed)
+{
+    if (!auditBalanceChanges) {
+        return;
+    }
+
+    if (address.empty()) {
+        AuditFail(strprintf("Auditor was notified of a balance change request with an invalid address (%s) by %s:%s (caller %s)\n", address, type, txid.GetHex(), caller));
+    }
+    if ((propertyId == 0) || ((propertyId > auditorPropertyCountMainEco) && (propertyId < 2147483647)) || (propertyId > auditorPropertyCountTestEco)) {
+        AuditFail(strprintf("Auditor was notified of a balance change request with an invalid property ID (%u) by %s:%s (caller %s)\n", propertyId, type, txid.GetHex(), caller));
+    }
+    if (tallyType > TALLY_TYPE_COUNT) {
+        AuditFail(strprintf("Auditor was notified of a balance change request with an invalid tallyType (%d) by %s:%s (caller %s)\n", tallyType, type, txid.GetHex(), caller));
+    }
+
+    if (processed) { // the balance change request was processed, change the cache accordingly
+        std::map<std::string, CMPTally>::iterator search_it = mapBalancesCache.find(address);
+        if (search_it == mapBalancesCache.end()) { // address doesn't exist, insert
+            search_it = ( mapBalancesCache.insert(std::make_pair(address,CMPTally())) ).first;
+        }
+        CMPTally &tally = search_it->second;
+        if(!tally.updateMoney(propertyId, amount, tallyType)) {
+            AuditFail(strprintf("Auditor was unable to modify the balances cache for %s, %ld of SP%u on tally %d, (%s:%s, %s)\n", address, amount, propertyId, tallyType, type, txid.GetHex(), caller));
+        }
+    }
+
+    if (!auditDevOmni && (type == "Award Dev OMNI")) {
+        return;
+    } else {
+        PrintToAuditLog(strprintf("Balance Update %s: %s, %ld of SP%u on tally %d, (%s:%s, %s)\n", processed ? "Accepted":"REJECTED", address, amount, propertyId, tallyType, type, txid>0 ? txid.GetHex():"N/A", caller));
+    }
+}
+
+/* This function handles auditor functions for the beginning of a block
+ */
+void mastercore::Auditor_NotifyBlockStart(CBlockIndex const * pBlockIndex)
+{
+    // DEBUG : Log that auditor informed a new block
+    if (omni_debug_auditor_verbose) {
+        PrintToAuditLog("Auditor was notified block %d has begun processing\n", pBlockIndex->nHeight);
+    }
+
+    // Is this the first block processed or is this block number as expected?
+    if (lastBlockProcessed == -1) {
+        lastBlockProcessed = pBlockIndex->nHeight;
+    } else {
+        if (lastBlockProcessed+1 == pBlockIndex->nHeight) {
+            if (omni_debug_auditor_verbose) {
+                PrintToAuditLog("Auditor did not detect processing of an out of order block (%d)\n", pBlockIndex->nHeight);
+            }
+            lastBlockProcessed = pBlockIndex->nHeight;
+        } else { // audit failure - case should never occur but safety check
+            AuditFail(strprintf("Auditor has detected processing of a block in a non-sequential order (%d)\n", pBlockIndex->nHeight));
+        }
+    }
+}
+
+/* This function handles auditor functions for the end of a block
+ */
+void mastercore::Auditor_NotifyBlockFinish(CBlockIndex const * pBlockIndex)
+{
+    // DEBUG : Log that auditor informed block processing completed
+    if (omni_debug_auditor_verbose) {
+        PrintToAuditLog("Auditor was notified block %d has been processed\n", pBlockIndex->nHeight);
+    }
+
+    // Verify that the finish notification is for the correct block (otherwise the auditor has somehow missed a/some block(s)
+    if ((pBlockIndex->nHeight != lastBlockProcessed) && (pBlockIndex->nHeight != 0)) { // audit failure
+        AuditFail(strprintf("Auditor has received unexpected notification of completion of block %d\n", pBlockIndex->nHeight));
+    }
+
+    // Compare the property totals from the state with the auditor property totals map
+    uint32_t mismatch = ComparePropertyTotals();
+    if (mismatch == 0) {
+        if (omni_debug_auditor_verbose) {
+            PrintToAuditLog("Auditor did not detect any inconsistencies in property token totals following block %d\n", pBlockIndex->nHeight);
+        }
+    } else { // audit failure
+        AuditFail(strprintf("Auditor has detected inconsistencies in the amount of tokens for property %u following block %d\n", mismatch, pBlockIndex->nHeight));
+    }
+
+    // Compare the number of properties in state with cache
+    bool comparePropertyCount = ComparePropertyCounts();
+    if (comparePropertyCount) {
+        if (omni_debug_auditor_verbose) {
+            PrintToAuditLog("Auditor did not detect any inconsistencies in the total number of properties following block %d\n", pBlockIndex->nHeight);
+        }
+    } else { // audit failure
+        AuditFail(strprintf("Auditor has detected inconsistencies in the total number of properties following block %d\n", pBlockIndex->nHeight));
+    }
+
+    // Check the MetaDEx does not have any bad trades present
+    for (int i = 1; i<100; ++i) { // stop after 100 bad trades - indicates significant bug
+        uint256 badTrade = SearchForBadTrades();
+        if (badTrade == 0) {
+            if (omni_debug_auditor_verbose) {
+                PrintToAuditLog("Auditor did not detect any problems in the MetaDEx maps following block %d\n", pBlockIndex->nHeight);
+            }
+            break;
+        } else {
+            AuditFail(strprintf("Auditor has detected an invalid trade (txid: %s) present in the MetaDEx following block %d\n", pBlockIndex->nHeight, badTrade.GetHex().c_str()));
+        }
+    }
+
+    // If balance change auditing is enabled, compare cache with state
+    if (auditBalanceChanges) {
+        std::string compareFailures;
+        bool cacheMatch = CompareBalances(compareFailures);
+        if (cacheMatch) {
+            if (omni_debug_auditor_verbose) {
+                PrintToAuditLog("Auditor did not detect any inconsistencies in the balance cache following block %d\n", pBlockIndex->nHeight);
+            }
+        } else { // audit failure
+            AuditFail(strprintf("Auditor has detected inconsistencies in the balance cache following block %d\n%s", pBlockIndex->nHeight, compareFailures));
+        }
+    }
+}
+
+/* This function updates the property totals cache when an increase occurs
+ */
+void mastercore::Auditor_NotifyPropertyTotalChanged(bool increase, uint32_t propertyId, int64_t amount, std::string const& reasonStr)
+{
+    if (propertyId == 0) {
+        AuditFail("Auditor was notified of a property total change for property ID zero\n");
+    }
+    if (amount <= 0) {
+        AuditFail(strprintf("Auditor was notified of a property total change with an invalid amount (%ld) for property %u due to %s\n", amount, propertyId, reasonStr.c_str()));
+    }
+    std::map<uint32_t,int64_t>::iterator it = mapPropertyTotals.find(propertyId);
+    if (it != mapPropertyTotals.end()) {
+        int64_t cachedValue = it->second;
+        int64_t stateValue = SafeGetTotalTokens(propertyId);
+        int64_t newValue;
+        if (increase) {
+            newValue = cachedValue + amount;
+        } else {
+            newValue = cachedValue - amount;
+        }
+        if (newValue == stateValue) { // additional sanity check - cached + amount increased should equal state total
+            it->second = newValue;
+            if (!auditDevOmni && ((reasonStr.length() > 8) && (reasonStr.substr(0,8) == "Dev OMNI"))) {
+                // skip logging
+            } else {
+                PrintToAuditLog("Auditor was notified of %s of %ld tokens for property %u due to %s\n", increase ? "an increase" : "a decrease", amount, propertyId, reasonStr.c_str());
+            }
+        } else { // audit failure - sanity check failed
+            std::string details = strprintf("Type:%s  Amount cached:%ld  Amount changed:%ld  Amount updated:%ld  Amount state:%ld\n", increase ? "increase" : "decrease", cachedValue, amount, newValue, stateValue);
+            AuditFail(strprintf("Auditor has detected inconsistencies when attempting to update the total amount of tokens for property %u\n%s",propertyId,details));
+        }
+    } else { // audit failure - property not found
+        AuditFail(strprintf("Auditor has detected inconsistencies when attempting to update the total amount of tokens for non-existent property %u\n",propertyId));
+    }
+}
+
+/* This function adds a new property to the cached totals map
+ */
+void mastercore::Auditor_NotifyPropertyCreated(uint32_t propertyId)
+{
+    if (propertyId == 0) {
+        AuditFail("Auditor was notified of a property creation with property ID zero\n");
+    }
+    std::map<uint32_t,int64_t>::iterator it = mapPropertyTotals.find(propertyId);
+    if((it == mapPropertyTotals.end()) && ((propertyId == auditorPropertyCountMainEco + 1) || (propertyId == auditorPropertyCountTestEco + 1))) { // check it does not already exist and is sequential
+        mapPropertyTotals.insert(std::pair<uint32_t,int64_t>(propertyId,0));
+        if (!isTestEcosystemProperty(propertyId)) {
+            auditorPropertyCountMainEco += 1;
+        } else {
+            auditorPropertyCountTestEco += 1;
+        }
+        PrintToAuditLog("Auditor was notified of a new property creation with ID %u\n", propertyId);
+    } else { // audit failure - new property, it should not already exist in cached totals map
+        AuditFail(strprintf("Auditor has detected a duplicated or non sequential property ID when attempting to insert property %u\n",propertyId));
+    }
+}
+
+/* This function searches the MetaDEx maps for any invalid trades
+ */
+uint256 SearchForBadTrades()
+{
+    for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it) {
+        md_PricesMap & prices = my_it->second;
+        for (md_PricesMap::iterator it = prices.begin(); it != prices.end(); ++it) {
+            const rational_t price = (it->first);
+            md_Set & indexes = (it->second);
+            for (md_Set::iterator it = indexes.begin(); it != indexes.end(); ++it) {
+                CMPMetaDEx obj = *it;
+                if (0 >= obj.getAmountDesired()) return obj.getHash();
+                if (0 >= obj.getAmountForSale()) return obj.getHash();
+                if (0 >= price) return obj.getHash();
+                if ("0.00000000000000000000000000000000000000000000000000" >= obj.displayFullUnitPrice()) return obj.getHash();
+            }
+        }
+    }
+    return 0;
+}
+
+/* This function compares the cached number of properties with the state
+ */
+bool ComparePropertyCounts()
+{
+    unsigned int nextPropIdMainEco = GetNextPropertyId(true);
+    unsigned int nextPropIdTestEco = GetNextPropertyId(false);
+    if ((nextPropIdMainEco == auditorPropertyCountMainEco + 1) && (nextPropIdTestEco == auditorPropertyCountTestEco + 1)) {
+         return true;
+    } else {
+         return false;
+    }
+}
+
+/* This function compares the current state with the cached property totals map
+ */
+uint32_t ComparePropertyTotals()
+{
+    unsigned int propertyId;
+    unsigned int nextPropIdMainEco = GetNextPropertyId(true);
+    unsigned int nextPropIdTestEco = GetNextPropertyId(false);
+    for (propertyId = 1; propertyId < nextPropIdMainEco; propertyId++) {
+        std::map<uint32_t,int64_t>::iterator it = mapPropertyTotals.find(propertyId);
+        if(it == mapPropertyTotals.end()) { return propertyId; } else { if (SafeGetTotalTokens(propertyId) != it->second) return propertyId; }
+    }
+    for (propertyId = 2147483650; propertyId < nextPropIdTestEco; propertyId++) {
+        std::map<uint32_t,int64_t>::iterator it = mapPropertyTotals.find(propertyId);
+        if(it == mapPropertyTotals.end()) { return propertyId; } else { if (SafeGetTotalTokens(propertyId) != it->second) return propertyId; }
+    }
+    return 0;
+}
+
+/* This function obtains the total number of tokens for propertyId from the balances tally.
+ *
+ * Note: similar to getTotalTokens, however getTotalTokens utilizes a shortcut to request the
+ * number of tokens originally issued from the SP object for a fixed issuance property since the
+ * number of tokens should never change.  However for auditing purposes we want to verify how many
+ * tokens exist *now* so must avoid using such a shortcut.
+ */
+int64_t SafeGetTotalTokens(uint32_t propertyId)
+{
+  LOCK(cs_tally);
+  int64_t totalTokens = 0;
+  for(std::map<string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it) {
+      string address = (my_it->first).c_str();
+      totalTokens += getMPbalance(address, propertyId, BALANCE);
+      totalTokens += getMPbalance(address, propertyId, SELLOFFER_RESERVE);
+      totalTokens += getMPbalance(address, propertyId, METADEX_RESERVE);
+      if (propertyId<3) totalTokens += getMPbalance(address, propertyId, ACCEPT_RESERVE);
+  }
+  int64_t feesCached = p_feecache->GetCachedAmount(propertyId);
+  totalTokens += feesCached;
+
+  return totalTokens;
+}
+
+/* This function handles an audit failure
+ */
+void AuditFail(const std::string& msg)
+{
+    PrintToAuditLog("%s", msg);
+    if (!GetBoolArg("-overrideforcedshutdown", false)) {
+        AbortNode("Shutting down due to audit failure. " + msg + ". Please check omnicore.log for further details");
+    }
+}
+
+/* This function compres state balances with cached balances
+ *
+ * Note: this is a significant performance hit, but auditing balances is an on-demand action
+ */
+bool CompareBalances(std::string &compareFailures)
+{
+    for (std::map<string, CMPTally>::iterator my_it = mapBalancesCache.begin(); my_it != mapBalancesCache.end(); ++my_it) {
+        string address = my_it->first.c_str();
+        CMPTally &tally = my_it->second;
+        tally.init();
+        uint32_t propertyId;
+        while (0 != (propertyId = tally.next())) {
+            if (getMPbalance(address, propertyId, BALANCE) != tally.getMoney(propertyId, BALANCE)) {
+                compareFailures += strprintf("CACHE DIFF: %s, SP%u, Balance Tally, State Balance: %ld, Cache Balance: %ld\n", address, propertyId, getMPbalance(address, propertyId, BALANCE), tally.getMoney(propertyId, BALANCE));
+            }
+            if (getMPbalance(address, propertyId, SELLOFFER_RESERVE) != tally.getMoney(propertyId, SELLOFFER_RESERVE)) {
+                compareFailures += strprintf("CACHE DIFF: %s, SP%u, SellOffer Tally, State Balance: %ld, Cache Balance: %ld\n", address, propertyId, getMPbalance(address, propertyId, SELLOFFER_RESERVE), tally.getMoney(propertyId, SELLOFFER_RESERVE));
+            }
+            if (getMPbalance(address, propertyId, METADEX_RESERVE) != tally.getMoney(propertyId, METADEX_RESERVE)) {
+                compareFailures += strprintf("CACHE DIFF: %s, SP%u, MetaDEx Tally, State Balance: %ld, Cache Balance: %ld\n", address, propertyId, getMPbalance(address, propertyId, METADEX_RESERVE), tally.getMoney(propertyId, METADEX_RESERVE));
+            }
+            if (getMPbalance(address, propertyId, ACCEPT_RESERVE) != tally.getMoney(propertyId, ACCEPT_RESERVE)) {
+                compareFailures += strprintf("CACHE DIFF: %s, SP%u, Accept Tally, State Balance: %ld, Cache Balance: %ld\n", address, propertyId, getMPbalance(address, propertyId, ACCEPT_RESERVE), tally.getMoney(propertyId, ACCEPT_RESERVE));
+            }
+            if (getMPbalance(address, propertyId, PENDING) != tally.getMoney(propertyId, PENDING)) {
+                compareFailures += strprintf("CACHE DIFF: %s, SP%u, Pending Tally, State Balance: %ld, Cache Balance: %ld\n", address, propertyId, getMPbalance(address, propertyId, PENDING), tally.getMoney(propertyId, PENDING));
+            }
+        }
+    }
+
+    // search for addresses that are not in the cache - if there are no compareFailures at this point and sizes are the same that's a shortcut to know there are no missing cache entries
+    if ((!compareFailures.empty()) || (mp_tally_map.size() != mapBalancesCache.size())) {
+        for (std::map<std::string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it) {
+            string address = my_it->first.c_str();
+            std::map<std::string, CMPTally>::iterator it = mapBalancesCache.find(address);
+            if (it == mapBalancesCache.end()) {
+                // verify this isn't an empty address
+                CMPTally *tally = getTally(address);
+                if (tally == NULL) {
+                    tally->init();
+                    uint32_t propertyId;
+                    while (0 != (propertyId = tally->next())) {
+                        if ((getMPbalance(address, propertyId, BALANCE) != 0) ||
+                            (getMPbalance(address, propertyId, SELLOFFER_RESERVE) != 0) ||
+                            (getMPbalance(address, propertyId, METADEX_RESERVE) != 0) ||
+                            (getMPbalance(address, propertyId, ACCEPT_RESERVE) != 0) ||
+                            (getMPbalance(address, propertyId, PENDING) != 0)) {
+                                compareFailures += strprintf("CACHE MISS: %s is missing from balances cache\n", address);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (!compareFailures.empty()) {
+        return false;
+    } else {
+        return true;
+    }
+}
+

--- a/src/omnicore/auditor.h
+++ b/src/omnicore/auditor.h
@@ -1,0 +1,35 @@
+#ifndef OMNICORE_AUDITOR_H
+#define OMNICORE_AUDITOR_H
+
+#include "uint256.h"
+#include "omnicore/omnicore.h"
+
+#include <stdint.h>
+#include <string>
+
+class CBlockIndex;
+
+extern bool auditorEnabled;
+extern bool auditBalanceChanges;
+extern bool auditDevOmni;
+
+namespace mastercore
+{
+  void Auditor_Initialize();
+  void Auditor_NotifyBlockStart(CBlockIndex const * pBlockIndex);
+  void Auditor_NotifyBlockFinish(CBlockIndex const * pBlockIndex);
+  void Auditor_NotifyPropertyTotalChanged(bool incrase, uint32_t propertyId, int64_t amount, std::string const& reasonStr);
+  void Auditor_NotifyPropertyCreated(uint32_t propertyId);
+  void Auditor_NotifyChainReorg(int nWaterlineBlock);
+  void Auditor_NotifyBalanceChangeRequested(const std::string& address, int64_t amount, uint32_t propertyId, TallyType tallyType, const std::string& type, uint256 txid, const std::string& caller, bool processed);
+}
+
+uint32_t ComparePropertyTotals();
+bool ComparePropertyCounts();
+uint256 SearchForBadTrades();
+int64_t SafeGetTotalTokens(uint32_t propertyId);
+void AuditFail(const std::string& msg);
+bool CompareBalances(std::string &compareFailures);
+
+#endif // OMNICORE_AUDITOR_H
+

--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -191,8 +191,8 @@ int DEx_offerCreate(const std::string& addressSeller, uint32_t propertyId, int64
     // -------------------------------------------------------------------------
 
     if (amountOffered > 0) {
-        assert(update_tally_map(addressSeller, propertyId, -amountOffered, BALANCE));
-        assert(update_tally_map(addressSeller, propertyId, amountOffered, SELLOFFER_RESERVE));
+        assert(update_tally_map(addressSeller, propertyId, -amountOffered, BALANCE, txid, "DEx Sell", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+        assert(update_tally_map(addressSeller, propertyId, amountOffered, SELLOFFER_RESERVE, txid, "DEx Sell", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
         CMPOffer sellOffer(block, amountOffered, propertyId, amountDesired, minAcceptFee, paymentWindow, txid);
         my_offers.insert(std::make_pair(key, sellOffer));
@@ -220,8 +220,8 @@ int DEx_offerDestroy(const std::string& addressSeller, uint32_t propertyId)
 
     // return the remaining reserved amount back to the seller
     if (amountReserved > 0) {
-        assert(update_tally_map(addressSeller, propertyId, -amountReserved, SELLOFFER_RESERVE));
-        assert(update_tally_map(addressSeller, propertyId, amountReserved, BALANCE));
+        assert(update_tally_map(addressSeller, propertyId, -amountReserved, SELLOFFER_RESERVE, 0, "Erase DEx Sell", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+        assert(update_tally_map(addressSeller, propertyId, amountReserved, BALANCE, 0, "Erase DEx Sell", strprintf("%s line %d",__FUNCTION__,__LINE__)));
     }
 
     // delete the offer
@@ -307,8 +307,8 @@ int DEx_acceptCreate(const std::string& addressBuyer, const std::string& address
     }
 
     if (amountReserved > 0) {
-        assert(update_tally_map(addressSeller, propertyId, -amountReserved, SELLOFFER_RESERVE));
-        assert(update_tally_map(addressSeller, propertyId, amountReserved, ACCEPT_RESERVE));
+        assert(update_tally_map(addressSeller, propertyId, -amountReserved, SELLOFFER_RESERVE, 0, "DEx Accept", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+        assert(update_tally_map(addressSeller, propertyId, amountReserved, ACCEPT_RESERVE, 0, "DEx Accept", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
         CMPAccept acceptOffer(amountReserved, block, offer.getBlockTimeLimit(), offer.getProperty(), offer.getOfferAmountOriginal(), offer.getBTCDesiredOriginal(), offer.getHash());
         my_accepts.insert(std::make_pair(keyAcceptOrder, acceptOffer));
@@ -361,11 +361,11 @@ int DEx_acceptDestroy(const std::string& addressBuyer, const std::string& addres
 
     if (amountRemaining > 0) {
         if (fReturnToMoney) {
-            assert(update_tally_map(addressSeller, propertyid, -amountRemaining, ACCEPT_RESERVE));
-            assert(update_tally_map(addressSeller, propertyid, amountRemaining, BALANCE));
+            assert(update_tally_map(addressSeller, propertyid, -amountRemaining, ACCEPT_RESERVE, 0, "Erase DEx Accept", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(addressSeller, propertyid, amountRemaining, BALANCE, 0, "Erase DEx Accept", strprintf("%s line %d",__FUNCTION__,__LINE__)));
         } else {
-            assert(update_tally_map(addressSeller, propertyid, -amountRemaining, ACCEPT_RESERVE));
-            assert(update_tally_map(addressSeller, propertyid, amountRemaining, SELLOFFER_RESERVE));
+            assert(update_tally_map(addressSeller, propertyid, -amountRemaining, ACCEPT_RESERVE, 0, "Erase DEx Accept", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(addressSeller, propertyid, amountRemaining, SELLOFFER_RESERVE, 0, "Erase DEx Accept", strprintf("%s line %d",__FUNCTION__,__LINE__)));
         }
     }
 
@@ -510,8 +510,8 @@ int DEx_payment(const uint256& txid, unsigned int vout, const std::string& addre
         PrintToLog("%s: buyer %s pays %s BTC to purchase %s %s\n", __func__,
                 addressBuyer, FormatDivisibleMP(amountPaid), FormatDivisibleMP(amountPurchased), strMPProperty(propertyId));
 
-        assert(update_tally_map(addressSeller, propertyId, -amountPurchased, ACCEPT_RESERVE));
-        assert(update_tally_map(addressBuyer, propertyId, amountPurchased, BALANCE));
+        assert(update_tally_map(addressSeller, propertyId, -amountPurchased, ACCEPT_RESERVE, txid, "DEx Purchase", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+        assert(update_tally_map(addressBuyer, propertyId, amountPurchased, BALANCE, txid, "DEx Purchase", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
         bool valid = true;
         p_txlistdb->recordPaymentTX(txid, valid, block, vout, propertyId, amountPurchased, addressBuyer, addressSeller);

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -200,7 +200,7 @@ void COmniFeeCache::DistributeCache(const uint32_t &propertyId, int block)
         int64_t will_really_receive = it->first;
         sent_so_far += will_really_receive;
         if (msc_debug_fees) PrintToLog("  %s receives %d (running total %d of %d)\n", address, will_really_receive, sent_so_far, cachedAmount);
-        assert(update_tally_map(address, propertyId, will_really_receive, BALANCE));
+        assert(update_tally_map(address, propertyId, will_really_receive, BALANCE, 0, "Fee Distribution", strprintf("%s line %d",__FUNCTION__,__LINE__)));
         feeHistoryItem recipient(address, will_really_receive);
         historyItems.insert(recipient);
     }

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -9,6 +9,9 @@
 /** Prints to the log file. */
 int LogFilePrint(const std::string& str);
 
+/** Prints to the audit file. */
+int LogAuditPrint(const std::string& str);
+
 /** Prints to the console. */
 int ConsolePrint(const std::string& str);
 
@@ -52,30 +55,42 @@ extern bool msc_debug_consensus_hash_every_block;
 extern bool msc_debug_alerts;
 extern bool msc_debug_consensus_hash_every_transaction;
 extern bool msc_debug_fees;
+extern bool omni_debug_auditor;
+extern bool omni_debug_auditor_verbose;
 
 /* When we switch to C++11, this can be switched to variadic templates instead
  * of this macro-based construction (see tinyformat.h).
  */
-#define MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC(n)                                    \
-    template<TINYFORMAT_ARGTYPES(n)>                                            \
-    static inline int PrintToLog(const char* format, TINYFORMAT_VARARGS(n))     \
-    {                                                                           \
-        return LogFilePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));       \
-    }                                                                           \
-    template<TINYFORMAT_ARGTYPES(n)>                                            \
-    static inline int PrintToLog(TINYFORMAT_VARARGS(n))                         \
-    {                                                                           \
-        return LogFilePrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));         \
-    }                                                                           \
-    template<TINYFORMAT_ARGTYPES(n)>                                            \
-    static inline int PrintToConsole(const char* format, TINYFORMAT_VARARGS(n)) \
-    {                                                                           \
-        return ConsolePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));       \
-    }                                                                           \
-    template<TINYFORMAT_ARGTYPES(n)>                                            \
-    static inline int PrintToConsole(TINYFORMAT_VARARGS(n))                     \
-    {                                                                           \
-        return ConsolePrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));         \
+#define MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC(n)                                      \
+    template<TINYFORMAT_ARGTYPES(n)>                                              \
+    static inline int PrintToLog(const char* format, TINYFORMAT_VARARGS(n))       \
+    {                                                                             \
+        return LogFilePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));         \
+    }                                                                             \
+    template<TINYFORMAT_ARGTYPES(n)>                                              \
+    static inline int PrintToLog(TINYFORMAT_VARARGS(n))                           \
+    {                                                                             \
+        return LogFilePrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));           \
+    }                                                                             \
+    template<TINYFORMAT_ARGTYPES(n)>                                              \
+    static inline int PrintToAuditLog(const char* format, TINYFORMAT_VARARGS(n))  \
+    {                                                                             \
+        return LogAuditPrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));        \
+    }                                                                             \
+    template<TINYFORMAT_ARGTYPES(n)>                                              \
+    static inline int PrintToAuditLog(TINYFORMAT_VARARGS(n))                      \
+    {                                                                             \
+        return LogAuditPrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));          \
+    }                                                                             \
+    template<TINYFORMAT_ARGTYPES(n)>                                              \
+    static inline int PrintToConsole(const char* format, TINYFORMAT_VARARGS(n))   \
+    {                                                                             \
+        return ConsolePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));         \
+    }                                                                             \
+    template<TINYFORMAT_ARGTYPES(n)>                                              \
+    static inline int PrintToConsole(TINYFORMAT_VARARGS(n))                       \
+    {                                                                             \
+        return ConsolePrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));           \
     }
 
 TINYFORMAT_FOREACH_ARGNUM(MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC)

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -278,12 +278,12 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
             }
 
             // transfer the payment property from buyer to seller
-            assert(update_tally_map(pnew->getAddr(), pnew->getProperty(), -seller_amountGot, BALANCE));
-            assert(update_tally_map(pold->getAddr(), pold->getDesProperty(), seller_amountGot, BALANCE));
+            assert(update_tally_map(pnew->getAddr(), pnew->getProperty(), -seller_amountGot, BALANCE, pnew->getHash(), "MetaDEx Trade Match (new)", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(pold->getAddr(), pold->getDesProperty(), seller_amountGot, BALANCE, pold->getHash(), "MetaDEx Trade Match (existing)", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
             // transfer the market (the one being sold) property from seller to buyer
-            assert(update_tally_map(pold->getAddr(), pold->getProperty(), -buyer_amountGot, METADEX_RESERVE));
-            assert(update_tally_map(pnew->getAddr(), pnew->getDesProperty(), buyer_amountGotAfterFee, BALANCE));
+            assert(update_tally_map(pold->getAddr(), pold->getProperty(), -buyer_amountGot, METADEX_RESERVE, pold->getHash(), "MetaDEx Trade Match (existing)", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(pnew->getAddr(), pnew->getDesProperty(), buyer_amountGotAfterFee, BALANCE, pnew->getHash(), "MetaDEx Trade Match (new)", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
             NewReturn = TRADED;
 
@@ -510,8 +510,8 @@ int mastercore::MetaDEx_ADD(const std::string& sender_addr, uint32_t prop, int64
             return METADEX_ERROR -70;
         } else {
             // move tokens into reserve
-            assert(update_tally_map(sender_addr, prop, -new_mdex.getAmountRemaining(), BALANCE));
-            assert(update_tally_map(sender_addr, prop, new_mdex.getAmountRemaining(), METADEX_RESERVE));
+            assert(update_tally_map(sender_addr, prop, -new_mdex.getAmountRemaining(), BALANCE, txid, "MetaDEx Trade", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(sender_addr, prop, new_mdex.getAmountRemaining(), METADEX_RESERVE, txid, "MetaDEx Trade", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
             if (msc_debug_metadex1) PrintToLog("==== INSERTED: %s= %s\n", xToString(new_mdex.unitPrice()), new_mdex.ToString());
             if (msc_debug_metadex3) MetaDEx_debug_print();
@@ -560,8 +560,8 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
             PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
 
             // move from reserve to main
-            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), -p_mdex->getAmountRemaining(), METADEX_RESERVE));
-            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), p_mdex->getAmountRemaining(), BALANCE));
+            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), -p_mdex->getAmountRemaining(), METADEX_RESERVE, txid, "MetaDEx Cancel Price", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), p_mdex->getAmountRemaining(), BALANCE, txid, "MetaDEx Cancel Price", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
             // record the cancellation
             bool bValid = true;
@@ -609,8 +609,8 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
             PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
 
             // move from reserve to main
-            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), -p_mdex->getAmountRemaining(), METADEX_RESERVE));
-            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), p_mdex->getAmountRemaining(), BALANCE));
+            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), -p_mdex->getAmountRemaining(), METADEX_RESERVE, txid, "MetaDEx Cancel Pair", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), p_mdex->getAmountRemaining(), BALANCE, txid, "MetaDEx Cancel Pair", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
             // record the cancellation
             bool bValid = true;
@@ -666,8 +666,8 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
                 PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, it->ToString());
 
                 // move from reserve to balance
-                assert(update_tally_map(it->getAddr(), it->getProperty(), -it->getAmountRemaining(), METADEX_RESERVE));
-                assert(update_tally_map(it->getAddr(), it->getProperty(), it->getAmountRemaining(), BALANCE));
+                assert(update_tally_map(it->getAddr(), it->getProperty(), -it->getAmountRemaining(), METADEX_RESERVE, txid, "MetaDEx Cancel All", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+                assert(update_tally_map(it->getAddr(), it->getProperty(), it->getAmountRemaining(), BALANCE, txid, "MetaDEx Cancel All", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
                 // record the cancellation
                 bool bValid = true;

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -56,6 +56,10 @@ int const MAX_STATE_HISTORY = 50;
 #define MP_TX_PKT_V0  0
 #define MP_TX_PKT_V1  1
 
+// Auditor increase/decrease
+#define OMNI_AUDITOR_DECREASE 0
+#define OMNI_AUDITOR_INCREASE 1
+
 #define MIN_PAYLOAD_SIZE     5
 #define PACKET_SIZE_CLASS_A 19
 #define PACKET_SIZE         31
@@ -350,7 +354,7 @@ bool UseEncodingClassC(size_t nDataSize);
 
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 
-bool update_tally_map(const std::string& who, uint32_t propertyId, int64_t amount, TallyType ttype);
+bool update_tally_map(const std::string& who, uint32_t propertyId, int64_t amount, TallyType ttype, uint256 txid, const std::string& updateReason, const std::string& caller);
 
 std::string getTokenLabel(uint32_t propertyId);
 }

--- a/src/omnicore/pending.cpp
+++ b/src/omnicore/pending.cpp
@@ -38,7 +38,7 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, uint16_t
 
     // bypass tally update for pending transactions, if there the amount should not be subtracted from the balance (e.g. for cancels)
     if (fSubtract) {
-        if (!update_tally_map(sendingAddress, propertyId, -amount, PENDING)) {
+        if (!update_tally_map(sendingAddress, propertyId, -amount, PENDING, txid, "Add pending transaction", strprintf("%s line %d",__FUNCTION__,__LINE__))) {
             PrintToLog("ERROR - Update tally for pending failed! %s(%s,%s,%d,%d,%d,%s)\n", __func__, txid.GetHex(), sendingAddress, type, propertyId, amount, fSubtract);
             return;
         }
@@ -73,7 +73,7 @@ void PendingDelete(const uint256& txid)
         const CMPPending& pending = it->second;
         int64_t src_amount = getMPbalance(pending.src, pending.prop, PENDING);
         if (msc_debug_pending) PrintToLog("%s(%s): amount=%d\n", __FUNCTION__, txid.GetHex(), src_amount);
-        if (src_amount) update_tally_map(pending.src, pending.prop, pending.amount, PENDING);
+        if (src_amount) update_tally_map(pending.src, pending.prop, pending.amount, PENDING, txid, "Erase pending transaction", strprintf("%s line %d",__FUNCTION__,__LINE__));
         my_pending.erase(it);
 
         // if pending map is now empty following deletion, trigger a status change

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -846,7 +846,7 @@ unsigned int mastercore::eraseExpiredCrowdsale(const CBlockIndex* pBlockIndex)
 
             // update values
             if (missedTokens > 0) {
-                assert(update_tally_map(sp.issuer, crowdsale.getPropertyId(), missedTokens, BALANCE));
+                assert(update_tally_map(sp.issuer, crowdsale.getPropertyId(), missedTokens, BALANCE, sp.txid, "Close Expired Crowdsale", strprintf("%s line %d",__FUNCTION__,__LINE__)));
             }
 
             my_crowds.erase(my_it++);

--- a/src/omnicore/test/checkpoint_tests.cpp
+++ b/src/omnicore/test/checkpoint_tests.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(verify_checkpoints)
     BOOST_CHECK(!VerifyCheckpoint(0, uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce260")));
 
     // Pollute the state (and therefore hash)
-    BOOST_CHECK(update_tally_map("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1, 12345, BALANCE));
+    BOOST_CHECK(update_tally_map("3CwZ7FiQ4MqBenRdCkjjc41M5bnoKQGC2b", 1, 12345, BALANCE, 0, "Test Balance Update", "BOOST TEST"));
     // Checkpoint mismatch, due to the state pollution
     BOOST_CHECK(!VerifyCheckpoint(0, uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")));
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -3,6 +3,7 @@
 #include "omnicore/tx.h"
 
 #include "omnicore/activation.h"
+#include "omnicore/auditor.h"
 #include "omnicore/convert.h"
 #include "omnicore/dex.h"
 #include "omnicore/fees.h"
@@ -817,10 +818,15 @@ int CMPTransaction::logicHelper_CrowdsaleParticipation()
 
     // Credit tokens for this fundraiser
     if (tokens.first > 0) {
-        assert(update_tally_map(sender, pcrowdsale->getPropertyId(), tokens.first, BALANCE));
+        assert(update_tally_map(sender, pcrowdsale->getPropertyId(), tokens.first, BALANCE, txid, "Crowdsale Purchase", strprintf("%s line %d",__FUNCTION__,__LINE__)));
     }
     if (tokens.second > 0) {
-        assert(update_tally_map(receiver, pcrowdsale->getPropertyId(), tokens.second, BALANCE));
+        assert(update_tally_map(receiver, pcrowdsale->getPropertyId(), tokens.second, BALANCE, txid, "Crowdsale Purchase", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+    }
+
+    // notify the auditor that we've created some tokens
+    if (auditorEnabled) {
+        Auditor_NotifyPropertyTotalChanged(OMNI_AUDITOR_INCREASE, pcrowdsale->getPropertyId(), tokens.first+tokens.second, "Crowdsale Purchase (txid: " + txid.GetHex() + ")");
     }
 
     // Close crowdsale, if we hit MAX_TOKENS
@@ -878,8 +884,8 @@ int CMPTransaction::logicMath_SimpleSend()
     }
 
     // Move the tokens
-    assert(update_tally_map(sender, property, -nValue, BALANCE));
-    assert(update_tally_map(receiver, property, nValue, BALANCE));
+    assert(update_tally_map(sender, property, -nValue, BALANCE, txid, "Simple Send", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+    assert(update_tally_map(receiver, property, nValue, BALANCE, txid, "Simple Send", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
     // Is there an active crowdsale running from this recepient?
     logicHelper_CrowdsaleParticipation();
@@ -975,9 +981,10 @@ int CMPTransaction::logicMath_SendToOwners()
 
     // ------------------------------------------
 
-    assert(update_tally_map(sender, feeProperty, -transferFee, BALANCE));
+    assert(update_tally_map(sender, feeProperty, -transferFee, BALANCE, txid, "Send To Owners Fee", strprintf("%s line %d",__FUNCTION__,__LINE__)));
     if (version == MP_TX_PKT_V0) {
-        // v0 - do not credit the subtracted fee to any tally (ie burn the tokens)
+        // v0 - do not credit the subtracted fee to any tally (ie burn the tokens) - notify auditor
+        if (auditorEnabled) Auditor_NotifyPropertyTotalChanged(OMNI_AUDITOR_DECREASE, feeProperty, transferFee, "Send To Owners Fee (txid: " + txid.GetHex() + ")");
     } else {
         // v1 - credit the subtracted fee to the fee cache
         p_feecache->AddFee(feeProperty, block, transferFee);
@@ -992,8 +999,8 @@ int CMPTransaction::logicMath_SendToOwners()
         sent_so_far += will_really_receive;
 
         // real execution of the loop
-        assert(update_tally_map(sender, property, -will_really_receive, BALANCE));
-        assert(update_tally_map(address, property, will_really_receive, BALANCE));
+        assert(update_tally_map(sender, property, -will_really_receive, BALANCE, txid, "Send To Owners", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+        assert(update_tally_map(address, property, will_really_receive, BALANCE, txid, "Send To Owners", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
         // add to stodb
         s_stolistdb->recordSTOReceive(address, txid, block, property, will_really_receive);
@@ -1052,8 +1059,8 @@ int CMPTransaction::logicMath_SendAll()
         int64_t moneyAvailable = ptally->getMoney(propertyId, BALANCE);
         if (moneyAvailable > 0) {
             ++numberOfPropertiesSent;
-            assert(update_tally_map(sender, propertyId, -moneyAvailable, BALANCE));
-            assert(update_tally_map(receiver, propertyId, moneyAvailable, BALANCE));
+            assert(update_tally_map(sender, propertyId, -moneyAvailable, BALANCE, txid, "Send All", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+            assert(update_tally_map(receiver, propertyId, moneyAvailable, BALANCE, txid, "Send All", strprintf("%s line %d",__FUNCTION__,__LINE__)));
             p_txlistdb->recordSendAllSubRecord(txid, numberOfPropertiesSent, propertyId, moneyAvailable);
         }
     }
@@ -1454,7 +1461,15 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
 
     const uint32_t propertyId = _my_sps->putSP(ecosystem, newSP);
     assert(propertyId > 0);
-    assert(update_tally_map(sender, propertyId, nValue, BALANCE));
+    if (auditorEnabled) {
+        Auditor_NotifyPropertyCreated(propertyId);
+    }
+
+    assert(update_tally_map(sender, propertyId, nValue, BALANCE,  txid, "Fixed property issuance", strprintf("%s line %d",__FUNCTION__,__LINE__)));
+
+    if (auditorEnabled) {
+        Auditor_NotifyPropertyTotalChanged(OMNI_AUDITOR_INCREASE, propertyId, nValue, "Fixed issuance (txid: " + txid.GetHex() + ")");
+    }
 
     return 0;
 }
@@ -1558,6 +1573,11 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
 
     PrintToLog("CREATED CROWDSALE id: %d value: %d property: %d\n", propertyId, nValue, property);
 
+    // notify the auditor that we've created a new token
+    if (auditorEnabled) {
+        Auditor_NotifyPropertyCreated(propertyId);
+    }
+
     return 0;
 }
 
@@ -1619,7 +1639,7 @@ int CMPTransaction::logicMath_CloseCrowdsale()
 
     assert(_my_sps->updateSP(property, sp));
     if (missedTokens > 0) {
-        assert(update_tally_map(sp.issuer, property, missedTokens, BALANCE));
+        assert(update_tally_map(sp.issuer, property, missedTokens, BALANCE, txid, "Close crowdsale (fractional catchup)", strprintf("%s line %d",__FUNCTION__,__LINE__)));
     }
     my_crowds.erase(it);
 
@@ -1688,6 +1708,11 @@ int CMPTransaction::logicMath_CreatePropertyManaged()
     assert(propertyId > 0);
 
     PrintToLog("CREATED MANUAL PROPERTY id: %d admin: %s\n", propertyId, sender);
+
+    // notify the auditor that we've created a new token
+    if (auditorEnabled) {
+        Auditor_NotifyPropertyCreated(propertyId);
+    }
 
     return 0;
 }
@@ -1762,13 +1787,18 @@ int CMPTransaction::logicMath_GrantTokens()
     // Persist the number of granted tokens
     assert(_my_sps->updateSP(property, sp));
 
+    // notify the auditor that we've granted some tokens
+    if (auditorEnabled) {
+        Auditor_NotifyPropertyTotalChanged(OMNI_AUDITOR_INCREASE, property, nValue, "Grant (txid: " + txid.GetHex() + ")");
+    }
+
     // Special case: if can't find the receiver -- assume grant to self!
     if (receiver.empty()) {
         receiver = sender;
     }
 
     // Move the tokens
-    assert(update_tally_map(receiver, property, nValue, BALANCE));
+    assert(update_tally_map(receiver, property, nValue, BALANCE, txid, "Token Grant", strprintf("%s line %d",__FUNCTION__,__LINE__)));
 
     /**
      * As long as the feature to disable the side effects of "granting tokens"
@@ -1844,8 +1874,11 @@ int CMPTransaction::logicMath_RevokeTokens()
     sp.historicalData.insert(std::make_pair(txid, dataPt));
     sp.update_block = blockHash;
 
-    assert(update_tally_map(sender, property, -nValue, BALANCE));
+    assert(update_tally_map(sender, property, -nValue, BALANCE, txid, "Token Revoke", strprintf("%s line %d",__FUNCTION__,__LINE__)));
     assert(_my_sps->updateSP(property, sp));
+
+    // notify the auditor that we've revoked some tokens
+    if (auditorEnabled) Auditor_NotifyPropertyTotalChanged(OMNI_AUDITOR_DECREASE, property, nValue, "Revoke (txid: " + txid.GetHex() + ")");
 
     return 0;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -107,6 +107,8 @@ bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
 /** Flag to indicate, whether the Omni Core log file should be reopened. */
 volatile bool fReopenOmniCoreLog = false;
+/** Flag to indicate, whether the audit log file should be reopened. */
+volatile bool fReopenAuditLog = false;
 
 /** Init OpenSSL library multithreading support */
 static CCriticalSection** ppmutexOpenSSL;

--- a/src/util.h
+++ b/src/util.h
@@ -39,6 +39,8 @@ extern bool fLogIPs;
 extern volatile bool fReopenDebugLog;
 /** Flag to indicate, whether the Omni Core log file should be reopened. */
 extern volatile bool fReopenOmniCoreLog;
+/** Flag to indicate, whether the audit log file should be reopened. */
+extern volatile bool fReopenAuditLog;
 
 void SetupEnvironment();
 


### PR DESCRIPTION
Please do not merge.

This is a placeholder for my work to bring the Auditor back to life (see https://github.com/OmniLayer/omnicore/pull/18).

General description from previous PR:

> In a nutshell, the auditor maintains a series of caches for certain data from the state and then verifies this data has not changed unexpectedly during processing of a block.

> The auditor is currently capable of detecting the following scenarios:

> * Property tokens created out of thin air. The auditor is notified when tokens are intentionally created in the state (such as by an issuance or a grant). If the number of tokens for a property increases without the auditor being notified (for example from a math error) the auditor will spot this.
> * Tokens disappearing. Basically the reverse of the above - things like revokes and fee burns can notify the auditor of a reduction in tokens for a property, but the auditor will raise a fail if the number of tokens drops unexpectedly.
> * Properties appearing/disappearing/non-sequential property creations. Again, pretty much the same logic - intentional property creations are notified to the auditor, so if property counts increase/decrease unexpectedly the auditor can spot this.
> * MetaDEx trades with zero values. Basically illegal values such as zero price, zero amount for sale,
zero amount desired etc appearing in the metadex maps will be spotted by the auditor.
> * MetaDEx trades where the unit price has changed. Unit prices are not supposed to change as per spec, so the auditor tracks the original price for each trade and makes sure that partial trades are not affecting the price.
> * (WIP) MetaDEx trades that are crossed (should have matched) but were not traded. This is a bit rough around the edges, uses pricing to determine highest "buy" (inverse market) against lowest sell.

> The auditor is thus able to identify these scenarios and we are able to see why the audit has failed, what block and in most cases what txid has triggered the issue. Idea being to complement the work the testing guys are doing and reduce the time spent identifying bugs so we can spend more time on diagnosis/remediation.

