### PR TITLE
 Add name field to omni_getallbalancesforaddress

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -721,6 +721,7 @@ Returns a list of all token balances for a given address.
 [                          // (array of JSON objects)
   {
     "propertyid" : n,          // (number) the property identifier
+    "name" : "name",           // (string) the name of the property
     "balance" : "n.nnnnnnnn",  // (string) the available balance of the address
     "reserved" : "n.nnnnnnnn", // (string) the amount reserved by sell offers and accepts
     "frozen" : "n.nnnnnnnn"    // (string) the amount frozen by the issuer (applies to managed properties only)

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -850,6 +850,7 @@ UniValue omni_getallbalancesforaddress(const UniValue& params, bool fHelp)
             "[                           (array of JSON objects)\n"
             "  {\n"
             "    \"propertyid\" : n,           (number) the property identifier\n"
+            "    \"name\" : \"name\",            (string) the name of the property\n"
             "    \"balance\" : \"n.nnnnnnnn\",   (string) the available balance of the address\n"
             "    \"reserved\" : \"n.nnnnnnnn\"   (string) the amount reserved by sell offers and accepts\n"
             "  },\n"

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -876,9 +876,16 @@ UniValue omni_getallbalancesforaddress(const UniValue& params, bool fHelp)
 
     uint32_t propertyId = 0;
     while (0 != (propertyId = addressTally->next())) {
+        CMPSPInfo::Entry property;
+        if (_my_sps->getSP(propertyId, property)) {
+            continue;
+        }
+
         UniValue balanceObj(UniValue::VOBJ);
         balanceObj.push_back(Pair("propertyid", (uint64_t) propertyId));
-        bool nonEmptyBalance = BalanceToJSON(address, propertyId, balanceObj, isPropertyDivisible(propertyId));
+        balanceObj.push_back(Pair("name", property.name));
+
+        bool nonEmptyBalance = BalanceToJSON(address, propertyId, balanceObj, property.isDivisible());
 
         if (nonEmptyBalance) {
             response.push_back(balanceObj);


### PR DESCRIPTION
This pull request adds the "name" field to the output of he RPC "omni_getallbalancesforaddress".

While token namens are by no way unique or serve as identifier, providing the name increases the user experience.