### PR TITLE
Remove git created macros to make builds deterministic

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2117,7 +2117,6 @@ int mastercore_init()
 
     PrintToLog("\nInitializing Omni Core v%s [%s]\n", OmniCoreVersion(), Params().NetworkIDString());
     PrintToLog("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
-    PrintToLog("Build date: %s, based on commit: %s\n", BuildDate(), BuildCommit());
 
     InitDebugLogLevels();
     ShrinkDebugLog();

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1837,7 +1837,6 @@ UniValue omni_getinfo(const UniValue& params, bool fHelp)
             "  \"omnicoreversion\" : \"x.x.x.x-xxx\",     (string) client version\n"
             "  \"mastercoreversion\" : \"x.x.x.x-xxx\",   (string) client version (DEPRECIATED)\n"
             "  \"bitcoincoreversion\" : \"x.x.x\",        (string) Bitcoin Core version\n"
-            "  \"commitinfo\" : \"xxxxxxx\",              (string) build commit identifier\n"
             "  \"block\" : nnnnnn,                      (number) index of the last processed block\n"
             "  \"blocktime\" : nnnnnnnnnn,              (number) timestamp of the last processed block\n"
             "  \"blocktransactions\" : nnnn,            (number) Omni transactions found in the last processed block\n"
@@ -1859,12 +1858,11 @@ UniValue omni_getinfo(const UniValue& params, bool fHelp)
 
     UniValue infoResponse(UniValue::VOBJ);
 
-    // provide the mastercore and bitcoin version and if available commit id
+    // provide the mastercore and bitcoin version
     infoResponse.push_back(Pair("omnicoreversion_int", OMNICORE_VERSION));
     infoResponse.push_back(Pair("omnicoreversion", OmniCoreVersion()));
     infoResponse.push_back(Pair("mastercoreversion", OmniCoreVersion()));
     infoResponse.push_back(Pair("bitcoincoreversion", BitcoinCoreVersion()));
-    infoResponse.push_back(Pair("commitinfo", BuildCommit()));
 
     // provide the current block details
     int block = GetHeight();

--- a/src/omnicore/version.cpp
+++ b/src/omnicore/version.cpp
@@ -9,24 +9,6 @@
 #    include "build.h"
 #endif
 
-#ifndef COMMIT_ID
-#   ifdef GIT_ARCHIVE
-#       define COMMIT_ID "$Format:%h$"
-#   elif defined(BUILD_SUFFIX)
-#       define COMMIT_ID STRINGIZE(BUILD_SUFFIX)
-#   else
-#       define COMMIT_ID ""
-#   endif
-#endif
-
-#ifndef BUILD_DATE
-#    ifdef GIT_COMMIT_DATE
-#        define BUILD_DATE GIT_COMMIT_DATE
-#    else
-#        define BUILD_DATE __DATE__ ", " __TIME__
-#    endif
-#endif
-
 #ifdef OMNICORE_VERSION_STATUS
 #    define OMNICORE_VERSION_SUFFIX STRINGIZE(OMNICORE_VERSION_STATUS)
 #else
@@ -65,16 +47,4 @@ const std::string BitcoinCoreVersion()
                 CLIENT_VERSION_MINOR,
                 CLIENT_VERSION_REVISION);
     }
-}
-
-//! Returns build date
-const std::string BuildDate()
-{
-    return std::string(BUILD_DATE);
-}
-
-//! Returns commit identifier, if available
-const std::string BuildCommit()
-{
-    return std::string(COMMIT_ID);
 }

--- a/src/omnicore/version.h
+++ b/src/omnicore/version.h
@@ -48,12 +48,6 @@ const std::string OmniCoreVersion();
 //! Returns formatted Bitcoin Core version, e.g. "0.10", "0.9.3"
 const std::string BitcoinCoreVersion();
 
-//! Returns build date
-const std::string BuildDate();
-
-//! Returns commit identifier, if available
-const std::string BuildCommit();
-
 
 #endif // WINDRES_PREPROC
 


### PR DESCRIPTION
Linux and Mac OS builds via Gitian were not deterministic. This fixes the issue by removing macros, which were generated by git.