### PR TITLE
Set minimum fee distribution threshold and protect against empty distributions

### DIFF
--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -36,6 +36,10 @@ int64_t COmniFeeCache::GetDistributionThreshold(const uint32_t &propertyId)
 void COmniFeeCache::UpdateDistributionThresholds(uint32_t propertyId)
 {
     int64_t distributionThreshold = getTotalTokens(propertyId) / OMNI_FEE_THRESHOLD;
+    if (distributionThreshold <= 0) {
+        // protect against zero valued thresholds for low token count properties
+        distributionThreshold = 1;
+    }
     distributionThresholds[propertyId] = distributionThreshold;
 }
 

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -181,6 +181,10 @@ void COmniFeeCache::DistributeCache(const uint32_t &propertyId, int block)
 
     int64_t cachedAmount = GetCachedAmount(propertyId);
 
+    if (cachedAmount == 0) {
+        PrintToLog("Aborting fee distribution for property %d, the fee cache is empty!\n", propertyId);
+    }
+
     OwnerAddrType receiversSet;
     if (isTestEcosystemProperty(propertyId)) {
         receiversSet = STO_GetReceivers("FEEDISTRIBUTION", OMNI_PROPERTY_TMSC, cachedAmount);


### PR DESCRIPTION
This PR sets a minimum fee distribution threshold value of 1 and protects against empty fee distributions.

With the current `OMNI_FEE_THRESHOLD` value, a property with less than 100,000 tokens is currently calculated as having a fee distribution threshold of zero.  

To test simply create a property with less than 100,000 tokens and call `omni_getfeetrigger` to see:

```
    {
        "propertyid" : 3,
        "feetrigger" : "0"
    }
```

`EvalCache()` checks to see if the amount cached is >= to the distribution threshold (zero) thus it would always believe it is time to do a distribution regardless of whether the fee cache has any tokens in it.  

Attempting a distribution with an empty fee cache means passing a zero into `STO_GetReceivers()` and subsequently making a request for a divide by zero during the STO math.  Thankfully @dexx has a check in `DivideAndRoundUp()` to prevent executing that divide by zero so we don't crash out, but we would record an empty fee distribution assigned to no recipients over and over.

This PR sets a minimum distribution threshold of one, and adds a check in DistributeCache() to ensure there is an amount to distribute before proceeding.

Thanks
Z