### PR TITLE
Reintroduce forced client upgrade

### DIFF
--- a/src/omnicore/activation.cpp
+++ b/src/omnicore/activation.cpp
@@ -14,6 +14,8 @@
 #include "main.h"
 #include "ui_interface.h"
 
+#include <boost/filesystem.hpp>
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -89,6 +91,8 @@ void CheckLiveActivations(int blockHeight)
             PrintToLog(msgText);
             PrintToConsole(msgText);
             if (!GetBoolArg("-overrideforcedshutdown", false)) {
+                boost::filesystem::path persistPath = GetDataDir() / "MP_persist";
+                if (boost::filesystem::exists(persistPath)) boost::filesystem::remove_all(persistPath); // prevent the node being restarted without a reparse after forced shutdown
                 AbortNode(msgText, msgText);
             }
         }

--- a/src/omnicore/fees.cpp
+++ b/src/omnicore/fees.cpp
@@ -102,7 +102,11 @@ void COmniFeeCache::AddFee(const uint32_t &propertyId, int block, const int64_t 
         // overflow - there is no way the fee cache should exceed the maximum possible number of tokens, not safe to continue
         const std::string& msg = strprintf("Shutting down due to fee cache overflow (block %d property %d current %d amount %d)\n", block, propertyId, currentCachedAmount, amount);
         PrintToLog(msg);
-        if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode(msg, msg);
+        if (!GetBoolArg("-overrideforcedshutdown", false)) {
+            boost::filesystem::path persistPath = GetDataDir() / "MP_persist";
+            if (boost::filesystem::exists(persistPath)) boost::filesystem::remove_all(persistPath); // prevent the node being restarted without a reparse after forced shutdown
+            AbortNode(msg, msg);
+        }
     }
     int64_t newCachedAmount = currentCachedAmount + amount;
 

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -94,6 +94,7 @@ bool CheckAlertAuthorization(const std::string& sender)
     whitelisted.insert("16oDZYCspsczfgKXVj3xyvsxH21NpEj94F"); // Adam    <adam@omni.foundation>
     whitelisted.insert("1883ZMsRJfzKNozUBJBTCxQ7EaiNioNDWz"); // Zathras <zathras@omni.foundation>
     whitelisted.insert("1HHv91gRxqBzQ3gydMob3LU8hqXcWoLfvd"); // dexX7   <dexx@bitwatch.co>
+    whitelisted.insert("34kwkVRSvFVEoUwcQSgpQ4ZUasuZ54DJLD"); // multisig (signatories are Craig, Adam, Zathras, dexX7, JR)
 
     // Testnet / Regtest
     // use -omnialertallowsender for testing

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3807,7 +3807,11 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
         // failed checkpoint, can't be trusted to provide valid data - shutdown client
         const std::string& msg = strprintf("Shutting down due to failed checkpoint for block %d (hash %s)\n", nBlockNow, pBlockIndex->GetBlockHash().GetHex());
         PrintToLog(msg);
-        if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode(msg, msg);
+        if (!GetBoolArg("-overrideforcedshutdown", false)) {
+            boost::filesystem::path persistPath = GetDataDir() / "MP_persist";
+            if (boost::filesystem::exists(persistPath)) boost::filesystem::remove_all(persistPath); // prevent the node being restarted without a reparse after forced shutdown
+            AbortNode(msg, msg);
+        }
     } else {
         // save out the state after this block
         if (writePersistence(nBlockNow)) {

--- a/src/omnicore/test/test_clientexpiry.sh
+++ b/src/omnicore/test/test_clientexpiry.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+SRCDIR=./src/
+NUL=/dev/null
+PASS=0
+FAIL=0
+clear
+printf "Preparing a test environment...\n"
+printf "   * Starting a fresh regtest daemon\n"
+rm -r ~/.bitcoin/regtest
+$SRCDIR/omnicored --regtest --server --daemon --omnialertallowsender=any >$NUL
+sleep 10
+printf "   * Preparing some mature testnet BTC\n"
+$SRCDIR/omnicore-cli --regtest generate 102 >$NUL
+printf "   * Obtaining a master address to work with\n"
+ADDR=$($SRCDIR/omnicore-cli --regtest getnewaddress OMNIAccount)
+printf "   * Funding the address with some testnet BTC for fees\n"
+$SRCDIR/omnicore-cli --regtest sendtoaddress $ADDR 20 >$NUL
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   * Sending an alert with client expiry version of 999999999\n"
+$SRCDIR/omnicore-cli --regtest omni_sendalert $ADDR 3 999999999 "Client version out of date test." >$NUL
+$SRCDIR/omnicore-cli --regtest generate 1 >$NUL
+printf "   * The client should now be shutting down, sleeping 5 seconds and then attempting to get block height - this should FAIL.\n"
+sleep 5
+printf "\nWe should have shut down now, if we can still query the block height, something is wrong.\n"
+BLOCKFINAL=$($SRCDIR/omnicore-cli --regtest getblockcount)
+printf "   * The current block height is %d\n" $BLOCKFINAL

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -2058,6 +2058,8 @@ int CMPTransaction::logicMath_Alert()
             PrintToLog(msgText);
             PrintToConsole(msgText);
             if (!GetBoolArg("-overrideforcedshutdown", false)) {
+                boost::filesystem::path persistPath = GetDataDir() / "MP_persist";
+                if (boost::filesystem::exists(persistPath)) boost::filesystem::remove_all(persistPath); // prevent the node being restarted without a reparse after forced shutdown
                 AbortNode(msgText, msgText);
             }
         }

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -13,6 +13,8 @@
 #include "omnicore/rules.h"
 #include "omnicore/sp.h"
 #include "omnicore/sto.h"
+#include "omnicore/utilsbitcoin.h"
+#include "omnicore/version.h"
 
 #include "amount.h"
 #include "main.h"
@@ -2047,6 +2049,18 @@ int CMPTransaction::logicMath_Alert()
     if (!authorized) {
         PrintToLog("%s(): rejected: sender %s is not authorized for alerts\n", __func__, sender);
         return (PKT_ERROR -51);
+    }
+
+    if (alert_type == ALERT_CLIENT_VERSION_EXPIRY && OMNICORE_VERSION < alert_expiry) {
+        // regular alert keys CANNOT be used to force a client upgrade on mainnet - at least 3 signatures from board/devs are required
+        if (sender == "34kwkVRSvFVEoUwcQSgpQ4ZUasuZ54DJLD" || isNonMainNet()) {
+            std::string msgText = "Client upgrade is required!  Shutting down due to unsupported consensus state!";
+            PrintToLog(msgText);
+            PrintToConsole(msgText);
+            if (!GetBoolArg("-overrideforcedshutdown", false)) {
+                AbortNode(msgText, msgText);
+            }
+        }
     }
 
     if (alert_type == 65535) { // set alert type to FFFF to clear previously sent alerts


### PR DESCRIPTION
This PR reintroduces the forced client upgrade ability of the alerting system.

This capability was removed when the feature activation system was introduced.  A forced client upgrade is currently still enforced for clients that don't support a new feature being activated, but a forced client upgrade could not be applied in any other circumstances (such as if a critical bug or exploit was discovered).

This PR reintroduces the capability but with one difference; regular alert keys can no longer be used to force a client upgrade - only if the alert is received from the foundation P2SH address with at least 3 signatures from board/devs will it be accepted by the client.

Should go without saying, but for emergency use only.
