### PR TITLE
Automatically remove stale pending transactions 

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3777,6 +3777,9 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     // check the alert status, do we need to do anything else here?
     CheckExpiredAlerts(nBlockNow, pBlockIndex->GetBlockTime());
 
+    // check that pending transactions are still in the mempool
+    PendingCheck();
+
     // transactions were found in the block, signal the UI accordingly
     if (countMP > 0) CheckWalletUpdate(true);
 

--- a/src/omnicore/pending.h
+++ b/src/omnicore/pending.h
@@ -24,6 +24,10 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, uint16_t
 
 /** Deletes a transaction from the pending map and credits the amount back to the pending tally for the address. */
 void PendingDelete(const uint256& txid);
+
+/** Performs a check to ensure all pending transactions are still in the mempool. */
+void PendingCheck();
+
 }
 
 /** Structure to hold information about pending transactions.


### PR DESCRIPTION
During a recent support issue it became evident that it is possible for a pending transaction to become stale (eg if orphaned) and thus never removed from the `PendingMap`.  This causes the balance provided at the RPC layer to be incorrect until the issue is discovered and the node restarted (the `PendingMap` is not persisted).

This PR adds an automatic check which removes transactions from the `PendingMap` if they have been removed from the mempool.

The change can be demonstrated using regtest.  First we'll send a transaction to create a pending entry:

```
$ omni_send mpGRoxX1pQwGWfxEzMDjZ9ihx6kh3eErju mpv4tJcAcSFodJJfM5DkWxNAKgNRdrdtH8 1 10
602f381ff5fb0a9fde3624fcabe7c53b058911234509480ac3f06285777720c4
```
```
2017-03-14 06:49:42 PendingAdd(602f381ff5fb0a9fde3624fcabe7c53b058911234509480ac3f06285777720c4,mpGRoxX1pQwGWfxEzMDjZ9ihx6kh3eErju,0,1,1000000000,true)
2017-03-14 06:49:42 update_tally_map(mpGRoxX1pQwGWfxEzMDjZ9ihx6kh3eErju, 1=0x1, -1000000000, ttype=3): before=0, after=-1000000000
```

We can check that the transaction is now pending:
```
$ omni_listpendingtransactions
[
  {
    "txid": "602f381ff5fb0a9fde3624fcabe7c53b058911234509480ac3f06285777720c4",
    "fee": "0.00008100",
    "sendingaddress": "mpGRoxX1pQwGWfxEzMDjZ9ihx6kh3eErju",
    "referenceaddress": "mpv4tJcAcSFodJJfM5DkWxNAKgNRdrdtH8",
    "ismine": true,
    "version": 0,
    "type_int": 0,
    "type": "Simple Send",
    "propertyid": 1,
    "divisible": true,
    "amount": "10.00000000",
    "confirmations": 0
  }
]
```

Now let's empty the mempool:
```
clearmempool
[
  "602f381ff5fb0a9fde3624fcabe7c53b058911234509480ac3f06285777720c4"
]
```

We can then check that the transaction is no longer pending:
```
omni_listpendingtransactions
[
]
```

Finally we can mine a block, and confirm that the missing pending transaction has been detected, deleted and the amount credited back to the tally:
```
generate 1
[
  "4e12052669793f3f06b6bd618516c3f739295ca2933f67440296ee7462ca9095"
]
```
```
2017-03-14 06:52:24 WARNING: Pending transaction 602f381ff5fb0a9fde3624fcabe7c53b058911234509480ac3f06285777720c4 is no longer in this nodes mempool and will be discarded
2017-03-14 06:52:24 PendingDelete(602f381ff5fb0a9fde3624fcabe7c53b058911234509480ac3f06285777720c4): amount=-1000000000
2017-03-14 06:52:24 update_tally_map(mpGRoxX1pQwGWfxEzMDjZ9ihx6kh3eErju, 1=0x1, +1000000000, ttype=3): before=-1000000000, after=0
```

Thanks
Z