### PR TITLE
Skip wallet balance caching, when not in UI mode

### DIFF
--- a/src/Makefile.omnicore.include
+++ b/src/Makefile.omnicore.include
@@ -39,6 +39,7 @@ OMNICORE_H = \
   omnicore/tx.h \
   omnicore/uint256_extensions.h \
   omnicore/utilsbitcoin.h \
+  omnicore/utilsui.h \
   omnicore/version.h \
   omnicore/walletcache.h \
   omnicore/walletfetchtxs.h \
@@ -84,6 +85,7 @@ OMNICORE_CPP = \
   omnicore/tally.cpp \
   omnicore/tx.cpp \
   omnicore/utilsbitcoin.cpp \
+  omnicore/utilsui.cpp \
   omnicore/version.cpp \
   omnicore/walletcache.cpp \
   omnicore/walletfetchtxs.cpp \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -18,6 +18,8 @@
 #include "httprpc.h"
 #include "utilstrencodings.h"
 
+#include "omnicore/utilsui.h"
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
@@ -183,6 +185,9 @@ bool AppInit(int argc, char* argv[])
 int main(int argc, char* argv[])
 {
     SetupEnvironment();
+
+    // Indicate no-UI mode
+    fQtMode = false;
 
     // Connect bitcoind signal handlers
     noui_connect();

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -32,6 +32,7 @@
 #include "omnicore/tally.h"
 #include "omnicore/tx.h"
 #include "omnicore/utilsbitcoin.h"
+#include "omnicore/utilsui.h"
 #include "omnicore/version.h"
 #include "omnicore/walletcache.h"
 #include "omnicore/walletutils.h"
@@ -585,6 +586,18 @@ void NotifyTotalTokensChanged(uint32_t propertyId, int block)
 
 void CheckWalletUpdate(bool forceUpdate)
 {
+#ifdef ENABLE_WALLET
+    if (!pwalletMain) {
+        return;
+    }
+#endif
+
+    // because the wallet balance cache is *only* used by the UI, it's not needed,
+    // when the daemon is running without UI.
+    if (!fQtMode) {
+        return;
+    }
+
     if (!WalletCacheUpdate()) {
         // no balance changes were detected that affect wallet addresses, signal a generic change to overall Omni state
         if (!forceUpdate) {

--- a/src/omnicore/utilsui.cpp
+++ b/src/omnicore/utilsui.cpp
@@ -1,0 +1,6 @@
+#include "omnicore/utilsui.h"
+
+#include <atomic>
+
+/** Flag to indicate, whether Omni Core was launched with UI. */
+std::atomic<bool> fQtMode (false);

--- a/src/omnicore/utilsui.h
+++ b/src/omnicore/utilsui.h
@@ -1,0 +1,10 @@
+#ifndef OMNICORE_UTILSUI_H
+#define OMNICORE_UTILSUI_H
+
+#include <atomic>
+
+/** Flag to indicate, whether Omni Core was launched with UI. */
+extern std::atomic<bool> fQtMode;
+
+
+#endif // OMNICORE_UTILSUI_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -35,6 +35,8 @@
 #include "wallet/wallet.h"
 #endif
 
+#include "omnicore/utilsui.h"
+
 #include <stdint.h>
 
 #include <boost/filesystem/operations.hpp>
@@ -513,6 +515,9 @@ WId BitcoinApplication::getMainWinId() const
 int main(int argc, char *argv[])
 {
     SetupEnvironment();
+
+    // Indicate UI mode
+    fQtMode = true;
 
     /// 1. Parse command-line options. These take precedence over anything else.
     // Command-line options take precedence:


### PR DESCRIPTION
The wallet balance cache is used to populate the UI with balance information, but given that it's unused, when not using the wallet or UI, it can be skipped to save time.