### PR TITLE
Make parsing more robust by persisting state every 10000 blocks

### DIFF
--- a/src/omnicore/dbtxlist.cpp
+++ b/src/omnicore/dbtxlist.cpp
@@ -497,6 +497,12 @@ void CMPTxList::LoadAlerts(int blockHeight)
             PrintToLog("ERROR: While loading alert %s: tx in levelDB but does not exist.\n", txid.GetHex());
             continue;
         }
+        CBlockIndex* pBlockIndex = GetBlockIndex(blockHash);
+        int currentBlockHeight = pBlockIndex->nHeight;
+        if (currentBlockHeight > blockHeight) {
+            // skipping, because it's in the future
+            continue;
+        }
         if (0 != ParseTransaction(wtx, blockHeight, 0, mp_obj)) {
             PrintToLog("ERROR: While loading alert %s: failed ParseTransaction.\n", txid.GetHex());
             continue;
@@ -577,8 +583,12 @@ void CMPTxList::LoadActivations(int blockHeight)
             PrintToLog("ERROR: While loading activation transaction %s: failed to retrieve block index.\n", hash.GetHex());
             continue;
         }
-        int blockHeight = pBlockIndex->nHeight;
-        if (0 != ParseTransaction(wtx, blockHeight, 0, mp_obj)) {
+        int currentBlockHeight = pBlockIndex->nHeight;
+        if (currentBlockHeight > blockHeight) {
+            // skipping, because it's in the future
+            continue;
+        }
+        if (0 != ParseTransaction(wtx, currentBlockHeight, 0, mp_obj)) {
             PrintToLog("ERROR: While loading activation transaction %s: failed ParseTransaction.\n", hash.GetHex());
             continue;
         }
@@ -652,12 +662,12 @@ bool CMPTxList::LoadFreezeState(int blockHeight)
             PrintToLog("ERROR: While loading freeze transaction %s: failed to retrieve block index.\n", hash.GetHex());
             return false;
         }
-        int txBlockHeight = pBlockIndex->nHeight;
-        if (txBlockHeight > blockHeight) {
-            PrintToLog("ERROR: While loading freeze transaction %s: transaction is in the future.\n", hash.GetHex());
-            return false;
+        int currentBlockHeight = pBlockIndex->nHeight;
+        if (currentBlockHeight > blockHeight) {
+            // skipping, because it's in the future
+            continue;
         }
-        if (0 != ParseTransaction(wtx, txBlockHeight, 0, mp_obj)) {
+        if (0 != ParseTransaction(wtx, currentBlockHeight, 0, mp_obj)) {
             PrintToLog("ERROR: While loading freeze transaction %s: failed ParseTransaction.\n", hash.GetHex());
             return false;
         }

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -25,6 +25,7 @@ class CTransaction;
 #include <unordered_map>
 
 int const MAX_STATE_HISTORY = 50;
+int const STORE_EVERY_N_BLOCK = 10000;
 
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 


### PR DESCRIPTION
Currently state is persisted for the last 50 blocks away from the chain tip.

This is fine in most cases, but during a reparse, when the chain is fully synchronized, no state is stored until the chain tip is reached. This is an issue, if the client is shutdown during the reparse, because it must then start from the beginning.

To avoid this, the state is permanently stored every 10000 blocks. When there is also an inconsistency, in particular because one or more state files are missing, the blocks are reverted until the next point. In practice, this may look like this:

![image](https://user-images.githubusercontent.com/5836089/39111870-e8e0c2c6-46d6-11e8-9ef0-ca6184c41eed.png)

As bonus, no state is persisted before the system was actually live, which speeds up the initial synchronization up to this point.

In summary, this pull request makes the initial parsing process a lot more robust and slightly speeds up parsing the very first time. It also allows to abort the initial scanning without the need to start from the very beginning.