### PR TITLE
Add omni_getbalanceshash RPC

### DIFF
--- a/src/omnicore/consensushash.cpp
+++ b/src/omnicore/consensushash.cpp
@@ -310,4 +310,36 @@ uint256 GetMetaDExHash(const uint32_t propertyId)
     return metadexHash;
 }
 
+/** Obtains a hash of the balances for a specific property. */
+uint256 GetBalancesHash(const uint32_t hashPropertyId)
+{
+    SHA256_CTX shaCtx;
+    SHA256_Init(&shaCtx);
+
+    LOCK(cs_tally);
+
+    std::map<std::string, CMPTally> tallyMapSorted;
+    for (std::unordered_map<string, CMPTally>::iterator uoit = mp_tally_map.begin(); uoit != mp_tally_map.end(); ++uoit) {
+        tallyMapSorted.insert(std::make_pair(uoit->first,uoit->second));
+    }
+    for (std::map<string, CMPTally>::iterator my_it = tallyMapSorted.begin(); my_it != tallyMapSorted.end(); ++my_it) {
+        const std::string& address = my_it->first;
+        CMPTally& tally = my_it->second;
+        tally.init();
+        uint32_t propertyId = 0;
+        while (0 != (propertyId = (tally.next()))) {
+            if (propertyId != hashPropertyId) continue;
+            std::string dataStr = GenerateConsensusString(tally, address, propertyId);
+            if (dataStr.empty()) continue;
+            if (msc_debug_consensus_hash) PrintToLog("Adding data to balances hash: %s\n", dataStr);
+            SHA256_Update(&shaCtx, dataStr.c_str(), dataStr.length());
+        }
+    }
+
+    uint256 balancesHash;
+    SHA256_Final((unsigned char*)&balancesHash, &shaCtx);
+
+    return balancesHash;
+}
+
 } // namespace mastercore

--- a/src/omnicore/consensushash.h
+++ b/src/omnicore/consensushash.h
@@ -14,6 +14,9 @@ uint256 GetConsensusHash();
 /** Obtains a hash of the overall MetaDEx state (default) or a specific orderbook (supply a property ID). */
 uint256 GetMetaDExHash(const uint32_t propertyId = 0);
 
+/** Obtains a hash of the balances for a specific property. */
+uint256 GetBalancesHash(const uint32_t hashPropertyId);
+
 }
 
 #endif // OMNICORE_CONSENSUSHASH_H

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -2157,6 +2157,47 @@ UniValue omni_getmetadexhash(const UniValue& params, bool fHelp)
     return response;
 }
 
+UniValue omni_getbalanceshash(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "omni_getbalanceshash propertyid\n"
+            "\nReturns a hash of the balances for the property.\n"
+            "\nArguments:\n"
+            "1. propertyid                  (number, required) the property to hash balances for\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"block\" : nnnnnn,          (number) the index of the block this hash applies to\n"
+            "  \"blockhash\" : \"hash\",    (string) the hash of the corresponding block\n"
+            "  \"propertyid\" : nnnnnn,     (number) the property id of the hashed balances\n"
+            "  \"balanceshash\" : \"hash\"  (string) the hash for the balances\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("omni_getbalanceshash", "31")
+            + HelpExampleRpc("omni_getbalanceshash", "31")
+        );
+
+    LOCK(cs_main);
+
+    uint32_t propertyId = ParsePropertyId(params[0]);
+    RequireExistingProperty(propertyId);
+
+    int block = GetHeight();
+    CBlockIndex* pblockindex = chainActive[block];
+    uint256 blockHash = pblockindex->GetBlockHash();
+
+    uint256 balancesHash = GetBalancesHash(propertyId);
+
+    UniValue response(UniValue::VOBJ);
+    response.push_back(Pair("block", block));
+    response.push_back(Pair("blockhash", blockHash.GetHex()));
+    response.push_back(Pair("propertyid", (uint64_t)propertyId));
+    response.push_back(Pair("balanceshash", balancesHash.GetHex()));
+
+    return response;
+}
+
 static const CRPCCommand commands[] =
 { //  category                             name                            actor (function)               okSafeMode
   //  ------------------------------------ ------------------------------- ------------------------------ ----------
@@ -2187,6 +2228,7 @@ static const CRPCCommand commands[] =
     { "omni layer (data retrieval)", "omni_getfeetrigger",             &omni_getfeetrigger,              false },
     { "omni layer (data retrieval)", "omni_getfeedistribution",        &omni_getfeedistribution,         false },
     { "omni layer (data retrieval)", "omni_getfeedistributions",       &omni_getfeedistributions,        false },
+    { "omni layer (data retrieval)", "omni_getbalanceshash",           &omni_getbalanceshash,            false },
 #ifdef ENABLE_WALLET
     { "omni layer (data retrieval)", "omni_listtransactions",          &omni_listtransactions,           false },
     { "omni layer (data retrieval)", "omni_getfeeshare",               &omni_getfeeshare,                false },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -135,6 +135,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getfeetrigger", 0 },
     { "omni_getfeedistribution", 0 },
     { "omni_getfeedistributions", 0 },
+    { "omni_getbalanceshash", 0 },
 
     /* Omni Core - transaction calls */
     { "omni_send", 2 },


### PR DESCRIPTION
This PR extends the consensus hash system to enable the hashing of one specific set of property balances.

The RPC `omni_getbalanceshash` is used to iterate over the tally and obtain a hash of all the balances for a specific property.

This functionality is useful for OE's engine, which currently freshes every balance for every property each block. 
