### PR TITLE
Avoid selecting uneconomic UTXO during transaction creation

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2427,7 +2427,10 @@ int mastercore::WalletTxBuilder(const std::string& senderAddress, const std::str
     }
 
     // Ask the wallet to create the transaction (note mining fee determined by Bitcoin Core params)
-    if (!pwalletMain->CreateTransaction(vecRecipients, wtxNew, reserveKey, nFeeRet, nChangePosInOut, strFailReason, &coinControl)) { return MP_ERR_CREATE_TX; }
+    if (!pwalletMain->CreateTransaction(vecRecipients, wtxNew, reserveKey, nFeeRet, nChangePosInOut, strFailReason, &coinControl)) {
+        PrintToLog("%s: ERROR: wallet transaction creation failed: %s\n", __func__, strFailReason);
+        return MP_ERR_CREATE_TX;
+    }
 
     // If this request is only to create, but not commit the transaction then display it and exit
     if (!commit) {

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2369,7 +2369,7 @@ bool mastercore::UseEncodingClassC(size_t nDataSize)
 
 // This function requests the wallet create an Omni transaction using the supplied parameters and payload
 int mastercore::WalletTxBuilder(const std::string& senderAddress, const std::string& receiverAddress, const std::string& redemptionAddress,
-        int64_t referenceAmount, const std::vector<unsigned char>& data, uint256& txid, std::string& rawHex, bool commit, unsigned int minInputs)
+        int64_t referenceAmount, const std::vector<unsigned char>& data, uint256& txid, std::string& rawHex, bool commit)
 {
 #ifdef ENABLE_WALLET
     if (pwalletMain == NULL) return MP_ERR_WALLET_ACCESS;
@@ -2392,7 +2392,7 @@ int mastercore::WalletTxBuilder(const std::string& senderAddress, const std::str
     coinControl.destChange = addr.Get();
 
     // Select the inputs
-    if (0 > SelectCoins(senderAddress, coinControl, referenceAmount, minInputs)) { return MP_INPUTS_INVALID; }
+    if (0 > SelectCoins(senderAddress, coinControl, referenceAmount)) { return MP_INPUTS_INVALID; }
 
     // Encode the data outputs
     switch(omniTxClass) {
@@ -2428,35 +2428,6 @@ int mastercore::WalletTxBuilder(const std::string& senderAddress, const std::str
 
     // Ask the wallet to create the transaction (note mining fee determined by Bitcoin Core params)
     if (!pwalletMain->CreateTransaction(vecRecipients, wtxNew, reserveKey, nFeeRet, nChangePosInOut, strFailReason, &coinControl)) { return MP_ERR_CREATE_TX; }
-
-    // Workaround for SigOps limit
-    {
-        if (!FillTxInputCache(wtxNew)) {
-            PrintToLog("%s ERROR: failed to get inputs for %s\n", __func__, wtxNew.GetHash().GetHex());
-        }
-
-        unsigned int nBytesPerSigOp = 20; // default of Bitcoin Core 12.1
-        unsigned int nSize = ::GetSerializeSize(wtxNew, SER_NETWORK, PROTOCOL_VERSION);
-        unsigned int nSigOps = GetLegacySigOpCount(wtxNew);
-        nSigOps += GetP2SHSigOpCount(wtxNew, view);
-
-        if (nSigOps > nSize / nBytesPerSigOp) {
-            std::vector<COutPoint> vInputs;
-            coinControl.ListSelected(vInputs);
-
-            // Ensure the requested number of inputs was available, so there may be more
-            if (vInputs.size() >= minInputs) {
-                // Build a new transaction and try to select one additional input to
-                // shift the bytes per sigops ratio in our favor
-                ++minInputs;
-                return WalletTxBuilder(senderAddress, receiverAddress, redemptionAddress,
-                    referenceAmount, data, txid, rawHex, commit, minInputs);
-            } else {
-                PrintToLog("%s WARNING: %s has %d sigops, and may not confirm in time\n",
-                        __func__, wtxNew.GetHash().GetHex(), nSigOps);
-            }
-        }
-    }
 
     // If this request is only to create, but not commit the transaction then display it and exit
     if (!commit) {

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -333,7 +333,7 @@ bool isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound);
 std::string FormatIndivisibleMP(int64_t n);
 
 int WalletTxBuilder(const std::string& senderAddress, const std::string& receiverAddress, const std::string& redemptionAddress,
-                 int64_t referenceAmount, const std::vector<unsigned char>& data, uint256& txid, std::string& rawHex, bool commit, unsigned int minInputs = 1);
+                 int64_t referenceAmount, const std::vector<unsigned char>& data, uint256& txid, std::string& rawHex, bool commit);
 
 bool isTestEcosystemProperty(uint32_t propertyId);
 bool isMainEcosystemProperty(uint32_t propertyId);

--- a/src/omnicore/wallettxs.cpp
+++ b/src/omnicore/wallettxs.cpp
@@ -163,13 +163,10 @@ int IsMyAddress(const std::string& address)
 /**
  * Selects spendable outputs to create a transaction.
  */
-int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional, unsigned int minOutputs)
+int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional)
 {
     // total output funds collected
     int64_t nTotal = 0;
-
-    // total number of outputs selected
-    unsigned int nNumOutputs = 0;
 
 #ifdef ENABLE_WALLET
     if (NULL == pwalletMain) {
@@ -221,13 +218,12 @@ int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, i
                 coinControl.Select(outpoint);
 
                 nTotal += txOut.nValue;
-                ++nNumOutputs;
 
-                if (nMax <= nTotal && nNumOutputs >= minOutputs) break;
+                if (nMax <= nTotal) break;
             }
         }
 
-        if (nMax <= nTotal && nNumOutputs >= minOutputs) break;
+        if (nMax <= nTotal) break;
     }
 #endif
 

--- a/src/omnicore/wallettxs.h
+++ b/src/omnicore/wallettxs.h
@@ -27,7 +27,7 @@ std::string GetAddressLabel(const std::string& address);
 int IsMyAddress(const std::string& address);
 
 /** Selects spendable outputs to create a transaction. */
-int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional = 0, unsigned int minOutputs = 0);
+int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional = 0);
 }
 
 #endif // OMNICORE_WALLETTXS_H


### PR DESCRIPTION
1. #396 introduced a workaround to bloat transactions, to get around a "sigops per byte limit". This limit was removed by https://github.com/bitcoin/bitcoin/pull/8365, and the workaround actually makes the situation worse, therefore the workaround is removed.

2. Failures during the wallet transaction are logged.

3. To avoid bloating transactions while lowering the effective fee, inputs are filtered during the coin selection, and uneconomic inputs are excluded. This is based on the estimated fee used for the transaction creation. Instead of selecting an amount based on a magic number, the amount to select for the transaction creation is also based on the estimated fee, used to create the transaction.