### PR TITLE
No longer print Exodus balance after startup

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1651,7 +1651,6 @@ int mastercore_init()
     int64_t exodus_balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);
     PrintToLog("Exodus balance after initialization: %s\n", FormatDivisibleMP(exodus_balance));
 
-    PrintToConsole("Exodus balance: %s OMNI\n", FormatDivisibleMP(exodus_balance));
     PrintToConsole("Omni Core initialization completed\n");
 
     return 0;


### PR DESCRIPTION
This was a relic from the past. The "Exodus address" is linked to the Omni foundation and printing the balance during startup served as indicator, whether the client loaded properly.

Thanks to @congnghiakhiem, who pointed this out in #578.