### PR TITLE
Update default value for end block of omni_listtransactions

### DIFF
--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1759,7 +1759,7 @@ UniValue omni_listtransactions(const UniValue& params, bool fHelp)
     int64_t nStartBlock = 0;
     if (params.size() > 3) nStartBlock = params[3].get_int64();
     if (nStartBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative start block");
-    int64_t nEndBlock = 999999;
+    int64_t nEndBlock = 999999999;
     if (params.size() > 4) nEndBlock = params[4].get_int64();
     if (nEndBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative end block");
 


### PR DESCRIPTION
The old default value was not larger than the testnet chain length, which caused transactions not to show up per default.

Thanks to @phanalpha for finding this!