### PR TITLE
Persist the parsing result and include the reason for tx invalidation in RPC response

### DIFF
--- a/src/omnicore/errors.h
+++ b/src/omnicore/errors.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "omnicore/omnicore.h"
+
 enum MPRPCErrorCode
 {
     //INTERNAL_1packet
@@ -76,6 +78,250 @@ inline std::string error_str(int ec) {
       case MP_ERR_COMMIT_TX:
           ec_str = "Error committing transaction";
           break;
+
+      case PKT_ERROR -1:
+          ec_str = "Attempt to execute logic in RPC mode";
+          break;
+      case PKT_ERROR -2:
+          ec_str = "Failed to interpret transaction";
+          break;
+      case PKT_ERROR -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR -51:
+          ec_str = "Sender is not authorized";
+          break;
+      case PKT_ERROR -54:
+          ec_str = "Activation failed";
+          break;
+
+      case PKT_ERROR -100:
+          ec_str = "Transaction is not a supported type";
+          break;
+      case PKT_ERROR -500:
+          ec_str = "Transaction version is not supported";
+          break;
+      case PKT_ERROR -999:
+          ec_str = "Failed to determine subaction";
+          break;
+
+      case PKT_ERROR_SEND -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR_SEND -23:
+          ec_str = "Value out of range or zero";
+          break;
+      case PKT_ERROR_SEND -24:
+          ec_str = "Property does not exist";
+          break;
+      case PKT_ERROR_SEND -25:
+          ec_str = "Sender has insufficient balance";
+          break;
+
+      case PKT_ERROR_STO -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR_STO -23:
+          ec_str = "Value out of range or zero";
+          break;
+      case PKT_ERROR_STO -24:
+          ec_str = "Property does not exist";
+          break;
+      case PKT_ERROR_STO -25:
+          ec_str = "Sender has insufficient balance";
+          break;
+      case PKT_ERROR_STO -26:
+          ec_str = "No other owners of the property";
+          break;
+      case PKT_ERROR_STO -27:
+          ec_str = "Sender has insufficient balance to pay for fee";
+          break;
+      case PKT_ERROR_STO -28:
+          ec_str = "Sender has insufficient balance to pay for amount + fee";
+          break;
+
+      case PKT_ERROR_SEND_ALL -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR_SEND_ALL -54:
+          ec_str = "Sender has no tokens to send";
+          break;
+      case PKT_ERROR_SEND_ALL -55:
+          ec_str = "Sender has no tokens to send";
+          break;
+
+      case PKT_ERROR_TRADEOFFER -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR_TRADEOFFER -23:
+          ec_str = "Value out of range or zero";
+          break;
+      case PKT_ERROR_TRADEOFFER -47:
+          ec_str = "Property for sale must be OMNI or TOMNI";
+          break;
+      case PKT_ERROR_TRADEOFFER -49:
+          ec_str = "Sender has no active sell offer for the property";
+          break;
+      case PKT_ERROR_TRADEOFFER -48:
+          ec_str = "Sender already has an active sell offer for the property";
+          break;
+
+      case DEX_ERROR_SELLOFFER -101:
+          ec_str = "Value out of range or zero";
+          break;
+      case DEX_ERROR_SELLOFFER -10:
+          ec_str = "Sender already has an active sell offer for the property";
+          break;
+      case DEX_ERROR_SELLOFFER -25:
+          ec_str = "Sender has insufficient balance";
+          break;
+      case DEX_ERROR_SELLOFFER -11:
+          ec_str = "Sender has no active sell offer for the property";
+          break;
+      case DEX_ERROR_SELLOFFER -12:
+          ec_str = "Sender has no active sell offer for the property";
+          break;
+
+      case DEX_ERROR_ACCEPT -15:
+          ec_str = "No matching sell offer for accept order found";
+          break;
+      case DEX_ERROR_ACCEPT -20:
+          ec_str = "Cannot locate accept to destroy";
+          break;
+      case DEX_ERROR_ACCEPT -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case DEX_ERROR_ACCEPT -23:
+          ec_str = "Value out of range or zero";
+          break;
+      case DEX_ERROR_ACCEPT -205:
+          ec_str = "An accept from the sender to the recipient already exists";
+          break;
+      case DEX_ERROR_ACCEPT -105:
+          ec_str = "Transaction fee too small";
+          break;
+
+      case PKT_ERROR_METADEX -21:
+          ec_str = "Ecosystem is invalid";
+          break;
+      case PKT_ERROR_METADEX -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR_METADEX -25:
+          ec_str = "Sender has insufficient balance";
+          break;
+      case PKT_ERROR_METADEX -29:
+          ec_str = "Property for sale and desired property are not be equal";
+          break;
+      case PKT_ERROR_METADEX -30:
+          ec_str = "Property for sale and desired property are not in the same ecosystem";
+          break;
+      case PKT_ERROR_METADEX -31:
+          ec_str = "Property for sale does not exist";
+          break;
+      case PKT_ERROR_METADEX -32:
+          ec_str = "Property desired does not exist";
+          break;
+      case PKT_ERROR_METADEX -33:
+          ec_str = "Amount for sale out of range or zero";
+          break;
+      case PKT_ERROR_METADEX -34:
+          ec_str = "Amount desired out of range or zero";
+          break;
+      case PKT_ERROR_METADEX -35:
+          ec_str = "One side of the trade must be OMNI or TOMNI";
+          break;
+
+      case METADEX_ERROR -1:
+          ec_str = "Unknown MetaDEx (Add) error";
+          break;
+      case METADEX_ERROR -20:
+          ec_str = "Unknown MetaDEx (Cancel Price) error";
+          break;
+      case METADEX_ERROR -30:
+          ec_str = "Unknown MetaDEx (Cancel Pair) error";
+          break;
+      case METADEX_ERROR -40:
+          ec_str = "Unknown MetaDEx (Cancel Everything) error";
+          break;
+      case METADEX_ERROR -66:
+          ec_str = "Trade has a unit price of zero";
+          break;
+      case METADEX_ERROR -70:
+          ec_str = "Trade already exists";
+          break;
+
+      case PKT_ERROR_SP -20:
+          ec_str = "Block is not in the active chain";
+          break;
+      case PKT_ERROR_SP -21:
+          ec_str = "Ecosystem is invalid";
+          break;
+      case PKT_ERROR_SP -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR_SP -23:
+          ec_str = "Value out of range or zero";
+          break;
+      case PKT_ERROR_SP -24:
+          ec_str = "Desired property does not exist";
+          break;
+      case PKT_ERROR_SP -36:
+          ec_str = "Invalid property type";
+          break;
+      case PKT_ERROR_SP -37:
+          ec_str = "Property name is empty";
+          break;
+      case PKT_ERROR_SP -38:
+          ec_str = "Deadline is in the past";
+          break;
+      case PKT_ERROR_SP -39:
+          ec_str = "Sender has an active crowdsale";
+          break;
+      case PKT_ERROR_SP -40:
+          ec_str = "Sender has no active crowdsale";
+          break;
+      case PKT_ERROR_SP -41:
+          ec_str = "Property identifier mismatch";
+          break;
+      case PKT_ERROR_SP -42:
+          ec_str = "Property is not managed";
+          break;
+      case PKT_ERROR_SP -43:
+          ec_str = "Sender is not the issuer of the property";
+          break;
+      case PKT_ERROR_SP -44:
+          ec_str = "Attempt to grant more than the maximum number of tokens";
+          break;
+      case PKT_ERROR_SP -50:
+          ec_str = "Tokens to issue and desired property are not in the same ecosystem";
+          break;
+
+      case PKT_ERROR_TOKENS -22:
+          ec_str = "Transaction type or version not permitted";
+          break;
+      case PKT_ERROR_TOKENS -23:
+          ec_str = "Value out of range or zero";
+          break;
+      case PKT_ERROR_TOKENS -24:
+          ec_str = "Property does not exist";
+          break;
+      case PKT_ERROR_TOKENS -25:
+          ec_str = "Sender has insufficient balance";
+          break;
+      case PKT_ERROR_TOKENS -39:
+          ec_str = "Sender has an active crowdsale";
+          break;
+      case PKT_ERROR_TOKENS -43:
+          ec_str = "Sender is not the issuer of the property";
+          break;
+      case PKT_ERROR_TOKENS -45:
+          ec_str = "Receiver is empty";
+          break;
+      case PKT_ERROR_TOKENS -46:
+          ec_str = "Receiver has an active crowdsale";
+          break;
+
       default:
           ec_str = "Unknown error";
   }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2502,6 +2502,18 @@ uint32_t COmniTransactionDB::FetchTransactionPosition(const uint256& txid)
     return posInBlock;
 }
 
+std::string COmniTransactionDB::FetchInvalidReason(const uint256& txid)
+{
+    int processingResult = -999999;
+
+    std::vector<std::string> vTransactionDetails = FetchTransactionDetails(txid);
+    if (vTransactionDetails.size() == 2) {
+        processingResult = boost::lexical_cast<int>(vTransactionDetails[1]);
+    }
+
+    return error_str(processingResult);
+}
+
 std::set<int> CMPTxList::GetSeedBlocks(int startHeight, int endHeight)
 {
     std::set<int> setSeedBlocks;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2344,7 +2344,7 @@ bool mastercore_handler_tx(const CTransaction& tx, int nBlock, unsigned int idx,
         if (interp_ret != PKT_ERROR - 2) {
             bool bValid = (0 <= interp_ret);
             p_txlistdb->recordTX(tx.GetHash(), bValid, nBlock, mp_obj.getType(), mp_obj.getNewAmount());
-            p_OmniTXDB->RecordTransaction(tx.GetHash(), idx);
+            p_OmniTXDB->RecordTransaction(tx.GetHash(), idx, interp_ret);
         }
         fFoundTx |= (interp_ret == 0);
     }
@@ -2456,28 +2456,47 @@ int mastercore::WalletTxBuilder(const std::string& senderAddress, const std::str
 
 }
 
-void COmniTransactionDB::RecordTransaction(const uint256& txid, uint32_t posInBlock)
+void COmniTransactionDB::RecordTransaction(const uint256& txid, uint32_t posInBlock, int processingResult)
 {
     assert(pdb);
 
     const std::string key = txid.ToString();
-    const std::string value = strprintf("%d", posInBlock);
+    const std::string value = strprintf("%d:%d", posInBlock, processingResult);
 
     Status status = pdb->Put(writeoptions, key, value);
     ++nWritten;
 }
 
-uint32_t COmniTransactionDB::FetchTransactionPosition(const uint256& txid)
+std::vector<std::string> COmniTransactionDB::FetchTransactionDetails(const uint256& txid)
 {
     assert(pdb);
-
-    const std::string key = txid.ToString();
     std::string strValue;
+    std::vector<std::string> vTransactionDetails;
+
+    Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
+    if (status.ok()) {
+        std::vector<std::string> vStr;
+        boost::split(vStr, strValue, boost::is_any_of(":"), boost::token_compress_on);
+        if (vStr.size() == 2) {
+            vTransactionDetails.push_back(vStr[0]);
+            vTransactionDetails.push_back(vStr[1]);
+        } else {
+            PrintToLog("ERROR: Entry (%s) found in OmniTXDB with unexpected number of attributes!\n", txid.GetHex());
+        }
+    } else {
+        PrintToLog("ERROR: Entry (%s) could not be loaded from OmniTXDB!\n", txid.GetHex());
+    }
+
+    return vTransactionDetails;
+}
+
+uint32_t COmniTransactionDB::FetchTransactionPosition(const uint256& txid)
+{
     uint32_t posInBlock = 999999; // setting an initial arbitrarily high value will ensure transaction is always "last" in event of bug/exploit
 
-    Status status = pdb->Get(readoptions, key, &strValue);
-    if (status.ok()) {
-        posInBlock = boost::lexical_cast<uint32_t>(strValue);
+    std::vector<std::string> vTransactionDetails = FetchTransactionDetails(txid);
+    if (vTransactionDetails.size() == 2) {
+        posInBlock = boost::lexical_cast<uint32_t>(vTransactionDetails[0]);
     }
 
     return posInBlock;

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -36,7 +36,7 @@ int const MAX_STATE_HISTORY = 50;
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 
 // increment this value to force a refresh of the state (similar to --startclean)
-#define DB_VERSION 3
+#define DB_VERSION 5
 
 // could probably also use: int64_t maxInt64 = std::numeric_limits<int64_t>::max();
 // maximum numeric values from the spec:

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -180,6 +180,7 @@ public:
     void RecordTransaction(const uint256& txid, uint32_t posInBlock, int processingResult);
     std::vector<std::string> FetchTransactionDetails(const uint256& txid);
     uint32_t FetchTransactionPosition(const uint256& txid);
+    std::string FetchInvalidReason(const uint256& txid);
 };
 
 /** LevelDB based storage for STO recipients.

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -177,7 +177,8 @@ public:
      *
      * and so on...
      */
-    void RecordTransaction(const uint256& txid, uint32_t posInBlock);
+    void RecordTransaction(const uint256& txid, uint32_t posInBlock, int processingResult);
+    std::vector<std::string> FetchTransactionDetails(const uint256& txid);
     uint32_t FetchTransactionPosition(const uint256& txid);
 };
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1674,6 +1674,7 @@ UniValue omni_gettransaction(const UniValue& params, bool fHelp)
             "  \"fee\" : \"n.nnnnnnnn\",             (string) the transaction fee in bitcoins\n"
             "  \"blocktime\" : nnnnnnnnnn,         (number) the timestamp of the block that contains the transaction\n"
             "  \"valid\" : true|false,             (boolean) whether the transaction is valid\n"
+            "  \"invalidreason\" : \"reason\",     (string) if a transaction is invalid, the reason \n"
             "  \"version\" : n,                    (number) the transaction version\n"
             "  \"type_int\" : n,                   (number) the transaction type as number\n"
             "  \"type\" : \"type\",                  (string) the transaction type as string\n"

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -143,6 +143,9 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
     // state and chain related information
     if (confirmations != 0 && !blockHash.IsNull()) {
         txobj.push_back(Pair("valid", valid));
+        if (!valid) {
+            txobj.push_back(Pair("invalidreason", p_OmniTXDB->FetchInvalidReason(txid)));
+        }
         txobj.push_back(Pair("blockhash", blockHash.GetHex()));
         txobj.push_back(Pair("blocktime", blockTime));
         txobj.push_back(Pair("positioninblock", positionInBlock));


### PR DESCRIPTION
This PR adds the ability for Omni Core to persistently store the reason that a transaction was invalidated and make this available via the RPC interface.

When a transaction is queried via the `omni_gettransaction` call, if the transaction is invalid then the RPC output will carry an additional attribute called "invalidreason" which contains a string detailing the reason the transaction was invalidated.

The changes are limited to storing the processing return code in levelDB, and do not affect consensus.

Examples of some invalid transactions:

```
$ src/omnicore-cli omni_gettransaction 290e48dacfb83ab49866e83e4bf936679536bc971c373665ad01e20ca32f0fa1
{
  "txid": "290e48dacfb83ab49866e83e4bf936679536bc971c373665ad01e20ca32f0fa1",
  "fee": "0.00100000",
  "sendingaddress": "1FzkeFAWdEv3Eokb7PBe7Ygrbfb6d7c9cf",
  "referenceaddress": "1Po1oWkD2LmodfkBYiAktwh76vkF93LKnh",
  "ismine": false,
  "version": 0,
  "type_int": 0,
  "type": "Simple Send",
  "propertyid": 31,
  "divisible": true,
  "amount": "84.21748017",
  "valid": false,
  "invalidreason": "Sender has insufficient balance",
  "blockhash": "000000000000000000c9a696e00609fd78aae6f5dcde1e5975adfe48f99216d5",
  "blocktime": 1510871747,
  "positioninblock": 1665,
  "block": 494684,
  "confirmations": 35
}
```
```
$ ./src/omnicore-cli omni_gettransaction 48a2dab06fb9dd514220b8944a33efe18162414ea3113a75974311783a04e31f
{
  "txid": "48a2dab06fb9dd514220b8944a33efe18162414ea3113a75974311783a04e31f",
  "fee": "0.00465500",
  "sendingaddress": "1DGUWy6N6iHTpussbSP8XrK96tZgDboiWK",
  "referenceaddress": "1gJ4FX7n4Udk1LVUSnutAgznyG9JZdQEU",
  "ismine": false,
  "version": 0,
  "type_int": 4,
  "type": "Send All",
  "ecosystem": "main",
  "valid": false,
  "invalidreason": "Sender has no tokens to send",
  "blockhash": "0000000000000000004d1fe8052ef1c84c8e5b49d1f7048fa4cd8d1c5a4ff3b4",
  "blocktime": 1510526943,
  "positioninblock": 246,
  "block": 494110,
  "confirmations": 605
}
```
```
$ ./src/omnicore-cli omni_gettransaction 449dfc6ac0d67f66eba40c8bc7a44752b0fda5f7dfd2fe8e98be496fd2bfd4a5
{
  "txid": "449dfc6ac0d67f66eba40c8bc7a44752b0fda5f7dfd2fe8e98be496fd2bfd4a5",
  "fee": "0.00029000",
  "sendingaddress": "1TLzm1ctVxqgTckWN9zdAZHrQzeWgYyed",
  "referenceaddress": "1CW3LZein5UdRdjeVV2t1U1TXpemBQdkGS",
  "ismine": false,
  "version": 0,
  "type_int": 55,
  "type": "Grant Property Tokens",
  "propertyid": 31,
  "divisible": true,
  "amount": "25000000.00000000",
  "valid": false,
  "invalidreason": "Sender is not the issuer of the property",
  "blockhash": "000000000000000000af437c3a36994d5ff3667118658bc6f41e8160aded866c",
  "blocktime": 1510041583,
  "positioninblock": 2002,
  "block": 493431,
  "confirmations": 1284
}
```
```
$ ./src/omnicore-cli omni_gettransaction ea2cab0efb2181927265b347ea2a9f17eb7f4b92aa050b84cb0f54f9933dcf3c
{
  "txid": "ea2cab0efb2181927265b347ea2a9f17eb7f4b92aa050b84cb0f54f9933dcf3c",
  "fee": "0.00200000",
  "sendingaddress": "3E9NmZ4A6Yw6iEYruLtagzHBvndUmAcqNW",
  "referenceaddress": "3BbDtxBSjgfTRxaBUgR2JACWRukLKtZdiQ",
  "ismine": false,
  "version": 0,
  "type_int": 0,
  "type": "Simple Send",
  "propertyid": 41,
  "divisible": true,
  "amount": "0.00000000",
  "valid": false,
  "invalidreason": "Value out of range or zero",
  "blockhash": "000000000000000000a49ea8bbe71de924f8b027cc77f83ba6a1cd8324523bcf",
  "blocktime": 1510587900,
  "positioninblock": 2404,
  "block": 494217,
  "confirmations": 498
}
```
```
$ ./src/omnicore-cli omni_gettransaction b5f45f70559d59ad1dc50fb8be3c1402d1829eb126c574e2d18fc5be2441b872
{
  "txid": "b5f45f70559d59ad1dc50fb8be3c1402d1829eb126c574e2d18fc5be2441b872",
  "fee": "0.00068649",
  "sendingaddress": "1Ctwr4qjEvESKgdW1PDUPSAAnKFCyLYMH3",
  "referenceaddress": "1Asx1zx92VVwbKVrjM71r9RKcQo5f5Sush",
  "ismine": false,
  "version": 0,
  "type_int": 22,
  "type": "DEx Accept Offer",
  "propertyid": 1,
  "divisible": true,
  "amount": "0.06056019",
  "valid": false,
  "invalidreason": "An accept from the sender to the recipient already exists",
  "blockhash": "00000000000000000085210193e850f228866bf1d59e8f0731000ad36fcaf21f",
  "blocktime": 1509364758,
  "positioninblock": 2216,
  "block": 492342,
  "confirmations": 2373
}
```