### PR TITLE
Show newest transactions for omni_gettradehistoryforaddress

### DIFF
--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1421,7 +1421,7 @@ UniValue omni_gettradehistoryforaddress(const UniValue& params, bool fHelp)
     // Populate the address trade history into JSON objects until we have processed count transactions
     UniValue response(UniValue::VARR);
     uint32_t processed = 0;
-    for(std::vector<uint256>::iterator it = vecTransactions.begin(); it != vecTransactions.end(); ++it) {
+    for(std::vector<uint256>::reverse_iterator it = vecTransactions.rbegin(); it != vecTransactions.rend(); ++it) {
         UniValue txobj(UniValue::VOBJ);
         int populateResult = populateRPCTransactionObject(*it, txobj, "", true);
         if (0 == populateResult) {


### PR DESCRIPTION
This PR amends the behaviour of `omni_gettradehistoryforaddress` to return newest transactions first instead of oldest.

As this is a change in the output for the call, we'll need to make a note in the release notes.