### PR TITLE
Check for fee distribution when total number of tokens is changed

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -420,7 +420,7 @@ bool mastercore::update_tally_map(const std::string& who, uint32_t propertyId, i
  * @param nTime  The timestamp of the block to update the "Dev MSC" for
  * @return The number of "Dev MSC" generated
  */
-static int64_t calculate_and_update_devmsc(unsigned int nTime)
+static int64_t calculate_and_update_devmsc(unsigned int nTime, int block)
 {
     // do nothing if before end of fundraiser
     if (nTime < 1377993874) return 0;
@@ -455,7 +455,7 @@ static int64_t calculate_and_update_devmsc(unsigned int nTime)
         exodus_prev = devmsc;
     }
 
-    NotifyTotalTokensChanged(OMNI_PROPERTY_MSC);
+    NotifyTotalTokensChanged(OMNI_PROPERTY_MSC, block);
 
     return exodus_delta;
 }
@@ -470,7 +470,7 @@ uint32_t mastercore::GetNextPropertyId(bool maineco)
 }
 
 // Perform any actions that need to be taken when the total number of tokens for a property ID changes
-void NotifyTotalTokensChanged(uint32_t propertyId)
+void NotifyTotalTokensChanged(uint32_t propertyId, int block)
 {
     p_feecache->UpdateDistributionThresholds(propertyId);
 }
@@ -3766,7 +3766,7 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     }
 
     // calculate devmsc as of this block and update the Exodus' balance
-    devmsc = calculate_and_update_devmsc(pBlockIndex->GetBlockTime());
+    devmsc = calculate_and_update_devmsc(pBlockIndex->GetBlockTime(), nBlockNow);
 
     if (msc_debug_exo) {
         int64_t balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -473,6 +473,7 @@ uint32_t mastercore::GetNextPropertyId(bool maineco)
 void NotifyTotalTokensChanged(uint32_t propertyId, int block)
 {
     p_feecache->UpdateDistributionThresholds(propertyId);
+    p_feecache->EvalCache(propertyId, block);
 }
 
 void CheckWalletUpdate(bool forceUpdate)

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -303,7 +303,7 @@ int mastercore_shutdown();
 void CheckWalletUpdate(bool forceUpdate = false);
 
 /** Used to notify that the number of tokens for a property has changed. */
-void NotifyTotalTokensChanged(uint32_t propertyId);
+void NotifyTotalTokensChanged(uint32_t propertyId, int block);
 
 int mastercore_handler_disc_begin(int nBlockNow, CBlockIndex const * pBlockIndex);
 int mastercore_handler_disc_end(int nBlockNow, CBlockIndex const * pBlockIndex);

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -846,7 +846,7 @@ int CMPTransaction::logicHelper_CrowdsaleParticipation()
     }
 
     // Number of tokens has changed, update fee distribution thresholds
-    NotifyTotalTokensChanged(pcrowdsale->getPropertyId());
+    NotifyTotalTokensChanged(pcrowdsale->getPropertyId(), block);
 
     // Close crowdsale, if we hit MAX_TOKENS
     if (close_crowdsale) {
@@ -1034,7 +1034,7 @@ int CMPTransaction::logicMath_SendToOwners()
     assert(sent_so_far == (int64_t)nValue);
 
     // Number of tokens has changed, update fee distribution thresholds
-    if (version == MP_TX_PKT_V0) NotifyTotalTokensChanged(OMNI_PROPERTY_MSC); // fee was burned
+    if (version == MP_TX_PKT_V0) NotifyTotalTokensChanged(OMNI_PROPERTY_MSC, block); // fee was burned
 
     return 0;
 }
@@ -1484,7 +1484,7 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
     assert(propertyId > 0);
     assert(update_tally_map(sender, propertyId, nValue, BALANCE));
 
-    NotifyTotalTokensChanged(propertyId);
+    NotifyTotalTokensChanged(propertyId, block);
 
     return 0;
 }
@@ -1809,7 +1809,7 @@ int CMPTransaction::logicMath_GrantTokens()
         logicHelper_CrowdsaleParticipation();
     }
 
-    NotifyTotalTokensChanged(property);
+    NotifyTotalTokensChanged(property, block);
 
     return 0;
 }
@@ -1879,7 +1879,7 @@ int CMPTransaction::logicMath_RevokeTokens()
     assert(update_tally_map(sender, property, -nValue, BALANCE));
     assert(_my_sps->updateSP(property, sp));
 
-    NotifyTotalTokensChanged(property);
+    NotifyTotalTokensChanged(property, block);
 
     return 0;
 }


### PR DESCRIPTION
This PR requests that the fee cache amount be evaluated against the distribution threshold when there has been a change in the number of tokens.

Currently it is considered that the only path during which the amount of fees cached for a property would cross the distribution threshold would be when the amount in the cache is being increased.  As such the evaluation of the amount of fees against the distribution threshold only occurs during `AddFee()`.

However given the distribution threshold is a function of the total number of tokens and `OMNI_FEE_THRESHOLD` then there is a scenario whereby a revoke on a managed property reduces the total number of tokens and thus in turn reduces the distribution threshold.  In this case the amount of fees cached may now be sufficient to trigger a distribution.

There is thus a path outside of `AddFee()` where distribution should occur & this PR allows for that.

I believe this scenario is unlikely but felt I should still attempt to cover it.

Thanks
Z