### PR TITLE
Fix possible lock contention in omni_getactivedexsells

### DIFF
--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1527,6 +1527,8 @@ UniValue omni_getactivedexsells(const UniValue& params, bool fHelp)
 
     UniValue response(UniValue::VARR);
 
+    int curBlock = GetHeight();
+
     LOCK(cs_tally);
 
     for (OfferMap::iterator it = my_offers.begin(); it != my_offers.end(); ++it) {
@@ -1581,7 +1583,7 @@ UniValue omni_getactivedexsells(const UniValue& params, bool fHelp)
                 // split acceptCombo out to get the buyer address
                 std::string buyer = acceptCombo.substr((acceptCombo.find("+") + 1), (acceptCombo.size()-(acceptCombo.find("+") + 1)));
                 int blockOfAccept = accept.getAcceptBlock();
-                int blocksLeftToPay = (blockOfAccept + selloffer.getBlockTimeLimit()) - GetHeight();
+                int blocksLeftToPay = (blockOfAccept + selloffer.getBlockTimeLimit()) - curBlock;
                 int64_t amountAccepted = accept.getAcceptAmountRemaining();
                 // TODO: don't recalculate!
                 int64_t amountToPayInBTC = calculateDesiredBTC(accept.getOfferAmountOriginal(), accept.getBTCDesiredOriginal(), amountAccepted);


### PR DESCRIPTION
This PR fixes a rare DExv1 bug that can cause lock contention when a new block is connected while the `omni_getactivedexsells` RPC is processing accept offers.

This has only been seen in the wild at Omni Explorer (where the RPCs are hit very frequently) AFAIK.  

For verification, the following regtest script will simulate the mining of blocks and the calling of `omni_getactivedexsells` at the same time with high frequency to trigger this bug, and will reliably crash an Omni Core node that does not have the fix noted in this PR.

Thanks 
Z

```
#!/bin/bash

SRCDIR=./src/
NUL=/dev/null
PASS=0
FAIL=0
clear
printf "Preparing a test environment...\n"
printf "   * Starting a fresh regtest daemon\n"
rm -r ~/.bitcoin/regtest
$SRCDIR/omnicored --regtest --server --daemon >$NUL
sleep 3
printf "   * Preparing some mature testnet BTC\n"
$SRCDIR/omnicore-cli --regtest generate 102 >$NUL
printf "   * Obtaining a master address to work with\n"
ADDR=$($SRCDIR/omnicore-cli --regtest getnewaddress OMNIAccount)
printf "   * Funding the address with some testnet BTC for fees\n"
$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 20 >$NUL
$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
ADDR2=$($SRCDIR/omnicore-cli --regtest getnewaddress ACCEPTAccount)
printf "   * Participating in the Exodus crowdsale to obtain some OMNI\n"
JSON="{\"moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP\":10,\""$ADDR"\":4,\""$ADDR2"\":2}"
$SRCDIR/omnicore-cli --regtest sendmany OMNIAccount $JSON >$NUL
$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
printf "   * Creating a sell offer from the master address\n"
$SRCDIR/omnicore-cli --regtest omni_senddexsell $ADDR 1 "11.5" "0.75" 25 "0.0005" 1 >$NUL
$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
printf "   * Accepting the sell offer\n"
$SRCDIR/omnicore-cli --regtest omni_senddexaccept $ADDR2 $ADDR 1 10 >$NUL
$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
printf "\nNow spawning a separate thread to call omni_getactivedexsells in a loop, while we mine blocks here\n"
printf "There should be 100x 'GET' and 100x 'MINE' events, followed by a 'Reached the end of the test' note\n"
printf "Starting...\n"
loopscript=`mktemp /tmp/.script.XXXXXX`;
cat >$loopscript <<END
for i in {1..100}
do
  printf "GET,"
  ./src/omnicore-cli --regtest omni_getactivedexsells >$NUL
done
END
chmod u+rx $loopscript
$loopscript &
for i in {1..100}
do
  printf "MINE,"
  $SRCDIR/omnicore-cli --regtest generate 1 >$NUL
done
wait
/bin/rm $loopscript
printf "\nReached the end of the test.\n"
$SRCDIR/omnicore-cli --regtest stop
exit
```