### PR TITLE
Add support for ecosystem specific consensus hashes

### DIFF
--- a/src/omnicore/consensushash.h
+++ b/src/omnicore/consensushash.h
@@ -8,11 +8,11 @@ namespace mastercore
 /** Checks if a given block should be consensus hashed. */
 bool ShouldConsensusHashBlock(int block);
 
-/** Obtains a hash of all balances to use for consensus verification and checkpointing. */
-uint256 GetConsensusHash();
+/** Obtains a hash of all balances to use for consensus verification and checkpointing. Defaults to both ecosystems. */
+uint256 GetConsensusHash(uint8_t ecosystem = 0);
 
-/** Obtains a hash of the overall MetaDEx state (default) or a specific orderbook (supply a property ID). */
-uint256 GetMetaDExHash(const uint32_t propertyId = 0);
+/** Obtains a hash of the overall MetaDEx state (default for both ecosystems) or a specific orderbook (supply a property ID). */
+uint256 GetMetaDExHash(uint8_t ecosystem = 0, const uint32_t propertyId = 0);
 
 }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -135,6 +135,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getfeetrigger", 0 },
     { "omni_getfeedistribution", 0 },
     { "omni_getfeedistributions", 0 },
+    { "omni_getcurrentconsensushash", 0 },
 
     /* Omni Core - transaction calls */
     { "omni_send", 2 },


### PR DESCRIPTION
This PR adds support for ecosystem specific consensus hashes.

The purpose is to allow the quick verification of consensus for a specific ecosystem rather than for the entire state.  For example clients may allow new transaction types such as UIT in the test ecosystem which would cause a differing consensus hash between clients when the whole state is considered.  With this amendment we can thus generate a hash specifically for the main (or test) ecosystem.

The default is still to generate a hash that covers both ecosystems, but an optional ecosystem parameter can be supplied with the consensus hash RPCs that will specify an ecosystem.

Examples:
```
omni_getcurrentconsensushash

{
  "block": 493420,
  "blockhash": "0000000000000000001e2dec9f2d1ba3315c5a6e661e2049bedd7f3dd72d83cd",
  "ecosystem": "both",
  "consensushash": "4a8193fbba907fbba52395e52fab375c2239f53902ae34cd54a057b2a511414b"
}
```
```
omni_getcurrentconsensushash 1

{
  "block": 493420,
  "blockhash": "0000000000000000001e2dec9f2d1ba3315c5a6e661e2049bedd7f3dd72d83cd",
  "ecosystem": "main",
  "consensushash": "df26c1ad23ee6dd912fc2c7cf91996661afefd175045448cc2d42c435823c489"
}
```
```
omni_getcurrentconsensushash 2

{
  "block": 493420,
  "blockhash": "0000000000000000001e2dec9f2d1ba3315c5a6e661e2049bedd7f3dd72d83cd",
  "ecosystem": "test",
  "consensushash": "2192cbdf25809d15642cd1fe0443d432153be12bacb3c630b3aab423cd29fc83"
}
```

Thanks
Z