### PR TITLE
Add API to create funded raw transactions

### DIFF
--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -37,13 +37,15 @@ using namespace mastercore;
 
 UniValue omni_createfunded_send(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 5)
+    if (fHelp || params.size() < 5 || params.size() > 6)
         throw runtime_error(
-            "omni_createfunded_send \"fromaddress\" \"toaddress\" propertyid \"amount\" \"feeaddress\"\n"
+            "omni_createfunded_send \"fromaddress\" \"toaddress\" propertyid \"amount\" \"feeaddress\" ( lockunspent )\n"
 
             "\nCreates a funded simple send raw transaction.\n"
 
             "\nAll coins from the sender are consumed and if there are coins missing, they are taken from the specified fee source. Change is sent to the fee source!\n"
+
+            "\nAs per default, the unspent outputs of this transaction are locked, to avoid that they are used for the construction of another transaction!\n"
 
             "\nArguments:\n"
             "1. fromaddress          (string, required) the address to send from\n"
@@ -51,6 +53,7 @@ UniValue omni_createfunded_send(const UniValue& params, bool fHelp)
             "3. propertyid           (number, required) the identifier of the tokens to send\n"
             "4. amount               (string, required) the amount to send\n"
             "5. feeaddress           (string, required) the address that is used to pay for fees, if needed\n"
+            "6. lockunspent          (boolean, optional) lock selected unspent outputs (default: true)\n"
 
             "\nResult:\n"
             "\"hex\"                 (string) the hex-encoded raw transaction\n"
@@ -66,6 +69,10 @@ UniValue omni_createfunded_send(const UniValue& params, bool fHelp)
     uint32_t propertyId = ParsePropertyId(params[2]);
     int64_t amount = ParseAmount(params[3], isPropertyDivisible(propertyId));
     std::string feeAddress = ParseAddress(params[4]);
+    bool lockUnspents = true;
+    if (params.size() > 5) {
+        lockUnspents = params[5].get_bool();
+    }
 
     // perform checks
     RequireExistingProperty(propertyId);
@@ -76,7 +83,7 @@ UniValue omni_createfunded_send(const UniValue& params, bool fHelp)
 
     // create the raw transaction
     std::string rawHex;
-    int result = CreateFundedTransaction(fromAddress, toAddress, feeAddress, payload, rawHex);
+    int result = CreateFundedTransaction(fromAddress, toAddress, feeAddress, payload, rawHex, lockUnspents);
     if (result != 0) {
         throw JSONRPCError(result, error_str(result));
     }
@@ -86,19 +93,22 @@ UniValue omni_createfunded_send(const UniValue& params, bool fHelp)
 
 UniValue omni_createfunded_sweep(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 4)
+    if (fHelp || params.size() < 4 || params.size() > 5)
         throw runtime_error(
-            "omni_createfunded_sweep \"fromaddress\" \"toaddress\" ecosystem \"feeaddress\"\n"
+            "omni_createfunded_sweep \"fromaddress\" \"toaddress\" ecosystem \"feeaddress\" ( lockunspent )\n"
 
             "\nCreates a raw transaction that transfers all available tokens in the given ecosystem to the recipient.\n"
 
             "\nAll coins from the sender are consumed and if there are coins missing, they are taken from the specified fee source. Change is sent to the fee source!\n"
+
+            "\nAs per default, the unspent outputs of this transaction are locked, to avoid that they are used for the construction of another transaction!\n"
 
             "\nArguments:\n"
             "1. fromaddress          (string, required) the address to send from\n"
             "2. toaddress            (string, required) the address of the receiver\n"
             "3. ecosystem            (number, required) the ecosystem of the tokens to send (1 for main ecosystem, 2 for test ecosystem)\n"
             "4. feeaddress           (string, required) the address that is used to pay for fees, if needed\n"
+            "5. lockunspent          (boolean, optional) lock selected unspent outputs (default: true)\n"
 
             "\nResult:\n"
             "\"hex\"                 (string) the hex-encoded raw transaction\n"
@@ -113,13 +123,17 @@ UniValue omni_createfunded_sweep(const UniValue& params, bool fHelp)
     std::string toAddress = ParseAddress(params[1]);
     uint8_t ecosystem = ParseEcosystem(params[2]);
     std::string feeAddress = ParseAddress(params[3]);
+    bool lockUnspents = true;
+    if (params.size() > 4) {
+        lockUnspents = params[4].get_bool();
+    }
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SendAll(ecosystem);
 
     // create the raw transaction
     std::string rawHex;
-    int result = CreateFundedTransaction(fromAddress, toAddress, feeAddress, payload, rawHex);
+    int result = CreateFundedTransaction(fromAddress, toAddress, feeAddress, payload, rawHex, lockUnspents);
     if (result != 0) {
         throw JSONRPCError(result, error_str(result));
     }

--- a/src/omnicore/wallettxbuilder.cpp
+++ b/src/omnicore/wallettxbuilder.cpp
@@ -119,6 +119,7 @@ int WalletTxBuilder(
 
 }
 
+#ifdef ENABLE_WALLET
 /** Locks all available coins that are not in the set of destinations. */
 static void LockUnrelatedCoins(
         CWallet* pwallet,
@@ -166,6 +167,7 @@ static void UnlockCoins(
         pwallet->UnlockCoin(output);
     }
 }
+#endif
 
 /**
  * Creates and funds a raw transaction by selecting all coins from the sender

--- a/src/omnicore/wallettxbuilder.h
+++ b/src/omnicore/wallettxbuilder.h
@@ -1,15 +1,35 @@
 #ifndef OMNICORE_WALLETTXBUILDER_H
 #define OMNICORE_WALLETTXBUILDER_H
 
+class uint256;
+
 #include <stdint.h>
 #include <string>
 #include <vector>
 
-class uint256;
+/**
+ * Creates and sends a transaction.
+ */
+int WalletTxBuilder(
+        const std::string& senderAddress,
+        const std::string& receiverAddress,
+        const std::string& redemptionAddress,
+        int64_t referenceAmount,
+        const std::vector<unsigned char>& payload,
+        uint256& retTxid,
+        std::string& retRawTx,
+        bool commit);
 
-
-int WalletTxBuilder(const std::string& senderAddress, const std::string& receiverAddress, const std::string& redemptionAddress,
-                 int64_t referenceAmount, const std::vector<unsigned char>& data, uint256& txid, std::string& rawHex, bool commit);
+/**
+ * Creates and funds a raw transaction by selecting all coins from the sender
+ * and enough coins from a fee source. Change is sent to the fee source!
+ */
+int CreateFundedTransaction(
+        const std::string& senderAddress,
+        const std::string& receiverAddress,
+        const std::string& feeAddress,
+        const std::vector<unsigned char>& payload,
+        std::string& retRawTx);
 
 
 #endif // OMNICORE_WALLETTXBUILDER_H

--- a/src/omnicore/wallettxbuilder.h
+++ b/src/omnicore/wallettxbuilder.h
@@ -29,7 +29,8 @@ int CreateFundedTransaction(
         const std::string& receiverAddress,
         const std::string& feeAddress,
         const std::vector<unsigned char>& payload,
-        std::string& retRawTx);
+        std::string& retRawTx,
+        bool fLockOutputs = false);
 
 
 #endif // OMNICORE_WALLETTXBUILDER_H

--- a/src/omnicore/walletutils.cpp
+++ b/src/omnicore/walletutils.cpp
@@ -276,5 +276,66 @@ int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, i
     return nTotal;
 }
 
+/**
+ * Selects all spendable outputs to create a transaction.
+ */
+int64_t SelectAllCoins(const std::string& fromAddress, CCoinControl& coinControl)
+{
+    // total output funds collected
+    int64_t nTotal = 0;
+
+#ifdef ENABLE_WALLET
+    if (NULL == pwalletMain) {
+        return 0;
+    }
+
+    int nHeight = GetHeight();
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    // iterate over the wallet
+    for (std::map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
+        const uint256& txid = it->first;
+        const CWalletTx& wtx = it->second;
+
+        if (!wtx.IsTrusted()) {
+            continue;
+        }
+        if (!wtx.GetAvailableCredit()) {
+            continue;
+        }
+
+        for (unsigned int n = 0; n < wtx.vout.size(); n++) {
+            const CTxOut& txOut = wtx.vout[n];
+
+            CTxDestination dest;
+            if (!CheckInput(txOut, nHeight, dest)) {
+                continue;
+            }
+            if (!IsMine(*pwalletMain, dest)) {
+                continue;
+            }
+            if (pwalletMain->IsSpent(txid, n)) {
+                continue;
+            }
+
+            std::string sAddress = CBitcoinAddress(dest).ToString();
+            if (msc_debug_tokens) {
+                PrintToLog("%s: sender: %s, outpoint: %s:%d, value: %d\n", __func__, sAddress, txid.GetHex(), n, txOut.nValue);
+            }
+
+            // only use funds from the sender's address
+            if (fromAddress == sAddress) {
+                COutPoint outpoint(txid, n);
+                coinControl.Select(outpoint);
+
+                nTotal += txOut.nValue;
+            }
+        }
+    }
+#endif
+
+    return nTotal;
+}
+
 
 } // namespace mastercore

--- a/src/omnicore/walletutils.cpp
+++ b/src/omnicore/walletutils.cpp
@@ -247,6 +247,9 @@ int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, i
             if (pwalletMain->IsSpent(txid, n)) {
                 continue;
             }
+            if (pwalletMain->IsLockedCoin(txid, n)) {
+                continue;
+            }
             if (txOut.nValue < GetEconomicThreshold(txOut)) {
                 if (msc_debug_tokens)
                     PrintToLog("%s: output value below economic threshold: %s:%d, value: %d\n",
@@ -315,6 +318,9 @@ int64_t SelectAllCoins(const std::string& fromAddress, CCoinControl& coinControl
                 continue;
             }
             if (pwalletMain->IsSpent(txid, n)) {
+                continue;
+            }
+            if (pwalletMain->IsLockedCoin(txid, n)) {
                 continue;
             }
 

--- a/src/omnicore/walletutils.h
+++ b/src/omnicore/walletutils.h
@@ -28,6 +28,9 @@ int IsMyAddress(const std::string& address);
 
 /** Selects spendable outputs to create a transaction. */
 int64_t SelectCoins(const std::string& fromAddress, CCoinControl& coinControl, int64_t additional = 0);
+
+/** Selects all spendable outputs to create a transaction. */
+int64_t SelectAllCoins(const std::string& fromAddress, CCoinControl& coinControl);
 }
 
 #endif // OMNICORE_WALLETUTILS_H

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -181,6 +181,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendactivation", 3 },
     { "omni_sendalert", 1 },
     { "omni_sendalert", 2 },
+    { "omni_createfunded_send", 2 },
+    { "omni_createfunded_sweep", 2 },
 
     /* Omni Core - raw transaction calls */
     { "omni_decodetransaction", 1 },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -182,7 +182,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendalert", 1 },
     { "omni_sendalert", 2 },
     { "omni_createfunded_send", 2 },
+    { "omni_createfunded_send", 5 },
     { "omni_createfunded_sweep", 2 },
+    { "omni_createfunded_sweep", 4 },
 
     /* Omni Core - raw transaction calls */
     { "omni_decodetransaction", 1 },


### PR DESCRIPTION
This pull request adds two new RPCs "omni_createfunded_send" and "omni_createfunded_sweep", which allow the creation of raw Omni Layer transactions, which are funded by a different source, which isn't necessarily the sender.

This can be used, when the sender only has a tiny fraction of coins available, but not enough to cover the fees of the transaction.

**All coins from the specified sender are consumed and used and if coins are missing to create the transaction, they are taken from the specified fee source. Change is sent to the fee source!**

**As per default, the unspent outputs of this transaction are locked, to avoid that they are used for the construction of another transaction.**

The resulting raw transaction then needs to be signed and broadcasted.

This submission closes #383 and replaces #388 - at least to some degree.

TODO:

- [ ] update documentation