### PR TITLE
Add Class D support

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -34,6 +34,7 @@ OMNICORE_H = \
   omnicore/uint256_extensions.h \
   omnicore/utils.h \
   omnicore/utilsbitcoin.h \
+  omnicore/varint.h \
   omnicore/version.h \
   omnicore/walletcache.h \
   omnicore/wallettxs.h
@@ -72,6 +73,7 @@ OMNICORE_CPP = \
   omnicore/tx.cpp \
   omnicore/utils.cpp \
   omnicore/utilsbitcoin.cpp \
+  omnicore/varint.cpp \
   omnicore/version.cpp \
   omnicore/walletcache.cpp \
   omnicore/wallettxs.cpp

--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -10,6 +10,7 @@ OMNICORE_TEST_CPP = \
   omnicore/test/dex_purchase_tests.cpp \
   omnicore/test/encoding_b_tests.cpp \
   omnicore/test/encoding_c_tests.cpp \
+  omnicore/test/encoding_d_tests.cpp \
   omnicore/test/exodus_tests.cpp \
   omnicore/test/lock_tests.cpp \
   omnicore/test/marker_tests.cpp \

--- a/src/omnicore/createpayload.cpp
+++ b/src/omnicore/createpayload.cpp
@@ -3,6 +3,7 @@
 #include "omnicore/createpayload.h"
 
 #include "omnicore/convert.h"
+#include "omnicore/varint.h"
 
 #include "tinyformat.h"
 
@@ -25,128 +26,207 @@
     reinterpret_cast<unsigned char *>((ptr)) + (size));
 
 
-std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount)
+std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount, bool compress)
 {
     std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 0;
     uint16_t messageType = 0;
-    uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
-    mastercore::swapByteOrder64(amount);
 
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
-    PUSH_BACK_BYTES(payload, amount);
-
-    return payload;
-}
-
-std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem)
-{
-    std::vector<unsigned char> payload;
-    uint16_t messageVer = 0;
-    uint16_t messageType = 4;
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, ecosystem);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        std::vector<uint8_t> vecAmount = CompressInteger(amount);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+        payload.insert(payload.end(), vecAmount.begin(), vecAmount.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyId);
+        mastercore::swapByteOrder64(amount);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+        PUSH_BACK_BYTES(payload, amount);
+    }
 
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction)
-{
-    std::vector<unsigned char> payload;
-    uint16_t messageType = 20;
-    uint16_t messageVer = 1;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
-    mastercore::swapByteOrder64(amountForSale);
-    mastercore::swapByteOrder64(amountDesired);
-    mastercore::swapByteOrder64(minFee);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
-    PUSH_BACK_BYTES(payload, amountForSale);
-    PUSH_BACK_BYTES(payload, amountDesired);
-    PUSH_BACK_BYTES(payload, timeLimit);
-    PUSH_BACK_BYTES(payload, minFee);
-    PUSH_BACK_BYTES(payload, subAction);
-
-    return payload;
-}
-
-std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount)
-{
-    std::vector<unsigned char> payload;
-    uint16_t messageType = 22;
-    uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
-    mastercore::swapByteOrder64(amount);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
-    PUSH_BACK_BYTES(payload, amount);
-
-    return payload;
-}
-
-std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty)
+std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty, bool compress)
 {
     bool v0 = (propertyId == distributionProperty) ? true : false;
 
     std::vector<unsigned char> payload;
 
-    uint16_t messageType = 3;
     uint16_t messageVer = (v0) ? 0 : 1;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
-    mastercore::swapByteOrder64(amount);
+    uint16_t messageType = 3;
 
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
-    PUSH_BACK_BYTES(payload, amount);
-    if (!v0) {
-        mastercore::swapByteOrder32(distributionProperty);
-        PUSH_BACK_BYTES(payload, distributionProperty);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        std::vector<uint8_t> vecAmount = CompressInteger(amount);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+        payload.insert(payload.end(), vecAmount.begin(), vecAmount.end());
+        if (!v0) {
+            std::vector<uint8_t> vecDistributionProperty = CompressInteger(distributionProperty);
+            payload.insert(payload.end(), vecDistributionProperty.begin(), vecDistributionProperty.end());
+        }
+    } else {
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder32(propertyId);
+        mastercore::swapByteOrder64(amount);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+        PUSH_BACK_BYTES(payload, amount);
+        if (!v0) {
+            mastercore::swapByteOrder32(distributionProperty);
+            PUSH_BACK_BYTES(payload, distributionProperty);
+        }
+    }
+
+    return payload;
+}
+
+std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem, bool compress)
+{
+    std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 0;
+    uint16_t messageType = 4;
+
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        PUSH_BACK_BYTES(payload, ecosystem);
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, ecosystem);
+    }
+
+    return payload;
+}
+
+std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction, bool compress)
+{
+    std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 1;
+    uint16_t messageType = 20;
+
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        std::vector<uint8_t> vecAmountForSale = CompressInteger(amountForSale);
+        std::vector<uint8_t> vecAmountDesired = CompressInteger(amountDesired);
+        std::vector<uint8_t> vecMinFee = CompressInteger(minFee);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+        payload.insert(payload.end(), vecAmountForSale.begin(), vecAmountForSale.end());
+        payload.insert(payload.end(), vecAmountDesired.begin(), vecAmountDesired.end());
+        PUSH_BACK_BYTES(payload, timeLimit);
+        payload.insert(payload.end(), vecMinFee.begin(), vecMinFee.end());
+        PUSH_BACK_BYTES(payload, subAction);
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyId);
+        mastercore::swapByteOrder64(amountForSale);
+        mastercore::swapByteOrder64(amountDesired);
+        mastercore::swapByteOrder64(minFee);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+        PUSH_BACK_BYTES(payload, amountForSale);
+        PUSH_BACK_BYTES(payload, amountDesired);
+        PUSH_BACK_BYTES(payload, timeLimit);
+        PUSH_BACK_BYTES(payload, minFee);
+        PUSH_BACK_BYTES(payload, subAction);
+    }
+
+    return payload;
+}
+
+std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount, bool compress)
+{
+    std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 0;
+    uint16_t messageType = 22;
+
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        std::vector<uint8_t> vecAmount = CompressInteger(amount);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+        payload.insert(payload.end(), vecAmount.begin(), vecAmount.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyId);
+        mastercore::swapByteOrder64(amount);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+        PUSH_BACK_BYTES(payload, amount);
     }
 
     return payload;
 }
 
 std::vector<unsigned char> CreatePayload_IssuanceFixed(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
-                                                       std::string subcategory, std::string name, std::string url, std::string data, uint64_t amount)
+                                                       std::string subcategory, std::string name, std::string url, std::string data, uint64_t amount, bool compress)
 {
     std::vector<unsigned char> payload;
-    uint16_t messageType = 50;
+
     uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(propertyType);
-    mastercore::swapByteOrder32(previousPropertyId);
-    mastercore::swapByteOrder64(amount);
+    uint16_t messageType = 50;
+
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger(messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger(messageType);
+        std::vector<uint8_t> vecPropertyType = CompressInteger(propertyType);
+        std::vector<uint8_t> vecPrevPropertyId = CompressInteger(previousPropertyId);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        PUSH_BACK_BYTES(payload, ecosystem);
+        payload.insert(payload.end(), vecPropertyType.begin(), vecPropertyType.end());
+        payload.insert(payload.end(), vecPrevPropertyId.begin(), vecPrevPropertyId.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder16(propertyType);
+        mastercore::swapByteOrder32(previousPropertyId);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, ecosystem);
+        PUSH_BACK_BYTES(payload, propertyType);
+        PUSH_BACK_BYTES(payload, previousPropertyId);
+    }
+
     if (category.size() > 255) category = category.substr(0,255);
     if (subcategory.size() > 255) subcategory = subcategory.substr(0,255);
     if (name.size() > 255) name = name.substr(0,255);
     if (url.size() > 255) url = url.substr(0,255);
     if (data.size() > 255) data = data.substr(0,255);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, ecosystem);
-    PUSH_BACK_BYTES(payload, propertyType);
-    PUSH_BACK_BYTES(payload, previousPropertyId);
     payload.insert(payload.end(), category.begin(), category.end());
     payload.push_back('\0');
     payload.insert(payload.end(), subcategory.begin(), subcategory.end());
@@ -157,36 +237,54 @@ std::vector<unsigned char> CreatePayload_IssuanceFixed(uint8_t ecosystem, uint16
     payload.push_back('\0');
     payload.insert(payload.end(), data.begin(), data.end());
     payload.push_back('\0');
-    PUSH_BACK_BYTES(payload, amount);
+
+    if (compress) {
+        std::vector<uint8_t> vecAmount = CompressInteger(amount);
+        payload.insert(payload.end(), vecAmount.begin(), vecAmount.end());
+    } else {
+        mastercore::swapByteOrder64(amount);
+        PUSH_BACK_BYTES(payload, amount);
+    }
 
     return payload;
 }
 
 std::vector<unsigned char> CreatePayload_IssuanceVariable(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
                                                           std::string subcategory, std::string name, std::string url, std::string data, uint32_t propertyIdDesired,
-                                                          uint64_t amountPerUnit, uint64_t deadline, uint8_t earlyBonus, uint8_t issuerPercentage)
+                                                          uint64_t amountPerUnit, uint64_t deadline, uint8_t earlyBonus, uint8_t issuerPercentage, bool compress)
 {
     std::vector<unsigned char> payload;
-    uint16_t messageType = 51;
+
     uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(propertyType);
-    mastercore::swapByteOrder32(previousPropertyId);
-    mastercore::swapByteOrder32(propertyIdDesired);
-    mastercore::swapByteOrder64(amountPerUnit);
-    mastercore::swapByteOrder64(deadline);
+    uint16_t messageType = 51;
+
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger(messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger(messageType);
+        std::vector<uint8_t> vecPropertyType = CompressInteger(propertyType);
+        std::vector<uint8_t> vecPrevPropertyId = CompressInteger(previousPropertyId);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        PUSH_BACK_BYTES(payload, ecosystem);
+        payload.insert(payload.end(), vecPropertyType.begin(), vecPropertyType.end());
+        payload.insert(payload.end(), vecPrevPropertyId.begin(), vecPrevPropertyId.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder16(propertyType);
+        mastercore::swapByteOrder32(previousPropertyId);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, ecosystem);
+        PUSH_BACK_BYTES(payload, propertyType);
+        PUSH_BACK_BYTES(payload, previousPropertyId);
+    }
+
     if (category.size() > 255) category = category.substr(0,255);
     if (subcategory.size() > 255) subcategory = subcategory.substr(0,255);
     if (name.size() > 255) name = name.substr(0,255);
     if (url.size() > 255) url = url.substr(0,255);
     if (data.size() > 255) data = data.substr(0,255);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, ecosystem);
-    PUSH_BACK_BYTES(payload, propertyType);
-    PUSH_BACK_BYTES(payload, previousPropertyId);
     payload.insert(payload.end(), category.begin(), category.end());
     payload.push_back('\0');
     payload.insert(payload.end(), subcategory.begin(), subcategory.end());
@@ -197,36 +295,90 @@ std::vector<unsigned char> CreatePayload_IssuanceVariable(uint8_t ecosystem, uin
     payload.push_back('\0');
     payload.insert(payload.end(), data.begin(), data.end());
     payload.push_back('\0');
-    PUSH_BACK_BYTES(payload, propertyIdDesired);
-    PUSH_BACK_BYTES(payload, amountPerUnit);
-    PUSH_BACK_BYTES(payload, deadline);
+
+    if (compress) {
+        std::vector<uint8_t> vecPropertyIdDesired = CompressInteger(propertyIdDesired);
+        std::vector<uint8_t> vecAmountPerUnit = CompressInteger(amountPerUnit);
+        std::vector<uint8_t> vecDeadline = CompressInteger(deadline);
+        payload.insert(payload.end(), vecPropertyIdDesired.begin(), vecPropertyIdDesired.end());
+        payload.insert(payload.end(), vecAmountPerUnit.begin(), vecAmountPerUnit.end());
+        payload.insert(payload.end(), vecDeadline.begin(), vecDeadline.end());
+    } else {
+        mastercore::swapByteOrder32(propertyIdDesired);
+        mastercore::swapByteOrder64(amountPerUnit);
+        mastercore::swapByteOrder64(deadline);
+        PUSH_BACK_BYTES(payload, propertyIdDesired);
+        PUSH_BACK_BYTES(payload, amountPerUnit);
+        PUSH_BACK_BYTES(payload, deadline);
+    }
+
     PUSH_BACK_BYTES(payload, earlyBonus);
     PUSH_BACK_BYTES(payload, issuerPercentage);
 
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_IssuanceManaged(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
-                                                       std::string subcategory, std::string name, std::string url, std::string data)
+std::vector<unsigned char> CreatePayload_CloseCrowdsale(uint32_t propertyId, bool compress)
 {
     std::vector<unsigned char> payload;
-    uint16_t messageType = 54;
+
     uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(propertyType);
-    mastercore::swapByteOrder32(previousPropertyId);
+    uint16_t messageType = 53;
+
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyId);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+    }
+
+    return payload;
+}
+
+std::vector<unsigned char> CreatePayload_IssuanceManaged(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
+                                                       std::string subcategory, std::string name, std::string url, std::string data, bool compress)
+{
+    std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 0;
+    uint16_t messageType = 54;
+
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger(messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger(messageType);
+        std::vector<uint8_t> vecPropertyType = CompressInteger(propertyType);
+        std::vector<uint8_t> vecPrevPropertyId = CompressInteger(previousPropertyId);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        PUSH_BACK_BYTES(payload, ecosystem);
+        payload.insert(payload.end(), vecPropertyType.begin(), vecPropertyType.end());
+        payload.insert(payload.end(), vecPrevPropertyId.begin(), vecPrevPropertyId.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder16(propertyType);
+        mastercore::swapByteOrder32(previousPropertyId);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, ecosystem);
+        PUSH_BACK_BYTES(payload, propertyType);
+        PUSH_BACK_BYTES(payload, previousPropertyId);
+    }
+
     if (category.size() > 255) category = category.substr(0,255);
     if (subcategory.size() > 255) subcategory = subcategory.substr(0,255);
     if (name.size() > 255) name = name.substr(0,255);
     if (url.size() > 255) url = url.substr(0,255);
     if (data.size() > 255) data = data.substr(0,255);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, ecosystem);
-    PUSH_BACK_BYTES(payload, propertyType);
-    PUSH_BACK_BYTES(payload, previousPropertyId);
     payload.insert(payload.end(), category.begin(), category.end());
     payload.push_back('\0');
     payload.insert(payload.end(), subcategory.begin(), subcategory.end());
@@ -241,37 +393,34 @@ std::vector<unsigned char> CreatePayload_IssuanceManaged(uint8_t ecosystem, uint
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_CloseCrowdsale(uint32_t propertyId)
+std::vector<unsigned char> CreatePayload_Grant(uint32_t propertyId, uint64_t amount, std::string memo, bool compress)
 {
     std::vector<unsigned char> payload;
-    uint16_t messageType = 53;
+
     uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
-
-    return payload;
-}
-
-std::vector<unsigned char> CreatePayload_Grant(uint32_t propertyId, uint64_t amount, std::string memo)
-{
-    std::vector<unsigned char> payload;
     uint16_t messageType = 55;
-    uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
-    mastercore::swapByteOrder64(amount);
-    if (memo.size() > 255) memo = memo.substr(0,255);
 
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
-    PUSH_BACK_BYTES(payload, amount);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        std::vector<uint8_t> vecAmount = CompressInteger(amount);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+        payload.insert(payload.end(), vecAmount.begin(), vecAmount.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyId);
+        mastercore::swapByteOrder64(amount);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+        PUSH_BACK_BYTES(payload, amount);
+    }
+
+    if (memo.size() > 255) memo = memo.substr(0,255);
     payload.insert(payload.end(), memo.begin(), memo.end());
     payload.push_back('\0');
 
@@ -279,127 +428,201 @@ std::vector<unsigned char> CreatePayload_Grant(uint32_t propertyId, uint64_t amo
 }
 
 
-std::vector<unsigned char> CreatePayload_Revoke(uint32_t propertyId, uint64_t amount, std::string memo)
+std::vector<unsigned char> CreatePayload_Revoke(uint32_t propertyId, uint64_t amount, std::string memo, bool compress)
 {
     std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 0;
     uint16_t messageType = 56;
-    uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
-    mastercore::swapByteOrder64(amount);
-    if (memo.size() > 255) memo = memo.substr(0,255);
 
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
-    PUSH_BACK_BYTES(payload, amount);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        std::vector<uint8_t> vecAmount = CompressInteger(amount);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+        payload.insert(payload.end(), vecAmount.begin(), vecAmount.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyId);
+        mastercore::swapByteOrder64(amount);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+        PUSH_BACK_BYTES(payload, amount);
+    }
+
+    if (memo.size() > 255) memo = memo.substr(0,255);
     payload.insert(payload.end(), memo.begin(), memo.end());
     payload.push_back('\0');
 
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_ChangeIssuer(uint32_t propertyId)
+std::vector<unsigned char> CreatePayload_ChangeIssuer(uint32_t propertyId, bool compress)
 {
     std::vector<unsigned char> payload;
+
+    uint16_t messageVer = 0;
     uint16_t messageType = 70;
-    uint16_t messageVer = 0;
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder32(propertyId);
 
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyId);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyId = CompressInteger((uint64_t)propertyId);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyId.begin(), vecPropertyId.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyId);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyId);
+    }
 
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired)
+std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired, bool compress)
 {
     std::vector<unsigned char> payload;
 
+    uint16_t messageVer = 0;
     uint16_t messageType = 25;
-    uint16_t messageVer = 0;
 
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder32(propertyIdForSale);
-    mastercore::swapByteOrder64(amountForSale);
-    mastercore::swapByteOrder32(propertyIdDesired);
-    mastercore::swapByteOrder64(amountDesired);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyIdForSale);
-    PUSH_BACK_BYTES(payload, amountForSale);
-    PUSH_BACK_BYTES(payload, propertyIdDesired);
-    PUSH_BACK_BYTES(payload, amountDesired);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyIdForSale = CompressInteger((uint64_t)propertyIdForSale);
+        std::vector<uint8_t> vecAmountForSale = CompressInteger(amountForSale);
+        std::vector<uint8_t> vecPropertyIdDesired = CompressInteger((uint64_t)propertyIdDesired);
+        std::vector<uint8_t> vecAmountDesired = CompressInteger(amountDesired);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyIdForSale.begin(), vecPropertyIdForSale.end());
+        payload.insert(payload.end(), vecAmountForSale.begin(), vecAmountForSale.end());
+        payload.insert(payload.end(), vecPropertyIdDesired.begin(), vecPropertyIdDesired.end());
+        payload.insert(payload.end(), vecAmountDesired.begin(), vecAmountDesired.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyIdForSale);
+        mastercore::swapByteOrder64(amountForSale);
+        mastercore::swapByteOrder32(propertyIdDesired);
+        mastercore::swapByteOrder64(amountDesired);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyIdForSale);
+        PUSH_BACK_BYTES(payload, amountForSale);
+        PUSH_BACK_BYTES(payload, propertyIdDesired);
+        PUSH_BACK_BYTES(payload, amountDesired);
+    }
 
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired)
+std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired, bool compress)
 {
     std::vector<unsigned char> payload;
 
+    uint16_t messageVer = 0;
     uint16_t messageType = 26;
-    uint16_t messageVer = 0;
 
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder32(propertyIdForSale);
-    mastercore::swapByteOrder64(amountForSale);
-    mastercore::swapByteOrder32(propertyIdDesired);
-    mastercore::swapByteOrder64(amountDesired);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyIdForSale);
-    PUSH_BACK_BYTES(payload, amountForSale);
-    PUSH_BACK_BYTES(payload, propertyIdDesired);
-    PUSH_BACK_BYTES(payload, amountDesired);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyIdForSale = CompressInteger((uint64_t)propertyIdForSale);
+        std::vector<uint8_t> vecAmountForSale = CompressInteger(amountForSale);
+        std::vector<uint8_t> vecPropertyIdDesired = CompressInteger((uint64_t)propertyIdDesired);
+        std::vector<uint8_t> vecAmountDesired = CompressInteger(amountDesired);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyIdForSale.begin(), vecPropertyIdForSale.end());
+        payload.insert(payload.end(), vecAmountForSale.begin(), vecAmountForSale.end());
+        payload.insert(payload.end(), vecPropertyIdDesired.begin(), vecPropertyIdDesired.end());
+        payload.insert(payload.end(), vecAmountDesired.begin(), vecAmountDesired.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyIdForSale);
+        mastercore::swapByteOrder64(amountForSale);
+        mastercore::swapByteOrder32(propertyIdDesired);
+        mastercore::swapByteOrder64(amountDesired);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyIdForSale);
+        PUSH_BACK_BYTES(payload, amountForSale);
+        PUSH_BACK_BYTES(payload, propertyIdDesired);
+        PUSH_BACK_BYTES(payload, amountDesired);
+    }
 
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdForSale, uint32_t propertyIdDesired)
+std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdForSale, uint32_t propertyIdDesired, bool compress)
 {
     std::vector<unsigned char> payload;
 
+    uint16_t messageVer = 0;
     uint16_t messageType = 27;
-    uint16_t messageVer = 0;
 
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-    mastercore::swapByteOrder32(propertyIdForSale);
-    mastercore::swapByteOrder32(propertyIdDesired);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, propertyIdForSale);
-    PUSH_BACK_BYTES(payload, propertyIdDesired);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        std::vector<uint8_t> vecPropertyIdForSale = CompressInteger((uint64_t)propertyIdForSale);
+        std::vector<uint8_t> vecPropertyIdDesired = CompressInteger((uint64_t)propertyIdDesired);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        payload.insert(payload.end(), vecPropertyIdForSale.begin(), vecPropertyIdForSale.end());
+        payload.insert(payload.end(), vecPropertyIdDesired.begin(), vecPropertyIdDesired.end());
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        mastercore::swapByteOrder32(propertyIdForSale);
+        mastercore::swapByteOrder32(propertyIdDesired);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, propertyIdForSale);
+        PUSH_BACK_BYTES(payload, propertyIdDesired);
+    }
 
     return payload;
 }
 
-std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem)
+std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem, bool compress)
 {
     std::vector<unsigned char> payload;
 
-    uint16_t messageType = 28;
     uint16_t messageVer = 0;
+    uint16_t messageType = 28;
 
-    mastercore::swapByteOrder16(messageVer);
-    mastercore::swapByteOrder16(messageType);
-
-    PUSH_BACK_BYTES(payload, messageVer);
-    PUSH_BACK_BYTES(payload, messageType);
-    PUSH_BACK_BYTES(payload, ecosystem);
+    if (compress) {
+        std::vector<uint8_t> vecMessageVer = CompressInteger((uint64_t)messageVer);
+        std::vector<uint8_t> vecMessageType = CompressInteger((uint64_t)messageType);
+        payload.insert(payload.end(), vecMessageVer.begin(), vecMessageVer.end());
+        payload.insert(payload.end(), vecMessageType.begin(), vecMessageType.end());
+        PUSH_BACK_BYTES(payload, ecosystem);
+    } else {
+        mastercore::swapByteOrder16(messageVer);
+        mastercore::swapByteOrder16(messageType);
+        PUSH_BACK_BYTES(payload, messageVer);
+        PUSH_BACK_BYTES(payload, messageType);
+        PUSH_BACK_BYTES(payload, ecosystem);
+    }
 
     return payload;
 }
+
+/**
+ *  Omni Layer Management Functions
+ *
+ *  These functions support the feature activation and alert system and require authorization to use.
+ */
 
 std::vector<unsigned char> CreatePayload_DeactivateFeature(uint16_t featureId)
 {

--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -5,26 +5,26 @@
 #include <vector>
 #include <stdint.h>
 
-std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount);
-std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem);
-std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction);
-std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount);
-std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty);
+std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount, bool compress=false);
+std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem, bool compress=false);
+std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction, bool compress=false);
+std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount, bool compress=false);
+std::vector<unsigned char> CreatePayload_SendToOwners(uint32_t propertyId, uint64_t amount, uint32_t distributionProperty, bool compress=false);
 std::vector<unsigned char> CreatePayload_IssuanceFixed(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
-                                                       std::string subcategory, std::string name, std::string url, std::string data, uint64_t amount);
+                                                       std::string subcategory, std::string name, std::string url, std::string data, uint64_t amount, bool compress=false);
 std::vector<unsigned char> CreatePayload_IssuanceVariable(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
                                                           std::string subcategory, std::string name, std::string url, std::string data, uint32_t propertyIdDesired,
-                                                          uint64_t amountPerUnit, uint64_t deadline, uint8_t earlyBonus, uint8_t issuerPercentage);
+                                                          uint64_t amountPerUnit, uint64_t deadline, uint8_t earlyBonus, uint8_t issuerPercentage, bool compress=false);
 std::vector<unsigned char> CreatePayload_IssuanceManaged(uint8_t ecosystem, uint16_t propertyType, uint32_t previousPropertyId, std::string category,
-                                                       std::string subcategory, std::string name, std::string url, std::string data);
-std::vector<unsigned char> CreatePayload_CloseCrowdsale(uint32_t propertyId);
-std::vector<unsigned char> CreatePayload_Grant(uint32_t propertyId, uint64_t amount, std::string memo);
-std::vector<unsigned char> CreatePayload_Revoke(uint32_t propertyId, uint64_t amount, std::string memo);
-std::vector<unsigned char> CreatePayload_ChangeIssuer(uint32_t propertyId);
-std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired);
-std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired);
-std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdForSale, uint32_t propertyIdDesired);
-std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem);
+                                                       std::string subcategory, std::string name, std::string url, std::string data, bool compress=false);
+std::vector<unsigned char> CreatePayload_CloseCrowdsale(uint32_t propertyId, bool compress=false);
+std::vector<unsigned char> CreatePayload_Grant(uint32_t propertyId, uint64_t amount, std::string memo, bool compress=false);
+std::vector<unsigned char> CreatePayload_Revoke(uint32_t propertyId, uint64_t amount, std::string memo, bool compress=false);
+std::vector<unsigned char> CreatePayload_ChangeIssuer(uint32_t propertyId, bool compress=false);
+std::vector<unsigned char> CreatePayload_MetaDExTrade(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired, bool compress=false);
+std::vector<unsigned char> CreatePayload_MetaDExCancelPrice(uint32_t propertyIdForSale, uint64_t amountForSale, uint32_t propertyIdDesired, uint64_t amountDesired, bool compress=false);
+std::vector<unsigned char> CreatePayload_MetaDExCancelPair(uint32_t propertyIdForSale, uint32_t propertyIdDesired, bool compress=false);
+std::vector<unsigned char> CreatePayload_MetaDExCancelEcosystem(uint8_t ecosystem, bool compress=false);
 std::vector<unsigned char> CreatePayload_OmniCoreAlert(uint16_t alertType, uint32_t expiryValue, const std::string& alertMessage);
 std::vector<unsigned char> CreatePayload_DeactivateFeature(uint16_t featureId);
 std::vector<unsigned char> CreatePayload_ActivateFeature(uint16_t featureId, uint32_t activationBlock, uint32_t minClientVersion);

--- a/src/omnicore/createtx.cpp
+++ b/src/omnicore/createtx.cpp
@@ -1,6 +1,7 @@
 #include "omnicore/createtx.h"
 
 #include "omnicore/encoding.h"
+#include "omnicore/omnicore.h"
 #include "omnicore/script.h"
 
 #include "base58.h"
@@ -145,7 +146,7 @@ OmniTxBuilder& OmniTxBuilder::addOpReturn(const std::vector<unsigned char>& data
 {
     std::vector<std::pair<CScript, int64_t> > outputs;
 
-    if (!OmniCore_Encode_ClassC(data, outputs)) {
+    if (!OmniCore_Encode_ClassCD(data, outputs, OMNI_CLASS_C)) {
         return *this;
     }
 

--- a/src/omnicore/encoding.cpp
+++ b/src/omnicore/encoding.cpp
@@ -80,11 +80,11 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
  * The request is rejected, if the size of the payload with marker is larger than
  * the allowed data carrier size ("-datacarriersize=n").
  */
-bool OmniCore_Encode_ClassC(const std::vector<unsigned char>& vchPayload,
-        std::vector<std::pair <CScript, int64_t> >& vecOutputs)
+bool OmniCore_Encode_ClassCD(const std::vector<unsigned char>& vchPayload,
+        std::vector<std::pair <CScript, int64_t> >& vecOutputs, int txClass)
 {
     std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchOmBytes = GetOmMarker();
+    std::vector<unsigned char> vchOmBytes = GetOmMarker(txClass);
     vchData.insert(vchData.end(), vchOmBytes.begin(), vchOmBytes.end());
     vchData.insert(vchData.end(), vchPayload.begin(), vchPayload.end());
     if (vchData.size() > nMaxDatacarrierBytes) { return false; }

--- a/src/omnicore/encoding.h
+++ b/src/omnicore/encoding.h
@@ -15,7 +15,7 @@ class CTxOut;
 bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& redeemingPubKey, const std::vector<unsigned char>& vchPayload, std::vector<std::pair<CScript, int64_t> >& vecOutputs);
 
 /** Embedds a payload in an OP_RETURN output, prefixed with a transaction marker. */
-bool OmniCore_Encode_ClassC(const std::vector<unsigned char>& vecPayload, std::vector<std::pair<CScript, int64_t> >& vecOutputs);
+bool OmniCore_Encode_ClassCD(const std::vector<unsigned char>& vecPayload, std::vector<std::pair<CScript, int64_t> >& vecOutputs, int txClass);
 
 
 #endif // OMNICORE_ENCODING_H

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -733,6 +733,11 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
         PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
     }
 
+    if (omniClass == OMNI_CLASS_D && !IsFeatureActivated(FEATURE_CLASS_D, nBlock)) {
+        PrintToLog("%s() REJECT: transaction is Class D but it's not activated yet (txid %s)\n", __func__, wtx.GetHash().GetHex());
+        return -112; // Class D transaction prior to activation
+    }
+
     // Add previous transaction inputs to the cache
     if (!FillTxInputCache(wtx)) {
         PrintToLog("%s() ERROR: failed to get inputs for %s\n", __func__, wtx.GetHash().GetHex());

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -50,6 +50,7 @@ int const MAX_STATE_HISTORY = 50;
 #define OMNI_CLASS_A 1
 #define OMNI_CLASS_B 2
 #define OMNI_CLASS_C 3
+#define OMNI_CLASS_D 4
 
 // Omni Layer Transaction (Packet) Version
 #define MP_TX_PKT_V0  0
@@ -143,8 +144,8 @@ const CBitcoinAddress ExodusAddress();
 /** Returns the Exodus crowdsale address. */
 const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock = 0);
 
-/** Returns the marker for class C transactions. */
-const std::vector<unsigned char> GetOmMarker();
+/** Returns the marker for class C & D transactions. */
+const std::vector<unsigned char> GetOmMarker(int txClass);
 
 //! Used to indicate, whether to automatically commit created transactions
 extern bool autoCommit;
@@ -333,7 +334,8 @@ bool isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound);
 std::string FormatIndivisibleMP(int64_t n);
 
 int WalletTxBuilder(const std::string& senderAddress, const std::string& receiverAddress, const std::string& redemptionAddress,
-                 int64_t referenceAmount, const std::vector<unsigned char>& data, uint256& txid, std::string& rawHex, bool commit, unsigned int minInputs = 1);
+                 int64_t referenceAmount, const std::vector<unsigned char>& data, const std::vector<unsigned char>& compressedData,
+                 uint256& txid, std::string& rawHex, bool commit, unsigned int minInputs = 1);
 
 bool isTestEcosystemProperty(uint32_t propertyId);
 bool isMainEcosystemProperty(uint32_t propertyId);
@@ -348,8 +350,9 @@ std::string strTransactionType(uint16_t txType);
 /** Returns the encoding class, used to embed a payload. */
 int GetEncodingClass(const CTransaction& tx, int nBlock);
 
-/** Determines, whether it is valid to use a Class C transaction for a given payload size. */
+/** Determines, whether it is valid to use a Class C or D transaction for a given payload size. */
 bool UseEncodingClassC(size_t nDataSize);
+bool UseEncodingClassD(size_t nDataSize);
 
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -58,10 +58,12 @@ UniValue omni_sendrawtx(const UniValue& params, bool fHelp)
     std::string redeemAddress = (params.size() > 3) ? ParseAddressOrEmpty(params[3]): "";
     int64_t referenceAmount = (params.size() > 4) ? ParseAmount(params[4], true): 0;
 
+    std::vector<unsigned char> compressedPayload; // raw tx support remains class C only at the moment
+
     //some sanity checking of the data supplied?
     uint256 newTX;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, toAddress, redeemAddress, referenceAmount, data, newTX, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, toAddress, redeemAddress, referenceAmount, data, compressedPayload, newTX, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -112,13 +114,14 @@ UniValue omni_send(const UniValue& params, bool fHelp)
     RequireBalance(fromAddress, propertyId, amount);
     RequireSaneReferenceAmount(referenceAmount);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_SimpleSend(propertyId, amount);
+    std::vector<unsigned char> compressedPayload = CreatePayload_SimpleSend(propertyId, amount, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, toAddress, redeemAddress, referenceAmount, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, toAddress, redeemAddress, referenceAmount, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -166,13 +169,14 @@ UniValue omni_sendall(const UniValue& params, bool fHelp)
     // perform checks
     RequireSaneReferenceAmount(referenceAmount);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_SendAll(ecosystem);
+    std::vector<unsigned char> compressedPayload = CreatePayload_SendAll(ecosystem, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, toAddress, redeemAddress, referenceAmount, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, toAddress, redeemAddress, referenceAmount, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -254,13 +258,14 @@ UniValue omni_senddexsell(const UniValue& params, bool fHelp)
         }
     }
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_DExSell(propertyIdForSale, amountForSale, amountDesired, paymentWindow, minAcceptFee, action);
+    std::vector<unsigned char> compressedPayload = CreatePayload_DExSell(propertyIdForSale, amountForSale, amountDesired, paymentWindow, minAcceptFee, action, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -333,13 +338,14 @@ UniValue omni_senddexaccept(const UniValue& params, bool fHelp)
     // fPayAtLeastCustomFee = true;
 #endif
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_DExAccept(propertyId, amount);
+    std::vector<unsigned char> compressedPayload = CreatePayload_DExAccept(propertyId, amount, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, toAddress, "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, toAddress, "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
 #ifdef ENABLE_WALLET
     // set the custom fee back to original
@@ -411,13 +417,14 @@ UniValue omni_sendissuancecrowdsale(const UniValue& params, bool fHelp)
     RequireExistingProperty(propertyIdDesired);
     RequireSameEcosystem(ecosystem, propertyIdDesired);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceVariable(ecosystem, type, previousId, category, subcategory, name, url, data, propertyIdDesired, numTokens, deadline, earlyBonus, issuerPercentage);
+    std::vector<unsigned char> compressedPayload = CreatePayload_IssuanceVariable(ecosystem, type, previousId, category, subcategory, name, url, data, propertyIdDesired, numTokens, deadline, earlyBonus, issuerPercentage, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -474,13 +481,14 @@ UniValue omni_sendissuancefixed(const UniValue& params, bool fHelp)
     // perform checks
     RequirePropertyName(name);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceFixed(ecosystem, type, previousId, category, subcategory, name, url, data, amount);
+    std::vector<unsigned char> compressedPayload = CreatePayload_IssuanceFixed(ecosystem, type, previousId, category, subcategory, name, url, data, amount, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -535,13 +543,14 @@ UniValue omni_sendissuancemanaged(const UniValue& params, bool fHelp)
     // perform checks
     RequirePropertyName(name);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceManaged(ecosystem, type, previousId, category, subcategory, name, url, data);
+    std::vector<unsigned char> compressedPayload = CreatePayload_IssuanceManaged(ecosystem, type, previousId, category, subcategory, name, url, data, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -588,13 +597,14 @@ UniValue omni_sendsto(const UniValue& params, bool fHelp)
     // perform checks
     RequireBalance(fromAddress, propertyId, amount);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_SendToOwners(propertyId, amount, distributionPropertyId);
+    std::vector<unsigned char> compressedPayload = CreatePayload_SendToOwners(propertyId, amount, distributionPropertyId, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", redeemAddress, 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", redeemAddress, 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -644,13 +654,14 @@ UniValue omni_sendgrant(const UniValue& params, bool fHelp)
     RequireManagedProperty(propertyId);
     RequireTokenIssuer(fromAddress, propertyId);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_Grant(propertyId, amount, memo);
+    std::vector<unsigned char> compressedPayload = CreatePayload_Grant(propertyId, amount, memo, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, toAddress, "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, toAddress, "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -698,13 +709,14 @@ UniValue omni_sendrevoke(const UniValue& params, bool fHelp)
     RequireTokenIssuer(fromAddress, propertyId);
     RequireBalance(fromAddress, propertyId, amount);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_Revoke(propertyId, amount, memo);
+    std::vector<unsigned char> compressedPayload = CreatePayload_Revoke(propertyId, amount, memo, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -748,13 +760,14 @@ UniValue omni_sendclosecrowdsale(const UniValue& params, bool fHelp)
     RequireActiveCrowdsale(propertyId);
     RequireTokenIssuer(fromAddress, propertyId);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_CloseCrowdsale(propertyId);
+    std::vector<unsigned char> compressedPayload = CreatePayload_CloseCrowdsale(propertyId, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -867,13 +880,14 @@ UniValue omni_sendtrade(const UniValue& params, bool fHelp)
     RequireSameEcosystem(propertyIdForSale, propertyIdDesired);
     RequireDifferentIds(propertyIdForSale, propertyIdDesired);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExTrade(propertyIdForSale, amountForSale, propertyIdDesired, amountDesired);
+    std::vector<unsigned char> compressedPayload = CreatePayload_MetaDExTrade(propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -925,13 +939,14 @@ UniValue omni_sendcanceltradesbyprice(const UniValue& params, bool fHelp)
     RequireDifferentIds(propertyIdForSale, propertyIdDesired);
     // TODO: check, if there are matching offers to cancel
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExCancelPrice(propertyIdForSale, amountForSale, propertyIdDesired, amountDesired);
+    std::vector<unsigned char> compressedPayload = CreatePayload_MetaDExCancelPrice(propertyIdForSale, amountForSale, propertyIdDesired, amountDesired, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -979,13 +994,14 @@ UniValue omni_sendcanceltradesbypair(const UniValue& params, bool fHelp)
     RequireDifferentIds(propertyIdForSale, propertyIdDesired);
     // TODO: check, if there are matching offers to cancel
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExCancelPair(propertyIdForSale, propertyIdDesired);
+    std::vector<unsigned char> compressedPayload = CreatePayload_MetaDExCancelPair(propertyIdForSale, propertyIdDesired, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -1027,13 +1043,14 @@ UniValue omni_sendcancelalltrades(const UniValue& params, bool fHelp)
     // perform checks
     // TODO: check, if there are matching offers to cancel
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExCancelEcosystem(ecosystem);
+    std::vector<unsigned char> compressedPayload = CreatePayload_MetaDExCancelEcosystem(ecosystem, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -1079,13 +1096,14 @@ UniValue omni_sendchangeissuer(const UniValue& params, bool fHelp)
     RequireManagedProperty(propertyId);
     RequireTokenIssuer(fromAddress, propertyId);
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_ChangeIssuer(propertyId);
+    std::vector<unsigned char> compressedPayload = CreatePayload_ChangeIssuer(propertyId, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, toAddress, "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, toAddress, "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -1126,11 +1144,12 @@ UniValue omni_sendactivation(const UniValue& params, bool fHelp)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_ActivateFeature(featureId, activationBlock, minClientVersion);
+    std::vector<unsigned char> compressedPayload; // management features will remain class C only until Class D locked in
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -1167,11 +1186,12 @@ UniValue omni_senddeactivation(const UniValue& params, bool fHelp)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_DeactivateFeature(featureId);
+    std::vector<unsigned char> compressedPayload; // management features will remain class C only until Class D locked in
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -1220,11 +1240,12 @@ UniValue omni_sendalert(const UniValue& params, bool fHelp)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_OmniCoreAlert(alertType, expiryValue, alertMessage);
+    std::vector<unsigned char> compressedPayload; // management features will remain class C only until Class D locked in
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -162,6 +162,8 @@ CMainConsensusParams::CMainConsensusParams()
     SCRIPTHASH_BLOCK = 322000;
     MULTISIG_BLOCK = 0;
     NULLDATA_BLOCK = 999999;
+    // Payload related:
+    COMPRESS_PAYLOAD_BLOCK = 999999;
     // Transaction restrictions:
     MSC_ALERT_BLOCK = 0;
     MSC_SEND_BLOCK = 249498;
@@ -200,6 +202,8 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     SCRIPTHASH_BLOCK = 0;
     MULTISIG_BLOCK = 0;
     NULLDATA_BLOCK = 0;
+    // Payload related:
+    COMPRESS_PAYLOAD_BLOCK = 0;
     // Transaction restrictions:
     MSC_ALERT_BLOCK = 0;
     MSC_SEND_BLOCK = 0;
@@ -238,6 +242,8 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     SCRIPTHASH_BLOCK = 0;
     MULTISIG_BLOCK = 0;
     NULLDATA_BLOCK = 0;
+    // Payload related:
+    COMPRESS_PAYLOAD_BLOCK = 999999;
     // Transaction restrictions:
     MSC_ALERT_BLOCK = 0;
     MSC_SEND_BLOCK = 0;
@@ -417,6 +423,9 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
         case FEATURE_STOV1:
             MutableConsensusParams().MSC_STOV1_BLOCK = activationBlock;
         break;
+        case FEATURE_CLASS_D:
+            MutableConsensusParams().COMPRESS_PAYLOAD_BLOCK = activationBlock;
+        break;
         default:
             supported = false;
         break;
@@ -485,6 +494,9 @@ bool DeactivateFeature(uint16_t featureId, int transactionBlock)
         case FEATURE_STOV1:
             MutableConsensusParams().MSC_STOV1_BLOCK = 999999;
         break;
+        case FEATURE_CLASS_D:
+            MutableConsensusParams().COMPRESS_PAYLOAD_BLOCK = 999999;
+        break;
         default:
             return false;
         break;
@@ -515,7 +527,7 @@ std::string GetFeatureName(uint16_t featureId)
         case FEATURE_TRADEALLPAIRS: return "Allow trading all pairs on the Distributed Exchange";
         case FEATURE_FEES: return "Fee system (inc 0.05% fee from trades of non-Omni pairs)";
         case FEATURE_STOV1: return "Cross-property Send To Owners";
-
+        case FEATURE_CLASS_D: return "Class D transaction encoding (compressed payloads)";
         default: return "Unknown feature";
     }
 }
@@ -558,6 +570,9 @@ bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
             break;
         case FEATURE_STOV1:
             activationBlock = params.MSC_STOV1_BLOCK;
+            break;
+        case FEATURE_CLASS_D:
+            activationBlock = params.COMPRESS_PAYLOAD_BLOCK;
             break;
         default:
             return false;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -34,6 +34,8 @@ const uint16_t FEATURE_TRADEALLPAIRS = 8;
 const uint16_t FEATURE_FEES = 9;
 //! Feature identifier to enable cross property (v1) Send To Owners
 const uint16_t FEATURE_STOV1 = 10;
+//! Feature identifier to enable Class D transactions (compressed payloads)
+const uint16_t FEATURE_CLASS_D = 13;
 
 //! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
 const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
@@ -94,6 +96,9 @@ public:
     int MULTISIG_BLOCK;
     //! Block to enable OP_RETURN based encoding
     int NULLDATA_BLOCK;
+
+    //! Block to enable payload compression (class D)
+    int COMPRESS_PAYLOAD_BLOCK;
 
     //! Block to enable alerts and notifications
     int MSC_ALERT_BLOCK;

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -19,6 +19,13 @@ BOOST_AUTO_TEST_CASE(payload_simple_send)
         static_cast<int64_t>(100000000));  // amount to transfer: 1.0 MSC (in willets)
 
     BOOST_CHECK_EQUAL(HexStr(vch), "00000000000000010000000005f5e100");
+
+    vch = CreatePayload_SimpleSend(
+        static_cast<uint32_t>(1),          // property: MSC
+        static_cast<int64_t>(100000000),   // amount to transfer: 1.0 MSC (in willets)
+        true);                             // compress payload
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "00000180c2d72f");
 }
 
 BOOST_AUTO_TEST_CASE(payload_send_to_owners)
@@ -30,6 +37,14 @@ BOOST_AUTO_TEST_CASE(payload_send_to_owners)
         static_cast<uint32_t>(1));         // property: OMNI
 
     BOOST_CHECK_EQUAL(HexStr(vch), "00000003000000010000000005f5e100");
+
+    vch = CreatePayload_SendToOwners(
+        static_cast<uint32_t>(1),          // property: OMNI
+        static_cast<int64_t>(100000000),   // amount to transfer: 1.0 OMNI (in willets)
+        static_cast<uint32_t>(1),          // property: OMNI
+        true);                             // compress payload
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "00030180c2d72f");
 }
 
 BOOST_AUTO_TEST_CASE(payload_send_to_owners_v1)
@@ -41,6 +56,14 @@ BOOST_AUTO_TEST_CASE(payload_send_to_owners_v1)
         static_cast<uint32_t>(3));         // property: SP#3
 
     BOOST_CHECK_EQUAL(HexStr(vch), "00010003000000010000000005f5e10000000003");
+
+    vch = CreatePayload_SendToOwners(
+        static_cast<uint32_t>(1),          // property: OMNI
+        static_cast<int64_t>(100000000),   // amount to transfer: 1.0 OMNI (in willets)
+        static_cast<uint32_t>(3),          // property: SP#3
+        true);                             // compress payload
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "01030180c2d72f03");
 }
 
 BOOST_AUTO_TEST_CASE(payload_send_all)
@@ -50,6 +73,11 @@ BOOST_AUTO_TEST_CASE(payload_send_all)
         static_cast<uint8_t>(2));          // ecosystem: Test
 
     BOOST_CHECK_EQUAL(HexStr(vch), "0000000402");
+
+    vch = CreatePayload_SendAll(
+        static_cast<uint8_t>(2),           // ecosystem: Test
+        true);                             // compress payload
+    BOOST_CHECK_EQUAL(HexStr(vch), "000402");
 }
 
 BOOST_AUTO_TEST_CASE(payload_dex_offer)
@@ -65,6 +93,18 @@ BOOST_AUTO_TEST_CASE(payload_dex_offer)
 
     BOOST_CHECK_EQUAL(HexStr(vch),
         "00010014000000010000000005f5e1000000000001312d000a000000000000271001");
+
+    vch = CreatePayload_DExSell(
+        static_cast<uint32_t>(1),         // property: MSC
+        static_cast<int64_t>(100000000),  // amount to transfer: 1.0 MSC (in willets)
+        static_cast<int64_t>(20000000),   // amount desired: 0.2 BTC (in satoshis)
+        static_cast<uint8_t>(10),         // payment window in blocks
+        static_cast<int64_t>(10000),      // commitment fee in satoshis
+        static_cast<uint8_t>(1),          // sub-action: new offer
+        true);
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "01140180c2d72f80dac4090a904e01");
 }
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_new_trade)
@@ -78,6 +118,16 @@ BOOST_AUTO_TEST_CASE(payload_meta_dex_new_trade)
 
     BOOST_CHECK_EQUAL(HexStr(vch),
         "0000001900000001000000000ee6b2800000001f000000012a05f200");
+
+    vch = CreatePayload_MetaDExTrade(
+        static_cast<uint32_t>(1),          // property: MSC
+        static_cast<int64_t>(250000000),   // amount for sale: 2.5 MSC
+        static_cast<uint32_t>(31),         // property desired: TetherUS
+        static_cast<int64_t>(5000000000),  // amount desired: 50.0 TetherUS
+        true);                             // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "00190180e59a771f80e497d012");
 }
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_at_price)
@@ -91,6 +141,16 @@ BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_at_price)
 
     BOOST_CHECK_EQUAL(HexStr(vch),
         "0000001a00000001000000000ee6b2800000001f000000012a05f200");
+
+    vch = CreatePayload_MetaDExCancelPrice(
+        static_cast<uint32_t>(1),          // property: MSC
+        static_cast<int64_t>(250000000),   // amount for sale: 2.5 MSC
+        static_cast<uint32_t>(31),         // property desired: TetherUS
+        static_cast<int64_t>(5000000000),  // amount desired: 50.0 TetherUS
+        true);                             // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "001a0180e59a771f80e497d012");
 }
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_pair)
@@ -102,6 +162,14 @@ BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_pair)
 
     BOOST_CHECK_EQUAL(HexStr(vch),
         "0000001b000000010000001f");
+
+    vch = CreatePayload_MetaDExCancelPair(
+        static_cast<uint32_t>(1),          // property: MSC
+        static_cast<uint32_t>(31),         // property desired: TetherUS
+        true);                             // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "001b011f");
 }
 
 BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_ecosystem)
@@ -112,6 +180,12 @@ BOOST_AUTO_TEST_CASE(payload_meta_dex_cancel_ecosystem)
 
     BOOST_CHECK_EQUAL(HexStr(vch),
         "0000001c01");
+
+    vch = CreatePayload_MetaDExCancelEcosystem(
+        static_cast<uint8_t>(1),           // ecosystem: Main
+        true);                             // compress
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "001c01");
 }
 
 BOOST_AUTO_TEST_CASE(payload_accept_dex_offer)
@@ -122,6 +196,13 @@ BOOST_AUTO_TEST_CASE(payload_accept_dex_offer)
         static_cast<int64_t>(130000000));  // amount to transfer: 1.3 MSC (in willets)
 
     BOOST_CHECK_EQUAL(HexStr(vch), "00000016000000010000000007bfa480");
+
+    vch = CreatePayload_DExAccept(
+        static_cast<uint32_t>(1),          // property: MSC
+        static_cast<int64_t>(130000000),   // amount to transfer: 1.3 MSC (in willets)
+        true);                             // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "00160180c9fe3d");
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_property)
@@ -142,6 +223,22 @@ BOOST_AUTO_TEST_CASE(payload_create_property)
         "0000003201000100000000436f6d70616e69657300426974636f696e204d696e696e67"
         "005175616e74756d204d696e6572006275696c6465722e62697477617463682e636f00"
         "0000000000000f4240");
+
+    vch = CreatePayload_IssuanceFixed(
+        static_cast<uint8_t>(1),             // ecosystem: main
+        static_cast<uint16_t>(1),            // property type: indivisible tokens
+        static_cast<uint32_t>(0),            // previous property: none
+        std::string("Companies"),            // category
+        std::string("Bitcoin Mining"),       // subcategory
+        std::string("Quantum Miner"),        // label
+        std::string("builder.bitwatch.co"),  // website
+        std::string(""),                     // additional information
+        static_cast<int64_t>(1000000),       // number of units to create
+        true);                               // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "0032010100436f6d70616e69657300426974636f696e204d696e696e67005175616e74"
+        "756d204d696e6572006275696c6465722e62697477617463682e636f0000c0843d");
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_property_empty)
@@ -159,6 +256,20 @@ BOOST_AUTO_TEST_CASE(payload_create_property_empty)
         static_cast<int64_t>(1000000));  // number of units to create
 
     BOOST_CHECK_EQUAL(vch.size(), 24);
+
+    vch = CreatePayload_IssuanceFixed(
+        static_cast<uint8_t>(1),         // ecosystem: main
+        static_cast<uint16_t>(1),        // property type: indivisible tokens
+        static_cast<uint32_t>(0),        // previous property: none
+        std::string(""),                 // category
+        std::string(""),                 // subcategory
+        std::string(""),                 // label
+        std::string(""),                 // website
+        std::string(""),                 // additional information
+        static_cast<int64_t>(1000000),   // number of units to create
+        true);                           // compress
+
+    BOOST_CHECK_EQUAL(vch.size(), 13);
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_property_full)
@@ -200,6 +311,27 @@ BOOST_AUTO_TEST_CASE(payload_create_crowdsale)
         "0000003301000100000000436f6d70616e69657300426974636f696e204d696e696e67"
         "005175616e74756d204d696e6572006275696c6465722e62697477617463682e636f00"
         "0000000001000000000000006400000001ccd403f00a0c");
+
+    vch = CreatePayload_IssuanceVariable(
+        static_cast<uint8_t>(1),             // ecosystem: main
+        static_cast<uint16_t>(1),            // property type: indivisible tokens
+        static_cast<uint32_t>(0),            // previous property: none
+        std::string("Companies"),            // category
+        std::string("Bitcoin Mining"),       // subcategory
+        std::string("Quantum Miner"),        // label
+        std::string("builder.bitwatch.co"),  // website
+        std::string(""),                     // additional information
+        static_cast<uint32_t>(1),            // property desired: MSC
+        static_cast<int64_t>(100),           // tokens per unit vested
+        static_cast<uint64_t>(7731414000L),  // deadline: 31 Dec 2214 23:00:00 UTC
+        static_cast<uint8_t>(10),            // early bird bonus: 10 % per week
+        static_cast<uint8_t>(12),            // issuer bonus: 12 %
+        true);
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "0033010100436f6d70616e69657300426974636f696e204d696e696e67005175616e74"
+        "756d204d696e6572006275696c6465722e62697477617463682e636f00000164f087d0"
+        "e61c0a0c");
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_crowdsale_empty)
@@ -221,6 +353,24 @@ BOOST_AUTO_TEST_CASE(payload_create_crowdsale_empty)
         static_cast<uint8_t>(12));          // issuer bonus: 12 %
 
     BOOST_CHECK_EQUAL(vch.size(), 38);
+
+    vch = CreatePayload_IssuanceVariable(
+        static_cast<uint8_t>(1),            // ecosystem: main
+        static_cast<uint16_t>(1),           // property type: indivisible tokens
+        static_cast<uint32_t>(0),           // previous property: none
+        std::string(""),                    // category
+        std::string(""),                    // subcategory
+        std::string(""),                    // label
+        std::string(""),                    // website
+        std::string(""),                    // additional information
+        static_cast<uint32_t>(1),           // property desired: MSC
+        static_cast<int64_t>(100),          // tokens per unit vested
+        static_cast<uint64_t>(7731414000L), // deadline: 31 Dec 2214 23:00:00 UTC
+        static_cast<uint8_t>(10),           // early bird bonus: 10 % per week
+        static_cast<uint8_t>(12),           // issuer bonus: 12 %
+        true);                              // compress
+
+    BOOST_CHECK_EQUAL(vch.size(), 19);
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_crowdsale_full)
@@ -251,6 +401,12 @@ BOOST_AUTO_TEST_CASE(payload_close_crowdsale)
         static_cast<uint32_t>(9));  // property: SP #9
 
     BOOST_CHECK_EQUAL(HexStr(vch), "0000003500000009");
+
+    vch = CreatePayload_CloseCrowdsale(
+        static_cast<uint32_t>(9),   // property: SP #9
+        true);                      // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "003509");
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_managed_property)
@@ -270,6 +426,21 @@ BOOST_AUTO_TEST_CASE(payload_create_managed_property)
         "0000003601000100000000436f6d70616e69657300426974636f696e204d696e696e67"
         "005175616e74756d204d696e6572006275696c6465722e62697477617463682e636f00"
         "00");
+
+    vch = CreatePayload_IssuanceManaged(
+        static_cast<uint8_t>(1),             // ecosystem: main
+        static_cast<uint16_t>(1),            // property type: indivisible tokens
+        static_cast<uint32_t>(0),            // previous property: none
+        std::string("Companies"),            // category
+        std::string("Bitcoin Mining"),       // subcategory
+        std::string("Quantum Miner"),        // label
+        std::string("builder.bitwatch.co"),  // website
+        std::string(""),                     // additional information
+        true);                               // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "0036010100436f6d70616e69657300426974636f696e204d696e696e67005175616e74"
+        "756d204d696e6572006275696c6465722e62697477617463682e636f0000");
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_managed_property_empty)
@@ -286,6 +457,19 @@ BOOST_AUTO_TEST_CASE(payload_create_managed_property_empty)
         std::string(""));          // additional information
 
     BOOST_CHECK_EQUAL(vch.size(), 16);
+
+    vch = CreatePayload_IssuanceManaged(
+        static_cast<uint8_t>(1),   // ecosystem: main
+        static_cast<uint16_t>(1),  // property type: indivisible tokens
+        static_cast<uint32_t>(0),  // previous property: none
+        std::string(""),           // category
+        std::string(""),           // subcategory
+        std::string(""),           // label
+        std::string(""),           // website
+        std::string(""),           // additional information
+        true);                     // compress
+
+    BOOST_CHECK_EQUAL(vch.size(), 10);
 }
 
 BOOST_AUTO_TEST_CASE(payload_create_managed_property_full)
@@ -315,6 +499,15 @@ BOOST_AUTO_TEST_CASE(payload_grant_tokens)
     BOOST_CHECK_EQUAL(HexStr(vch),
         "000000370000000800000000000003e84669727374204d696c6573746f6e6520526561"
         "636865642100");
+
+    vch = CreatePayload_Grant(
+        static_cast<uint32_t>(8),                  // property: SP #8
+        static_cast<int64_t>(1000),                // number of units to issue
+        std::string("First Milestone Reached!"),   // additional information
+        true);                                     // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "003708e8074669727374204d696c6573746f6e6520526561636865642100");
 }
 
 BOOST_AUTO_TEST_CASE(payload_grant_tokens_empty)
@@ -326,6 +519,14 @@ BOOST_AUTO_TEST_CASE(payload_grant_tokens_empty)
         std::string(""));                          // additional information
 
     BOOST_CHECK_EQUAL(vch.size(), 17);
+
+    vch = CreatePayload_Grant(
+        static_cast<uint32_t>(8),                  // property: SP #8
+        static_cast<int64_t>(1000),                // number of units to issue
+        std::string(""),                           // additional information
+        true);                                     // compress
+
+    BOOST_CHECK_EQUAL(vch.size(), 6);
 }
 
 BOOST_AUTO_TEST_CASE(payload_grant_tokens_full)
@@ -350,6 +551,16 @@ BOOST_AUTO_TEST_CASE(payload_revoke_tokens)
     BOOST_CHECK_EQUAL(HexStr(vch),
         "000000380000000800000000000003e8526564656d7074696f6e206f6620746f6b656e"
         "7320666f7220426f622c205468616e6b7320426f622100");
+
+    vch = CreatePayload_Revoke(
+        static_cast<uint32_t>(8),                                   // property: SP #8
+        static_cast<int64_t>(1000),                                 // number of units to revoke
+        std::string("Redemption of tokens for Bob, Thanks Bob!"),   // additional information
+        true);                                                      // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "003808e807526564656d7074696f6e206f6620746f6b656e7320666f7220426f622c20"
+        "5468616e6b7320426f622100");
 }
 
 BOOST_AUTO_TEST_CASE(payload_revoke_tokens_empty)
@@ -361,6 +572,14 @@ BOOST_AUTO_TEST_CASE(payload_revoke_tokens_empty)
         std::string(""));            // additional information
 
     BOOST_CHECK_EQUAL(vch.size(), 17);
+
+    vch = CreatePayload_Revoke(
+        static_cast<uint32_t>(8),    // property: SP #8
+        static_cast<int64_t>(1000),  // number of units to revoke
+        std::string(""),             // additional information
+        true);                       // compress
+
+    BOOST_CHECK_EQUAL(vch.size(), 6);
 }
 
 BOOST_AUTO_TEST_CASE(payload_revoke_tokens_full)
@@ -381,7 +600,19 @@ BOOST_AUTO_TEST_CASE(payload_change_property_manager)
         static_cast<uint32_t>(13));  // property: SP #13
 
     BOOST_CHECK_EQUAL(HexStr(vch), "000000460000000d");
+
+    vch = CreatePayload_ChangeIssuer(
+        static_cast<uint32_t>(13),   // property: SP #13
+        true);                       // compress
+
+    BOOST_CHECK_EQUAL(HexStr(vch), "00460d");
 }
+
+/**
+ *  Omni Layer Management Functions
+ *
+ *  These functions support the feature activation and alert system and require authorization to use.
+ */
 
 BOOST_AUTO_TEST_CASE(payload_feature_deactivation)
 {

--- a/src/omnicore/test/encoding_d_tests.cpp
+++ b/src/omnicore/test/encoding_d_tests.cpp
@@ -17,9 +17,9 @@
 // Is resetted to a norm value in each test
 extern unsigned nMaxDatacarrierBytes;
 
-BOOST_FIXTURE_TEST_SUITE(omnicore_encoding_c_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(omnicore_encoding_d_tests, BasicTestingSetup)
 
-BOOST_AUTO_TEST_CASE(class_c_marker)
+BOOST_AUTO_TEST_CASE(class_d_marker)
 {
     // Store initial data carrier size
     unsigned nMaxDatacarrierBytesOriginal = nMaxDatacarrierBytes;
@@ -28,15 +28,13 @@ BOOST_AUTO_TEST_CASE(class_c_marker)
 
     std::vector<unsigned char> vchMarker;
     vchMarker.push_back(0x6f); // "o"
-    vchMarker.push_back(0x6d); // "m"
-    vchMarker.push_back(0x6e); // "n"
-    vchMarker.push_back(0x69); // "i"
+    vchMarker.push_back(0x6c); // "l"
 
     std::vector<unsigned char> vchPayload = ParseHex(
-        "00000000000000010000000006dac2c0");
+        "000001e807");
 
     std::vector<std::pair<CScript, int64_t> > vecOutputs;
-    BOOST_CHECK(OmniCore_Encode_ClassCD(vchPayload, vecOutputs, OMNI_CLASS_C));
+    BOOST_CHECK(OmniCore_Encode_ClassCD(vchPayload, vecOutputs, OMNI_CLASS_D));
 
     // One output was created
     BOOST_CHECK_EQUAL(vecOutputs.size(), 1);
@@ -73,7 +71,7 @@ BOOST_AUTO_TEST_CASE(class_c_marker)
     nMaxDatacarrierBytes = nMaxDatacarrierBytesOriginal;
 }
 
-BOOST_AUTO_TEST_CASE(class_c_with_empty_payload)
+BOOST_AUTO_TEST_CASE(class_d_with_empty_payload)
 {
     // Store initial data carrier size
     unsigned nMaxDatacarrierBytesOriginal = nMaxDatacarrierBytes;
@@ -85,13 +83,13 @@ BOOST_AUTO_TEST_CASE(class_c_with_empty_payload)
     nMaxDatacarrierBytes = 0; // byte
 
     std::vector<std::pair<CScript, int64_t> > vecOutputs;
-    BOOST_CHECK(!OmniCore_Encode_ClassCD(vchEmptyPayload, vecOutputs, OMNI_CLASS_C));
+    BOOST_CHECK(!OmniCore_Encode_ClassCD(vchEmptyPayload, vecOutputs, OMNI_CLASS_D));
     BOOST_CHECK_EQUAL(vecOutputs.size(), 0);
 
     // Exactly the size of the marker
-    nMaxDatacarrierBytes = 4; // byte
+    nMaxDatacarrierBytes = 2; // byte
 
-    BOOST_CHECK(OmniCore_Encode_ClassCD(vchEmptyPayload, vecOutputs, OMNI_CLASS_C));
+    BOOST_CHECK(OmniCore_Encode_ClassCD(vchEmptyPayload, vecOutputs, OMNI_CLASS_D));
     BOOST_CHECK_EQUAL(vecOutputs.size(), 1);
 
     // Restore original data carrier size settings

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(trimmed_op_return)
         std::vector<CTxOut> txOutputs;
 
         std::vector<unsigned char> vchFiller(MAX_PACKETS * PACKET_SIZE, 0x07);
-        std::vector<unsigned char> vchPayload = GetOmMarker();
+        std::vector<unsigned char> vchPayload = GetOmMarker(OMNI_CLASS_C);
         vchPayload.insert(vchPayload.end(), vchFiller.begin(), vchFiller.end());
 
         // These will be trimmed:

--- a/src/omnicore/test/sender_firstin_tests.cpp
+++ b/src/omnicore/test/sender_firstin_tests.cpp
@@ -56,7 +56,7 @@ static CTransaction TxClassC(const std::vector<CTxOut>& txInputs)
     // Outputs:
     std::vector<std::pair<CScript, int64_t> > txOutputs;
     std::vector<unsigned char> vchPayload = CreatePayload_SimpleSend(1, 1000);
-    BOOST_CHECK(OmniCore_Encode_ClassC(vchPayload, txOutputs));
+    BOOST_CHECK(OmniCore_Encode_ClassCD(vchPayload, txOutputs, OMNI_CLASS_C));
 
     for (std::vector<std::pair<CScript, int64_t> >::const_iterator it = txOutputs.begin(); it != txOutputs.end(); ++it)
     {

--- a/src/omnicore/test/test_class_d.sh
+++ b/src/omnicore/test/test_class_d.sh
@@ -1,0 +1,1331 @@
+#!/bin/bash
+
+SRCDIR=./src/
+NUL=/dev/null
+PASS=0
+FAIL=0
+clear
+printf "##################################################################\n"
+printf "# Performing Class D encoding and decoding scenarios via regtest #\n"
+printf "##################################################################\n\n"
+printf "Preparing a test environment...\n"
+printf "   * Starting a fresh regtest daemon\n"
+rm -r ~/.bitcoin/regtest
+$SRCDIR/omnicored --regtest --server --daemon --omnidebug=all --omniactivationallowsender=any >$NUL
+sleep 5
+printf "   * Preparing some mature testnet BTC\n"
+$SRCDIR/omnicore-cli --regtest generate 102 >$NUL
+printf "   * Obtaining a master address to work with\n"
+ADDR=$($SRCDIR/omnicore-cli --regtest getnewaddress OMNIAccount)
+printf "   * Funding the address with some testnet BTC for fees\n"
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 20 >$NUL
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   * Participating in the Exodus crowdsale to obtain some OMNI\n"
+TOADD=$($SRCDIR/omnicore-cli --regtest getnewaddress)
+JSON="{\"moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP\":10,\""$ADDR"\":4,\""$TOADD"\":4}"
+$SRCDIR/omnicore-cli --regtest sendmany OMNIAccount $JSON >$NUL
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   * Creating an indivisible test property\n"
+$SRCDIR/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 1 0 "Z_TestCat" "Z_TestSubCat" "Z_IndivisTestProperty" "Z_TestURL" "Z_TestData" 10000000 >$NUL
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "\nActivating Class D transactions...\n"
+printf "   * Sending the activation\n"
+BLOCKS=$($SRCDIR/omnicore-cli --regtest getblockcount)
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendactivation $ADDR 13 $(($BLOCKS + 8)) 999)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "     # Checking the activation transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "     # Mining 10 blocks to forward past the activation block\n"
+$SRCDIR/omnicore-cli --regtest generate 10 >$NUL
+printf "     # Checking the activation went live as expected... "
+FEATUREID=$($SRCDIR/omnicore-cli --regtest omni_getactivations | grep -A 10 completed | grep featureid | cut -c20-21)
+if [ $FEATUREID == "13" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $FEATUREID
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Simple Send' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_send $ADDR $TOADD 1 50.0)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "00000180e497d012" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amount | cut -d '"' -f4)
+if [ $RESULT == "50.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Send To Owners' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendsto $ADDR 1 10.0)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "0003018094ebdc03" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "3," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amount | cut -d '"' -f4)
+if [ $RESULT == "10.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Send All' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendall $ADDR $TOADD 2)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "000402" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "4," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the ecosystem... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep ecosystem | cut -d '"' -f4)
+if [ $RESULT == "test" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'DEx Sell' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_senddexsell $ADDR 1 32.12345678 1.00000001 20 0.001 1)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "011401ce82e2fb0b81c2d72f14a08d0601" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "20," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "1," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property for sale... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyid | cut -d ' ' -f4)
+if [ $RESULT == "1," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount for sale... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amount | cut -d '"' -f4)
+if [ $RESULT == "32.12345678" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount desired... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep bitcoindesired | cut -d '"' -f4)
+if [ $RESULT == "1.00000001" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payment window... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep timelimit | cut -d ' ' -f4)
+if [ $RESULT == "20," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the minimum fee... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep feerequired | cut -d '"' -f4)
+if [ $RESULT == "0.00100000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the action... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep action | cut -d '"' -f4)
+if [ $RESULT == "new" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'DEx Accept' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_senddexaccept $TOADD $ADDR 1 15.0)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "00160180dea0cb05" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "22," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amount | cut -d '"' -f4)
+if [ $RESULT == "15.00000000" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'MetaDEx Trade' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendtrade $ADDR 1 11.99999999 3 60)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "001901ff979abc04033c" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "25," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property for sale... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyidforsale\" | cut -d ' ' -f4)
+if [ $RESULT == "1," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount for sale... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amountforsale | cut -d '"' -f4)
+if [ $RESULT == "11.99999999" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property desired... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyiddesired\" | cut -d ' ' -f4)
+if [ $RESULT == "3," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount desired... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amountdesired | cut -d '"' -f4)
+if [ $RESULT == "60" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'MetaDEx Cancel Price' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendcanceltradesbyprice $ADDR 1 11.99999999 3 60)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "001a01ff979abc04033c" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "26," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property for sale... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyidforsale\" | cut -d ' ' -f4)
+if [ $RESULT == "1," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount for sale... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amountforsale | cut -d '"' -f4)
+if [ $RESULT == "11.99999999" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property desired... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyiddesired\" | cut -d ' ' -f4)
+if [ $RESULT == "3," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount desired... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amountdesired | cut -d '"' -f4)
+if [ $RESULT == "60" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'MetaDEx Cancel Pair' for encoding and decoding...\n"
+printf "   # Relisting a trade\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendtrade $ADDR 1 11.99999999 3 60)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendcanceltradesbypair $ADDR 1 3)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "001b0103" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "27," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property for sale... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyidforsale\" | cut -d ' ' -f4)
+if [ $RESULT == "1," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property desired... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyiddesired\" | cut -d ' ' -f4)
+if [ $RESULT == "3," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'MetaDEx Cancel Ecosystem' for encoding and decoding...\n"
+printf "   # Relisting a trade\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendtrade $ADDR 1 11.99999999 3 60)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendcancelalltrades $ADDR 1)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "001c01" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "28," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the ecosystem... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep \"ecosystem\" | cut -d '"' -f4)
+if [ $RESULT == "main" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Create Property - Fixed' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendissuancefixed $ADDR 1 1 0 "TestCat" "TestSubCat" "TestProperty" "TestURL" "TestData" 14321)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "0032010100546573744361740054657374537562436174005465737450726f7065727479005465737455524c00546573744461746100f16f" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "50," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertytype | cut -d '"' -f4)
+if [ $RESULT == "indivisible" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the ecosystem... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep ecosystem | cut -d '"' -f4)
+if [ $RESULT == "main" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the category... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep \"category | cut -d '"' -f4)
+if [ $RESULT == "TestCat" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the subcategory... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep subcategory | cut -d '"' -f4)
+if [ $RESULT == "TestSubCat" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property name... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyname | cut -d '"' -f4)
+if [ $RESULT == "TestProperty" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the data... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep data | cut -d '"' -f4)
+if [ $RESULT == "TestData" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the URL... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep url | cut -d '"' -f4)
+if [ $RESULT == "TestURL" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amount | cut -d '"' -f4)
+if [ $RESULT == "14321" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Create Property - Variable' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendissuancecrowdsale $ADDR 1 1 0 "Cat" "SubCat" "Test" "URL" "Data" 3 400 1594309459 10 5)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "00330101004361740053756243617400546573740055524c004461746100039003d3f69cf8050a05" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "51," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertytype | cut -d '"' -f4)
+if [ $RESULT == "indivisible" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the ecosystem... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep ecosystem | cut -d '"' -f4)
+if [ $RESULT == "main" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the category... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep \"category | cut -d '"' -f4)
+if [ $RESULT == "Cat" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the subcategory... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep subcategory | cut -d '"' -f4)
+if [ $RESULT == "SubCat" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property name... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyname | cut -d '"' -f4)
+if [ $RESULT == "Test" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the data... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep data | cut -d '"' -f4)
+if [ $RESULT == "Data" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the URL... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep url | cut -d '"' -f4)
+if [ $RESULT == "URL" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property ID desired... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyiddesired | cut -d ' ' -f4)
+if [ $RESULT == "3," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the tokensperunit... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep tokensperunit | cut -d '"' -f4)
+if [ $RESULT == "400" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the deadline... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep deadline | cut -d ' ' -f4)
+if [ $RESULT == "1594309459," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the early bonus... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep earlybonus | cut -d ' ' -f4)
+if [ $RESULT == "10," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the issuer percentage... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep percenttoissuer | cut -d ' ' -f4)
+if [ $RESULT == "5," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Close Crowdsale' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendclosecrowdsale $ADDR 5)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "003505" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "53," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property ID... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyid | cut -d ' ' -f4)
+if [ $RESULT == "5," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Create Property - Managed' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendissuancemanaged $ADDR 1 1 0 "TestCat" "TestSubCat" "TestProperty" "TestURL" "TestData")
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "0036010100546573744361740054657374537562436174005465737450726f7065727479005465737455524c00546573744461746100" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "54," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertytype | cut -d '"' -f4)
+if [ $RESULT == "indivisible" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the ecosystem... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep ecosystem | cut -d '"' -f4)
+if [ $RESULT == "main" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the category... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep \"category | cut -d '"' -f4)
+if [ $RESULT == "TestCat" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the subcategory... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep subcategory | cut -d '"' -f4)
+if [ $RESULT == "TestSubCat" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property name... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyname | cut -d '"' -f4)
+if [ $RESULT == "TestProperty" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the data... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep data | cut -d '"' -f4)
+if [ $RESULT == "TestData" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the URL... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep url | cut -d '"' -f4)
+if [ $RESULT == "TestURL" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Grant' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendgrant $ADDR "" 6 25)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "0037061900" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "55," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amount | cut -d '"' -f4)
+if [ $RESULT == "25" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Revoke' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendrevoke $ADDR 6 15)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "0038060f00" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "56," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the amount... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep amount | cut -d '"' -f4)
+if [ $RESULT == "15" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+printf "\nTesting a Class D 'Change Issuer' for encoding and decoding...\n"
+printf "   # Sending the transaction\n"
+TXID=$($SRCDIR/omnicore-cli --regtest omni_sendchangeissuer $ADDR $TOADD 6)
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   # Checking the transaction was valid... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep valid | cut -c12-)
+if [ $RESULT == "true," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the payload is as expected... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_getpayload $TXID | grep payload\" | cut -d '"' -f4)
+if [ $RESULT == "004606" ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction type... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep type_int | cut -d ' ' -f4)
+if [ $RESULT == "70," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the transaction version... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep version | cut -d ' ' -f4)
+if [ $RESULT == "0," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+printf "   # Checking the property ID... "
+RESULT=$($SRCDIR/omnicore-cli --regtest omni_gettransaction $TXID | grep propertyid | cut -d ' ' -f4)
+if [ $RESULT == "6," ]
+  then
+    printf "PASS\n"
+    PASS=$((PASS+1))
+  else
+    printf "FAIL (result:%s)\n" $RESULT
+    FAIL=$((FAIL+1))
+fi
+
+printf "\n"
+printf "####################\n"
+printf "#  Summary:        #\n"
+printf "#    Passed = %d  #\n" $PASS
+printf "#    Failed = %d    #\n" $FAIL
+printf "####################\n"
+printf "\n"
+
+$SRCDIR/omnicore-cli --regtest stop
+exit
+

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -326,6 +326,10 @@ bool CMPTransaction::interpret_SendAll()
         std::vector<uint8_t> vecVersionBytes = GetNextVarIntBytes(i);
         std::vector<uint8_t> vecTypeBytes = GetNextVarIntBytes(i);
 
+        if (i >= pkt_size) {
+            return false;
+        }
+
         memcpy(&ecosystem, &pkt[i], 1);
     } else {
         if (pkt_size < 5) {
@@ -356,12 +360,20 @@ bool CMPTransaction::interpret_TradeOffer()
         std::vector<uint8_t> vecAmountBytes = GetNextVarIntBytes(i);
         std::vector<uint8_t> vecAmountDesiredBytes = GetNextVarIntBytes(i);
 
+        if (i >= pkt_size) {
+            return false;
+        }
+
         memcpy(&blocktimelimit, &pkt[i], 1);
         i++;
 
         std::vector<uint8_t> vecMinFeeBytes = GetNextVarIntBytes(i);
 
         if (version > MP_TX_PKT_V0) {
+            if (i >= pkt_size) {
+                return false;
+            }
+
             memcpy(&subaction, &pkt[i], 1);
             i++;
         }
@@ -600,6 +612,10 @@ bool CMPTransaction::interpret_MetaDExCancelEcosystem()
         std::vector<uint8_t> vecVersionBytes = GetNextVarIntBytes(i);
         std::vector<uint8_t> vecTypeBytes = GetNextVarIntBytes(i);
 
+        if (i >= pkt_size) {
+            return false;
+        }
+
         memcpy(&ecosystem, &pkt[i], 1);
     } else {
         if (pkt_size < 5) {
@@ -631,6 +647,10 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
 
         std::vector<uint8_t> vecVersionBytes = GetNextVarIntBytes(i);
         std::vector<uint8_t> vecTypeBytes = GetNextVarIntBytes(i);
+
+        if (i >= pkt_size) {
+            return false;
+        }
 
         memcpy(&ecosystem, &pkt[i], 1);
         i++;
@@ -729,6 +749,10 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
         std::vector<uint8_t> vecVersionBytes = GetNextVarIntBytes(i);
         std::vector<uint8_t> vecTypeBytes = GetNextVarIntBytes(i);
 
+        if (i >= pkt_size) {
+            return false;
+        }
+
         memcpy(&ecosystem, &pkt[i], 1);
         i++;
 
@@ -760,8 +784,17 @@ bool CMPTransaction::interpret_CreatePropertyVariable()
         std::vector<uint8_t> vecAmountPerUnitBytes = GetNextVarIntBytes(i);
         std::vector<uint8_t> vecDeadlineBytes = GetNextVarIntBytes(i);
 
+        if (i >= pkt_size) {
+            return false;
+        }
+
         memcpy(&early_bird, &pkt[i], 1);
         i++;
+
+        if (i >= pkt_size) {
+            return false;
+        }
+
         memcpy(&percentage, &pkt[i], 1);
         i++;
 
@@ -876,6 +909,10 @@ bool CMPTransaction::interpret_CreatePropertyManaged()
         int i = 0;
         std::vector<uint8_t> vecVersionBytes = GetNextVarIntBytes(i);
         std::vector<uint8_t> vecTypeBytes = GetNextVarIntBytes(i);
+
+        if (i >= pkt_size) {
+            return false;
+        }
 
         memcpy(&ecosystem, &pkt[i], 1);
         i++;

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -90,6 +90,10 @@ static std::string intToClass(int encodingClass)
 std::vector<uint8_t> CMPTransaction::GetNextVarIntBytes(int &i) {
     std::vector<uint8_t> vecBytes;
 
+    if (i >= pkt_size) {
+        return vecBytes;
+    }
+
     do {
         vecBytes.push_back(pkt[i]);
         if (!IsMSBSet(&pkt[i])) break;

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -100,6 +100,11 @@ private:
     bool isOverrun(const char* p);
 
     /**
+     * Variable Integers
+     */
+    std::vector<uint8_t> GetNextVarIntBytes(int &i);
+
+    /**
      * Payload parsing
      */
     bool interpret_TransactionType();

--- a/src/omnicore/varint.cpp
+++ b/src/omnicore/varint.cpp
@@ -1,0 +1,44 @@
+/**
+ * @file varint.cpp
+ *
+ * This file contains code to handle variable length integers.
+ */
+
+#include "omnicore/varint.h"
+
+// Returns true if a byte has the MSB set
+bool IsMSBSet(unsigned char* byte) {
+    if (*byte > 127) {
+        return true;
+    }
+    return false;
+}
+
+// Compresses an integer with variable length encoding
+std::vector<uint8_t> CompressInteger(uint64_t value) {
+    std::vector<uint8_t> compressedBytes;
+    // Loop while there are still >7 bits remaining
+    while (value > 127) {
+        // Set the MSB with Bitwise OR | 128 (128 = bits 100000000)
+        compressedBytes.push_back(value | 128);
+        // Shift 7 bits right
+       value >>= 7;
+    }
+    compressedBytes.push_back(value);
+    return compressedBytes;
+}
+
+// Decompresses an integer with variable length encoding
+// TODO - exploitable in any way? any potential overruns or other gotchas with byte shifting?
+uint64_t DecompressInteger(std::vector<uint8_t> compressedBytes) {
+    std::vector<uint8_t>::const_iterator it;
+    uint64_t value = 0;
+    int byteCount = 0;
+    // Iterate over the bytes adding the 7 least significant bits from each and bitshifting accordingly
+    for (it = compressedBytes.begin(); it != compressedBytes.end(); it++) {
+        uint8_t byte = *it;
+        value |= (uint64_t)(byte & 127) << (7 * byteCount);
+        byteCount++;
+    }
+    return value;
+}

--- a/src/omnicore/varint.h
+++ b/src/omnicore/varint.h
@@ -1,0 +1,16 @@
+#ifndef OMNICORE_VARINT_H
+#define OMNICORE_VARINT_H
+
+#include <stdint.h>
+#include <vector>
+
+// Returns true if a byte has the MSB set
+bool IsMSBSet(unsigned char* byte);
+
+// Compresses an integer with variable length encoding
+uint64_t DecompressInteger(std::vector<uint8_t> compressedBytes);
+
+// Decompresses an integer with variable length encoding
+std::vector<uint8_t> CompressInteger(uint64_t value);
+
+#endif // OMNICORE_VARINT_H

--- a/src/qt/metadexdialog.cpp
+++ b/src/qt/metadexdialog.cpp
@@ -536,13 +536,14 @@ void MetaDExDialog::sendTrade()
         return;
     }
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExTrade(GetPropForSale(), amountForSale, GetPropDesired(), amountDesired);
+    std::vector<unsigned char> compressedPayload = CreatePayload_MetaDExTrade(GetPropForSale(), amountForSale, GetPropDesired(), amountDesired, true);
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(strFromAddress, "", "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(strFromAddress, "", "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -313,13 +313,14 @@ void SendMPDialog::sendMPTransaction()
         return; // unlock wallet was cancelled/failed
     }
 
-    // create a payload for the transaction
+    // create payloads for the transaction
     std::vector<unsigned char> payload = CreatePayload_SimpleSend(propertyId, sendAmount);
+    std::vector<unsigned char> compressedPayload = CreatePayload_SimpleSend(propertyId, sendAmount, true);
 
     // request the wallet build the transaction (and if needed commit it) - note UI does not support added reference amounts currently
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress.ToString(), refAddress.ToString(), "", 0, payload, txid, rawHex, autoCommit);
+    int result = WalletTxBuilder(fromAddress.ToString(), refAddress.ToString(), "", 0, payload, compressedPayload, txid, rawHex, autoCommit);
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {


### PR DESCRIPTION
This PR adds Class D support to Omni Core.

Class D is not defined in the spec but can be summarized as follows:

Class D is identical to Class C with the following changes:
  * The marker bytes have been shortened to `ol` rather than `omni` (@dexx7 I should have listened to you earlier hehe)
  * Integers in payloads are compressed with variable length encoding similar to LEB128

The use of Class D is significantly more efficient than Class C (on average payloads are reduced by 40-50%).  Class D is activated via the feature activation system and Omni Core will start sending Class D by default once the activation has occurred.

This is an initial PR to request feedback and should be considered in progress...

Thanks! :)
Z
