### PR TITLE
Provide history for all addresses (not just those in the wallet)

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2549,6 +2549,20 @@ uint32_t COmniTransactionDB::FetchTransactionPosition(const uint256& txid)
     return posInBlock;
 }
 
+
+void COmniTransactionDB::printAll()
+{
+    int count = 0;
+    Iterator* it = NewIterator();
+
+    for (it->SeekToFirst(); it->Valid(); it->Next()) {
+        ++count;
+        PrintToConsole("entry #%8d= %s:%s\n", count, it->key().ToString(), it->value().ToString());
+    }
+
+    delete it;
+}
+
 std::set<int> CMPTxList::GetSeedBlocks(int startHeight, int endHeight)
 {
     std::set<int> setSeedBlocks;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2498,7 +2498,7 @@ std::map<std::string, uint256> COmniTransactionDB::FetchAddressTransactions(std:
         std::vector<std::string> vstr;
         std::string strValue = it->value().ToString();
         boost::split(vstr, strValue, boost::is_any_of(":"), boost::token_compress_on);
-        if (vstr.size() != 4) continue;
+        assert(vstr.size() == 4);
         if (address == vstr[2] || address == vstr[3]) {
             uint256 txHash = uint256S(it->key().ToString());
             int block = boost::lexical_cast<int>(vstr[0]);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3103,6 +3103,15 @@ unsigned int n_found = 0;
 }
 
 // MPSTOList here
+std::string CMPSTOList::getAddressSTOReceipts(std::string address)
+{
+  if (!pdb) return "";
+
+  std::string strValue;
+  leveldb::Status status = pdb->Get(readoptions, address, &strValue);
+  return strValue;
+}
+
 std::string CMPSTOList::getMySTOReceipts(string filterAddress)
 {
   if (!pdb) return "";

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -180,6 +180,7 @@ public:
     void RecordTransaction(const uint256& txid, int block, uint32_t posInBlock, std::string senderAddress, std::string referenceAddress);
     uint32_t FetchTransactionPosition(const uint256& txid);
     std::map<std::string, uint256> FetchAddressTransactions(std::string address, int count, int startBlock, int endBlock);
+    void printAll();
 };
 
 /** LevelDB based storage for STO recipients.

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -198,6 +198,7 @@ public:
     }
 
     void getRecipients(const uint256 txid, string filterAddress, UniValue *recipientArray, uint64_t *total, uint64_t *numRecipients);
+    std::string getAddressSTOReceipts(std::string address);
     std::string getMySTOReceipts(string filterAddress);
     int deleteAboveBlock(int blockNum);
     void printStats();

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -179,6 +179,7 @@ public:
      */
     void RecordTransaction(const uint256& txid, int block, uint32_t posInBlock, std::string senderAddress, std::string referenceAddress);
     uint32_t FetchTransactionPosition(const uint256& txid);
+    std::map<std::string, uint256> FetchAddressTransactions(std::string address, int count, int startBlock, int endBlock);
 };
 
 /** LevelDB based storage for STO recipients.

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -36,7 +36,7 @@ int const MAX_STATE_HISTORY = 50;
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 
 // increment this value to force a refresh of the state (similar to --startclean)
-#define DB_VERSION 3
+#define DB_VERSION 4
 
 // could probably also use: int64_t maxInt64 = std::numeric_limits<int64_t>::max();
 // maximum numeric values from the spec:
@@ -177,7 +177,7 @@ public:
      *
      * and so on...
      */
-    void RecordTransaction(const uint256& txid, uint32_t posInBlock);
+    void RecordTransaction(const uint256& txid, int block, uint32_t posInBlock, std::string senderAddress, std::string referenceAddress);
     uint32_t FetchTransactionPosition(const uint256& txid);
 };
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1748,11 +1748,16 @@ UniValue omni_gethistory(const UniValue& params, bool fHelp)
 
     // iterate backwards (most recent first) over transactions map and decode each one, adding to response array
     UniValue response(UniValue::VARR);
+    int64_t nAdded = 0;
     for (std::map<std::string,uint256>::reverse_iterator it = mapTransactions.rbegin(); it != mapTransactions.rend(); it++) {
         uint256 txHash = it->second;
         UniValue txobj(UniValue::VOBJ);
         int populateResult = populateRPCTransactionObject(txHash, txobj, address);
-        if (0 == populateResult) response.push_back(txobj);
+        if (0 == populateResult) {
+            response.push_back(txobj);
+            nAdded++;
+        }
+        if (nAdded >= nCount) break;
     }
 
     return response;

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1737,10 +1737,10 @@ UniValue omni_gethistory(const UniValue& params, bool fHelp)
     if (params.size() > 1) nCount = params[1].get_int64();
     if (nCount < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
     int64_t nStartBlock = 0;
-    if (params.size() > 3) nStartBlock = params[3].get_int64();
+    if (params.size() > 2) nStartBlock = params[2].get_int64();
     if (nStartBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative start block");
     int64_t nEndBlock = 999999;
-    if (params.size() > 4) nEndBlock = params[4].get_int64();
+    if (params.size() > 3) nEndBlock = params[3].get_int64();
     if (nEndBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative end block");
 
     // obtain a sorted list of Omni layer transactions for the address (including STO receipts)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -135,6 +135,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getfeetrigger", 0 },
     { "omni_getfeedistribution", 0 },
     { "omni_getfeedistributions", 0 },
+    { "omni_gethistory", 1 },
+    { "omni_gethistory", 2 },
+    { "omni_gethistory", 3 },
 
     /* Omni Core - transaction calls */
     { "omni_send", 2 },


### PR DESCRIPTION
This PR serves to provide the capability to retrieve transaction history for any address.  Currently it is only possible to retrieve transaction history for addresses in the wallet.

This capability should ease integration for many cases.

A new call `omni_gethistory` operates similarly to `omni_listtransactions` (which is wallet only).  An address is supplied and by default the 10 most recent transactions are provided.  Count, start and end block parameters are optional for refining the results and expanding to more than the default 10 transactions.

Note: whilst locating the transactions for an address is fast, decoding them is just as usual.  As such it is possible to use these calls irresponsibly - for example if `omni_gethistory` was called with an address containing thousands of historic transactions and further the count parameter was explicitly set to say 99999, Omni Core would need to do so much work to generate the response a timeout from RPC is more likely than a response to the query.

Note, this PR is fully functional but is also a prototype. Needs to be cleaned up before taking it on for real.
