### PR TITLE
Remove managed property check in Change Issuer RPC

### DIFF
--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -1076,7 +1076,6 @@ UniValue omni_sendchangeissuer(const UniValue& params, bool fHelp)
 
     // perform checks
     RequireExistingProperty(propertyId);
-    RequireManagedProperty(propertyId);
     RequireTokenIssuer(fromAddress, propertyId);
 
     // create a payload for the transaction


### PR DESCRIPTION
The 'change issuer' transaction (70) does not require a managed property (according to both the spec and the transaction processing logic within the reference client), however the RPC to send such a transaction enforces that the 'change issuer' transaction may only be used on a managed property.

This PR removes the managed property check to bring the RPC in line with processing rules.

