### PR TITLE
Fix JSON input conversions, remove checks, when creating raw payloads

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -224,6 +224,10 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_createpayload_canceltradesbypair", 0 },
     { "omni_createpayload_canceltradesbypair", 1 },
     { "omni_createpayload_cancelalltrades", 0 },
+    { "omni_createpayload_enablefreezing", 0 },
+    { "omni_createpayload_disablefreezing", 0 },
+    { "omni_createpayload_freeze", 1 },
+    { "omni_createpayload_unfreeze", 1 },
 
     /* Omni Core - backwards compatibility */
     { "getcrowdsale_MP", 0 },


### PR DESCRIPTION
1. Some RPCs had no proper input value conversion and as result these calls failed.

2. All state based checks were removed, when creating raw payloads. The checks are only possible, if the server is synchronized, but this isn't usually the case, when creating raw transactions.