### PR TITLE
Travis CI: move back to the minimal image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   hostname: bitcoin-tester
 
 os: linux
-language: generic
+language: minimal
 cache:
   directories:
   - depends/built


### PR DESCRIPTION
Original https://github.com/bitcoin/bitcoin/pull/11521:

---

The most recent update replaced the minimal image with a large one for the
'generic' image. Switching back to 'minimal' should reduce dependencies and
maybe speed us up some.

It should also eliminiate the need for https://github.com/bitcoin/bitcoin/commit/aa2e0f09ec94dd0908f792ebc2249859ad174586.

---

This should fix our CI issues.