### PR TITLE
Fix fail safe iteration when forming ECDSA point

### DIFF
--- a/src/omnicore/encoding.cpp
+++ b/src/omnicore/encoding.cpp
@@ -53,7 +53,7 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
             vchFakeKey.resize(33);
             CPubKey pubKey;
             unsigned char chRandom = static_cast<unsigned char>(GetRand(256));
-            for (int j = 0; i < 256 ; j++) { // Fix ECDSA coodinate
+            for (int j = 0; j < 256 ; j++) { // Fix ECDSA coodinate
                 vchFakeKey[32] = chRandom;
                 pubKey = CPubKey(vchFakeKey);
                 if (pubKey.IsFullyValid()) break;


### PR DESCRIPTION
The last byte of a pubkey of Class B transactions is iterated until a valid ECDSA point is formed. A valid point is usually right around the corner, but there is a fail safe included to avoid looping the last byte forever, in case there is none. The loop for this was faulty and is fixed now.

Thanks to @lxjxiaojun for spotting this!

This pull request resolves #633.