### PR TITLE
Sanitize RPC responses and replace non-UTF-8 compliant characters

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -483,6 +483,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug) {
         strUsage += HelpMessageOpt("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE));
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
+        strUsage += HelpMessageOpt("-rpcforceutf8", strprintf("Replace invalid UTF-8 encoded characters with question marks in RPC response (default: %d)", 1));
     }
 
     // TODO: append help messages somewhere else


### PR DESCRIPTION
RPC responses, which go through the RPC server, are sanitized, and invalid characters, or character sequences, are replaced with question marks '?'. This is enabled by default.

The PR resolves #438 and is essentially a port of #177.

It can be tested by starting `omnicored -rpcforceutf8=0`, then `omnicore-cli omni_getproperty 2147483662`, which should result in a failure. Without `-rpcforceutf8`, or the default `-rpcforceutf8=1`, there should be a valid, sanitized result.