### PR TITLE
Provide easy access to specific consensus hashes when parsing

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -504,6 +504,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-omniactivationallowsender", "Whitelist senders of activations");
     strUsage += HelpMessageOpt("-disclaimer", "Explicitly show QT disclaimer on startup (default: 0)");
     strUsage += HelpMessageOpt("-omniuiwalletscope", "Max. transactions to show in trade and transaction history (default: 65535)");
+    strUsage += HelpMessageOpt("-omnishowblockconsensushash", "Calculate and log the consensus hash for the specified block");
 
     return strUsage;
 }

--- a/src/omnicore/consensushash.cpp
+++ b/src/omnicore/consensushash.cpp
@@ -9,6 +9,7 @@
 #include "omnicore/mdex.h"
 #include "omnicore/log.h"
 #include "omnicore/omnicore.h"
+#include "omnicore/parse_string.h"
 #include "omnicore/sp.h"
 
 #include "arith_uint256.h"
@@ -23,6 +24,27 @@
 
 namespace mastercore
 {
+bool ShouldConsensusHashBlock(int block) {
+    if (msc_debug_consensus_hash_every_block) {
+        return true;
+    }
+
+    if (!mapArgs.count("-omnishowblockconsensushash")) {
+        return false;
+    }
+
+    const std::vector<std::string>& vecBlocks = mapMultiArgs["-omnishowblockconsensushash"];
+    for (std::vector<std::string>::const_iterator it = vecBlocks.begin(); it != vecBlocks.end(); ++it) {
+        int64_t paramBlock = StrToInt64(*it, false);
+        if (paramBlock < 1) continue; // ignore non numeric values
+        if (paramBlock == block) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // Generates a consensus string for hashing based on a tally object
 std::string GenerateConsensusString(const CMPTally& tallyObj, const std::string& address, const uint32_t propertyId)
 {

--- a/src/omnicore/consensushash.h
+++ b/src/omnicore/consensushash.h
@@ -5,6 +5,9 @@
 
 namespace mastercore
 {
+/** Checks if a given block should be consensus hashed. */
+bool ShouldConsensusHashBlock(int block);
+
 /** Obtains a hash of all balances to use for consensus verification and checkpointing. */
 uint256 GetConsensusHash();
 

--- a/src/omnicore/doc/configuration.md
+++ b/src/omnicore/doc/configuration.md
@@ -43,6 +43,7 @@ More information about the general configuration and Bitcoin Core specific optio
 | `omnitxcache`                | number       | `500000`       | the maximum number of transactions in the input transaction cache               |
 | `omniprogressfrequency`      | number       | `30`           | time in seconds after which the initial scanning progress is reported           |
 | `omniseedblockfilter`        | boolean      | `1`            | set skipping of blocks without Omni transactions during initial scan            |
+| `omnishowblockconsensushash` | number       | `0`            | calculate and log the consensus hash for the specified block                    |
 
 #### Log options:
 
@@ -57,7 +58,7 @@ More information about the general configuration and Bitcoin Core specific optio
 |------------------------------|--------------|----------------|---------------------------------------------------------------------------------|
 | `autocommit`                 | boolean      | `1`            | enable or disable broadcasting of transactions, when creating transactions      |
 | `datacarrier`                | boolean      | `1`            | if disabled, payloads are embedded multisig, and not in `OP_RETURN` scripts     |
-| `datacarriersize`            | number       | `40`           | the maximum size in byte of payloads embedded in `OP_RETURN` scripts            |
+| `datacarriersize`            | number       | `80`           | the maximum size in byte of payloads embedded in `OP_RETURN` scripts            |
 
 **Note:** the options `-datacarrier` and `datacarriersize` affect the global relay policies of transactions with `OP_RETURN` scripts.
 

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3781,7 +3781,7 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     if (countMP > 0) CheckWalletUpdate(true);
 
     // calculate and print a consensus hash if required
-    if (msc_debug_consensus_hash_every_block) {
+    if (ShouldConsensusHashBlock(nBlockNow)) {
         uint256 consensusHash = GetConsensusHash();
         PrintToLog("Consensus hash for block %d: %s\n", nBlockNow, consensusHash.GetHex());
     }


### PR DESCRIPTION
This PR adds a debug option to specify which blocks to generate a consensus hash for during parsing.

Previously to confirm a consensus hash for a particular block it was required to enable `-omnidebug=consensus_hash_every_block` during parsing to log the hash for every block which caused a significant slow down due to the extra work involved.

This leads to circumstances where to validate a single consensus hash it is neccessary to perform vastly more work than necessary.

This PR adds a `-omnishowblockconsensushash` startup option which can be used to generate consensus hashes for specific blocks.

For example, to validate the checkpoint for block 450,000 without using seed block filtering we can use:

```
./omnicored --startclean --omniseedblockfilter=false --omnishowblockconsensushash=450000
```
Which will then cause a consensus hash to be generated for the corresponding block and written to the log.  Multiple instances of the parameter can be used to specify multiple blocks to generate consensus hashes for.

