### PR TITLE
Fix two Omni Core related build warnings

### DIFF
--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1981,10 +1981,10 @@ int CMPTransaction::logicMath_Deactivation()
 
     // successful deactivation - did we deactivate the MetaDEx?  If so close out all trades
     if (feature_id == FEATURE_METADEX) {
-        int closed = MetaDEx_SHUTDOWN();
+        MetaDEx_SHUTDOWN();
     }
     if (feature_id == FEATURE_TRADEALLPAIRS) {
-        int closed = MetaDEx_SHUTDOWN_ALLPAIR();
+        MetaDEx_SHUTDOWN_ALLPAIR();
     }
 
     return 0;

--- a/src/omnicore/utils.cpp
+++ b/src/omnicore/utils.cpp
@@ -43,7 +43,7 @@ void PrepareObfuscatedHashes(const std::string& strSeed, int hashCount, std::str
     if (hashCount > MAX_SHA256_OBFUSCATION_TIMES) hashCount = MAX_SHA256_OBFUSCATION_TIMES;
 
     // Do only as many re-hashes as there are data packets, 255 per specification
-    for (unsigned int j = 1; j <= hashCount; ++j)
+    for (int j = 1; j <= hashCount; ++j)
     {
         SHA256(sha_input, strlen((const char *)sha_input), sha_result);
         vec_chars.resize(32);


### PR DESCRIPTION
While building, I noticed the following two warnings:

```
omnicore/utils.cpp: In function ‘void PrepareObfuscatedHashes(const string&, int, std::string (&)[256])’:
omnicore/utils.cpp:46:35: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (unsigned int j = 1; j <= hashCount; ++j)
                                   ^
  CXX      omnicore/libbitcoin_server_a-utilsbitcoin.o
  CXX      omnicore/libbitcoin_server_a-version.o
  AR       libbitcoin_common.a
  CXX      support/libbitcoin_util_a-pagelocker.o
omnicore/tx.cpp: In member function ‘int CMPTransaction::logicMath_Deactivation()’:
omnicore/tx.cpp:1984:13: warning: unused variable ‘closed’ [-Wunused-variable]
         int closed = MetaDEx_SHUTDOWN();
             ^
omnicore/tx.cpp:1987:13: warning: unused variable ‘closed’ [-Wunused-variable]
         int closed = MetaDEx_SHUTDOWN_ALLPAIR();
             ^
```

There are more warnings, but the others are not from Omni code.