### PR TITLE
Fix log spam from unconfirmed transactions

### DIFF
--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -138,7 +138,7 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
     // populate type specific info and extended details if requested
     // extended details are not available for unconfirmed transactions
     if (confirmations <= 0) extendedDetails = false;
-    populateRPCTypeInfo(mp_obj, txobj, mp_obj.getType(), extendedDetails, extendedDetailsFilter);
+    populateRPCTypeInfo(mp_obj, txobj, mp_obj.getType(), extendedDetails, extendedDetailsFilter, confirmations);
 
     // state and chain related information
     if (confirmations != 0 && !blockHash.IsNull()) {
@@ -158,7 +158,7 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
 
 /* Function to call respective populators based on message type
  */
-void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txType, bool extendedDetails, std::string extendedDetailsFilter)
+void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txType, bool extendedDetails, std::string extendedDetailsFilter, int confirmations)
 {
     switch (txType) {
         case MSC_TYPE_SIMPLE_SEND:
@@ -168,7 +168,7 @@ void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txTyp
             populateRPCTypeSendToOwners(mp_obj, txobj, extendedDetails, extendedDetailsFilter);
             break;
         case MSC_TYPE_SEND_ALL:
-            populateRPCTypeSendAll(mp_obj, txobj);
+            populateRPCTypeSendAll(mp_obj, txobj, confirmations);
             break;
         case MSC_TYPE_TRADE_OFFER:
             populateRPCTypeTradeOffer(mp_obj, txobj);
@@ -279,12 +279,14 @@ void populateRPCTypeSendToOwners(CMPTransaction& omniObj, UniValue& txobj, bool 
     if (extendedDetails) populateRPCExtendedTypeSendToOwners(omniObj.getHash(), extendedDetailsFilter, txobj, omniObj.getVersion());
 }
 
-void populateRPCTypeSendAll(CMPTransaction& omniObj, UniValue& txobj)
+void populateRPCTypeSendAll(CMPTransaction& omniObj, UniValue& txobj, int confirmations)
 {
     UniValue subSends(UniValue::VARR);
     if (omniObj.getEcosystem() == 1) txobj.push_back(Pair("ecosystem", "main"));
     if (omniObj.getEcosystem() == 2) txobj.push_back(Pair("ecosystem", "test"));
-    if (populateRPCSendAllSubSends(omniObj.getHash(), subSends) > 0) txobj.push_back(Pair("subsends", subSends));
+    if (confirmations > 0) {
+        if (populateRPCSendAllSubSends(omniObj.getHash(), subSends) > 0) txobj.push_back(Pair("subsends", subSends));
+    }
 }
 
 void populateRPCTypeTradeOffer(CMPTransaction& omniObj, UniValue& txobj)

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -189,13 +189,13 @@ void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txTyp
             populateRPCTypeAcceptOffer(mp_obj, txobj);
             break;
         case MSC_TYPE_CREATE_PROPERTY_FIXED:
-            populateRPCTypeCreatePropertyFixed(mp_obj, txobj);
+            populateRPCTypeCreatePropertyFixed(mp_obj, txobj, confirmations);
             break;
         case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
-            populateRPCTypeCreatePropertyVariable(mp_obj, txobj);
+            populateRPCTypeCreatePropertyVariable(mp_obj, txobj, confirmations);
             break;
         case MSC_TYPE_CREATE_PROPERTY_MANUAL:
-            populateRPCTypeCreatePropertyManual(mp_obj, txobj);
+            populateRPCTypeCreatePropertyManual(mp_obj, txobj, confirmations);
             break;
         case MSC_TYPE_CLOSE_CROWDSALE:
             populateRPCTypeCloseCrowdsale(mp_obj, txobj);
@@ -404,13 +404,16 @@ void populateRPCTypeAcceptOffer(CMPTransaction& omniObj, UniValue& txobj)
     txobj.push_back(Pair("amount", FormatMP(propertyId, amount)));
 }
 
-void populateRPCTypeCreatePropertyFixed(CMPTransaction& omniObj, UniValue& txobj)
+void populateRPCTypeCreatePropertyFixed(CMPTransaction& omniObj, UniValue& txobj, int confirmations)
 {
     LOCK(cs_tally);
-    uint32_t propertyId = _my_sps->findSPByTX(omniObj.getHash());
-    if (propertyId > 0) txobj.push_back(Pair("propertyid", (uint64_t) propertyId));
-    if (propertyId > 0) txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
-
+    if (confirmations > 0) {
+        uint32_t propertyId = _my_sps->findSPByTX(omniObj.getHash());
+        if (propertyId > 0) {
+            txobj.push_back(Pair("propertyid", (uint64_t) propertyId));
+            txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
+        }
+    }
     txobj.push_back(Pair("ecosystem", strEcosystem(omniObj.getEcosystem())));
     txobj.push_back(Pair("propertytype", strPropertyType(omniObj.getPropertyType())));
     txobj.push_back(Pair("category", omniObj.getSPCategory()));
@@ -422,13 +425,16 @@ void populateRPCTypeCreatePropertyFixed(CMPTransaction& omniObj, UniValue& txobj
     txobj.push_back(Pair("amount", strAmount));
 }
 
-void populateRPCTypeCreatePropertyVariable(CMPTransaction& omniObj, UniValue& txobj)
+void populateRPCTypeCreatePropertyVariable(CMPTransaction& omniObj, UniValue& txobj, int confirmations)
 {
     LOCK(cs_tally);
-    uint32_t propertyId = _my_sps->findSPByTX(omniObj.getHash());
-    if (propertyId > 0) txobj.push_back(Pair("propertyid", (uint64_t) propertyId));
-    if (propertyId > 0) txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
-
+    if (confirmations > 0) {
+        uint32_t propertyId = _my_sps->findSPByTX(omniObj.getHash());
+        if (propertyId > 0) {
+            txobj.push_back(Pair("propertyid", (uint64_t) propertyId));
+            txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
+        }
+    }
     txobj.push_back(Pair("propertytype", strPropertyType(omniObj.getPropertyType())));
     txobj.push_back(Pair("ecosystem", strEcosystem(omniObj.getEcosystem())));
     txobj.push_back(Pair("category", omniObj.getSPCategory()));
@@ -446,13 +452,16 @@ void populateRPCTypeCreatePropertyVariable(CMPTransaction& omniObj, UniValue& tx
     txobj.push_back(Pair("amount", strAmount)); // crowdsale token creations don't issue tokens with the create tx
 }
 
-void populateRPCTypeCreatePropertyManual(CMPTransaction& omniObj, UniValue& txobj)
+void populateRPCTypeCreatePropertyManual(CMPTransaction& omniObj, UniValue& txobj, int confirmations)
 {
     LOCK(cs_tally);
-    uint32_t propertyId = _my_sps->findSPByTX(omniObj.getHash());
-    if (propertyId > 0) txobj.push_back(Pair("propertyid", (uint64_t) propertyId));
-    if (propertyId > 0) txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
-
+    if (confirmations > 0) {
+        uint32_t propertyId = _my_sps->findSPByTX(omniObj.getHash());
+        if (propertyId > 0) {
+            txobj.push_back(Pair("propertyid", (uint64_t) propertyId));
+            txobj.push_back(Pair("divisible", isPropertyDivisible(propertyId)));
+        }
+    }
     txobj.push_back(Pair("propertytype", strPropertyType(omniObj.getPropertyType())));
     txobj.push_back(Pair("ecosystem", strEcosystem(omniObj.getEcosystem())));
     txobj.push_back(Pair("category", omniObj.getSPCategory()));

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -23,9 +23,9 @@ void populateRPCTypeMetaDExCancelPrice(CMPTransaction& omniObj, UniValue& txobj,
 void populateRPCTypeMetaDExCancelPair(CMPTransaction& omniObj, UniValue& txobj, bool extendedDetails);
 void populateRPCTypeMetaDExCancelEcosystem(CMPTransaction& omniObj, UniValue& txobj, bool extendedDetails);
 void populateRPCTypeAcceptOffer(CMPTransaction& omniObj, UniValue& txobj);
-void populateRPCTypeCreatePropertyFixed(CMPTransaction& omniObj, UniValue& txobj);
-void populateRPCTypeCreatePropertyVariable(CMPTransaction& omniObj, UniValue& txobj);
-void populateRPCTypeCreatePropertyManual(CMPTransaction& omniObj, UniValue& txobj);
+void populateRPCTypeCreatePropertyFixed(CMPTransaction& omniObj, UniValue& txobj, int confirmations);
+void populateRPCTypeCreatePropertyVariable(CMPTransaction& omniObj, UniValue& txobj, int confirmations);
+void populateRPCTypeCreatePropertyManual(CMPTransaction& omniObj, UniValue& txobj, int confirmations);
 void populateRPCTypeCloseCrowdsale(CMPTransaction& omniObj, UniValue& txobj);
 void populateRPCTypeGrant(CMPTransaction& omniObj, UniValue& txobj);
 void populateRPCTypeRevoke(CMPTransaction& omniOobj, UniValue& txobj);

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -12,11 +12,11 @@ class CTransaction;
 int populateRPCTransactionObject(const uint256& txid, UniValue& txobj, std::string filterAddress = "", bool extendedDetails = false, std::string extendedDetailsFilter = "");
 int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHash, UniValue& txobj, std::string filterAddress = "", bool extendedDetails = false, std::string extendedDetailsFilter = "", int blockHeight = 0);
 
-void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txType, bool extendedDetails, std::string extendedDetailsFilter);
+void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txType, bool extendedDetails, std::string extendedDetailsFilter, int confirmations);
 
 void populateRPCTypeSimpleSend(CMPTransaction& omniObj, UniValue& txobj);
 void populateRPCTypeSendToOwners(CMPTransaction& omniObj, UniValue& txobj, bool extendedDetails, std::string extendedDetailsFilter);
-void populateRPCTypeSendAll(CMPTransaction& omniObj, UniValue& txobj);
+void populateRPCTypeSendAll(CMPTransaction& omniObj, UniValue& txobj, int confirmations);
 void populateRPCTypeTradeOffer(CMPTransaction& omniObj, UniValue& txobj);
 void populateRPCTypeMetaDExTrade(CMPTransaction& omniObj, UniValue& txobj, bool extendedDetails);
 void populateRPCTypeMetaDExCancelPrice(CMPTransaction& omniObj, UniValue& txobj, bool extendedDetails);


### PR DESCRIPTION
Each time certain unconfirmed transactions are queried via RPC spam entries are written to the log:

This PR removes the attempt to load data for unconfirmed transactions that is not available until after processing.

**Unconfirmed Send All**:
`TXLISTDB Error: Transaction parsed as send all but could not locate sub sends in txlistdb.`
 
This is because transactions are only processed once included in a block and so while it's unconfirmed the sub sends have not been determined or written to leveldb.

**Unconfirmed Property Creations**:
`findSPByTX(): ERROR: failed to find property created with {txid}`

This is because the SP database does not contain any property entries that are tagged with that creation txid until that transaction has been included in a block and gets processed.


