### PR TITLE
Add freezing transaction data to omni_gettransaction

### DIFF
--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -218,6 +218,18 @@ void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txTyp
         case MSC_TYPE_CHANGE_ISSUER_ADDRESS:
             populateRPCTypeChangeIssuer(mp_obj, txobj);
             break;
+        case MSC_TYPE_ENABLE_FREEZING:
+            populateRPCTypeEnableFreezing(mp_obj, txobj);
+            break;
+        case MSC_TYPE_DISABLE_FREEZING:
+            populateRPCTypeDisableFreezing(mp_obj, txobj);
+            break;
+        case MSC_TYPE_FREEZE_PROPERTY_TOKENS:
+            populateRPCTypeFreezeTokens(mp_obj, txobj);
+            break;
+        case MSC_TYPE_UNFREEZE_PROPERTY_TOKENS:
+            populateRPCTypeUnfreezeTokens(mp_obj, txobj);
+            break;
         case OMNICORE_MESSAGE_TYPE_ACTIVATION:
             populateRPCTypeActivation(mp_obj, txobj);
             break;
@@ -245,6 +257,10 @@ bool showRefForTx(uint32_t txType)
         case MSC_TYPE_REVOKE_PROPERTY_TOKENS: return false;
         case MSC_TYPE_CHANGE_ISSUER_ADDRESS: return true;
         case MSC_TYPE_SEND_ALL: return true;
+        case MSC_TYPE_ENABLE_FREEZING: return false;
+        case MSC_TYPE_DISABLE_FREEZING: return false;
+        case MSC_TYPE_FREEZE_PROPERTY_TOKENS: return true;
+        case MSC_TYPE_UNFREEZE_PROPERTY_TOKENS: return true;
         case OMNICORE_MESSAGE_TYPE_ACTIVATION: return false;
     }
     return true; // default to true, shouldn't be needed but just in case
@@ -517,6 +533,25 @@ void populateRPCTypeActivation(CMPTransaction& omniObj, UniValue& txobj)
     txobj.push_back(Pair("featureid", (uint64_t) omniObj.getFeatureId()));
     txobj.push_back(Pair("activationblock", (uint64_t) omniObj.getActivationBlock()));
     txobj.push_back(Pair("minimumversion", (uint64_t) omniObj.getMinClientVersion()));
+}
+
+void populateRPCTypeEnableFreezing(CMPTransaction& omniObj, UniValue& txobj)
+{
+    txobj.push_back(Pair("propertyid", (uint64_t) omniObj.getProperty()));
+}
+
+void populateRPCTypeDisableFreezing(CMPTransaction& omniObj, UniValue& txobj)
+{
+    txobj.push_back(Pair("propertyid", (uint64_t) omniObj.getProperty()));
+}
+void populateRPCTypeFreezeTokens(CMPTransaction& omniObj, UniValue& txobj)
+{
+    txobj.push_back(Pair("propertyid", (uint64_t) omniObj.getProperty()));
+}
+
+void populateRPCTypeUnfreezeTokens(CMPTransaction& omniObj, UniValue& txobj)
+{
+    txobj.push_back(Pair("propertyid", (uint64_t) omniObj.getProperty()));
 }
 
 void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, UniValue& txobj, uint16_t version)

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -31,6 +31,10 @@ void populateRPCTypeGrant(CMPTransaction& omniObj, UniValue& txobj);
 void populateRPCTypeRevoke(CMPTransaction& omniOobj, UniValue& txobj);
 void populateRPCTypeChangeIssuer(CMPTransaction& omniObj, UniValue& txobj);
 void populateRPCTypeActivation(CMPTransaction& omniObj, UniValue& txobj);
+void populateRPCTypeEnableFreezing(CMPTransaction& omniObj, UniValue& txobj);
+void populateRPCTypeDisableFreezing(CMPTransaction& omniObj, UniValue& txobj);
+void populateRPCTypeFreezeTokens(CMPTransaction& omniObj, UniValue& txobj);
+void populateRPCTypeUnfreezeTokens(CMPTransaction& omniObj, UniValue& txobj);
 
 void populateRPCExtendedTypeSendToOwners(const uint256 txid, std::string extendedDetailsFilter, UniValue& txobj, uint16_t version);
 void populateRPCExtendedTypeMetaDExTrade(const uint256& txid, uint32_t propertyIdForSale, int64_t amountForSale, UniValue& txobj);


### PR DESCRIPTION
When using `omni_gettransaction`, the related fields are now included in the result.