### PR TITLE
Fix missing include of test utils header

### DIFF
--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -1,4 +1,5 @@
-OMNICORE_TEST_H = 
+OMNICORE_TEST_H = \
+  omnicore/test/utils_tx.h
 
 OMNICORE_TEST_CPP = \
   omnicore/test/alert_tests.cpp \


### PR DESCRIPTION
During the port of the 0.13 code base, I missed to include the header `utils_tx.h`, which now causes the Gitian builds to fail.

This pull request adds the missing header to the makefile.