### PR TITLE
Change the number of signatures for deactivation to 3

### DIFF
--- a/src/omnicore/activation.cpp
+++ b/src/omnicore/activation.cpp
@@ -180,4 +180,56 @@ bool CheckActivationAuthorization(const std::string& sender)
     return fAuthorized;
 }
 
+/**
+ * Determines whether the sender is an authorized source to deactivate features.
+ *
+ * The custom options "-omniactivationallowsender=source" and "-omniactivationignoresender=source" are also applied to deactivations.
+ */
+
+bool CheckDeactivationAuthorization(const std::string& sender)
+{
+    std::set<std::string> whitelisted;
+
+    // Mainnet - 3 out of 5 signatures required from developers & board members
+    /*
+    "address" : "34kwkVRSvFVEoUwcQSgpQ4ZUasuZ54DJLD",
+    "script" : "multisig",
+    "sigsrequired" : 3,
+    "addresses" : [
+      "1883ZMsRJfzKNozUBJBTCxQ7EaiNioNDWz", // Zathras - zathras@omni.foundation - Project maintainer, developer
+      "1HHv91gRxqBzQ3gydMob3LU8hqXcWoLfvd", // dexx - dexx@bitwatch.co - Project maintainer, developer
+      "1oyvGmABkeFRUECn2t8DEZPes6F7Gsc9T", // J.R. Willett - jr@omni.foundation - Founder and Board Member
+      "17xr7sbehYY4YSZX9yuJe6gK9rrdRrZx26", // Craig Sellars - craig@omni.foundation - Technologist and Board Member
+      "16oDZYCspsczfgKXVj3xyvsxH21NpEj94F" // Adam Chamely - adam@omni.foundation - Project maintainer, developer
+    ],
+    */
+    whitelisted.insert("34kwkVRSvFVEoUwcQSgpQ4ZUasuZ54DJLD");
+
+    // Testnet / Regtest
+    // use -omniactivationallowsender for testing
+
+    // Add manually whitelisted sources - custom sources affect both activation and deactivation
+    if (mapArgs.count("-omniactivationallowsender")) {
+        const std::vector<std::string>& sources = mapMultiArgs["-omniactivationallowsender"];
+
+        for (std::vector<std::string>::const_iterator it = sources.begin(); it != sources.end(); ++it) {
+            whitelisted.insert(*it);
+        }
+    }
+
+    // Remove manually ignored sources - custom sources affect both activation and deactivation
+    if (mapArgs.count("-omniactivationignoresender")) {
+        const std::vector<std::string>& sources = mapMultiArgs["-omniactivationignoresender"];
+
+        for (std::vector<std::string>::const_iterator it = sources.begin(); it != sources.end(); ++it) {
+            whitelisted.erase(*it);
+        }
+    }
+
+    bool fAuthorized = (whitelisted.count(sender) ||
+                        whitelisted.count("any"));
+
+    return fAuthorized;
+}
+
 }

--- a/src/omnicore/activation.h
+++ b/src/omnicore/activation.h
@@ -21,6 +21,8 @@ struct FeatureActivation
 
 /** Determines whether the sender is an authorized source for Omni Core activations. */
 bool CheckActivationAuthorization(const std::string& sender);
+/** Determines whether the sender is an authorized source to deactivate features. */
+bool CheckDeactivationAuthorization(const std::string& sender);
 /** Returns the vector of pending activations */
 std::vector<FeatureActivation> GetPendingActivations();
 /** Returns the vector of completed activations */

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1949,8 +1949,8 @@ int CMPTransaction::logicMath_Deactivation()
         return (PKT_ERROR -22);
     }
 
-    // is sender authorized - temporarily use alert auths but ## TO BE MOVED TO FOUNDATION P2SH KEY ##
-    bool authorized = CheckActivationAuthorization(sender);
+    // is sender authorized
+    bool authorized = CheckDeactivationAuthorization(sender);
 
     PrintToLog("\t          sender: %s\n", sender);
     PrintToLog("\t      authorized: %s\n", authorized);


### PR DESCRIPTION
It was agreed at this mornings meeting that activation allows more time for signing than an emergency deactivation, and as such the number of signatories required is reduced from 4 to 3.