### PR TITLE
Clarify that bitcoins are meant in funded RPCs

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -696,7 +696,7 @@ $ omnicore-cli "omni_sendrawtx" \
 
 Creates and sends a funded simple send transaction.
 
-All coins from the sender are consumed and if there are coins missing, they are taken from the specified fee source. Change is sent to the fee source!
+All bitcoins from the sender are consumed and if there are bitcoins missing, they are taken from the specified fee source. Change is sent to the fee source!
 
 **Arguments:**
 
@@ -727,7 +727,7 @@ $ omnicore-cli "omni_funded_send" "1DFa5bT6KMEr6ta29QJouainsjaNBsJQhH" \
 
 Creates and sends a transaction that transfers all available tokens in the given ecosystem to the recipient.
 
-All coins from the sender are consumed and if there are coins missing, they are taken from the specified fee source. Change is sent to the fee source!
+All bitcoins from the sender are consumed and if there are bitcoins missing, they are taken from the specified fee source. Change is sent to the fee source!
 
 **Arguments:**
 

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -43,7 +43,7 @@ UniValue omni_funded_send(const UniValue& params, bool fHelp)
 
             "\nCreates and sends a funded simple send transaction.\n"
 
-            "\nAll coins from the sender are consumed and if there are coins missing, they are taken from the specified fee source. Change is sent to the fee source!\n"
+            "\nAll bitcoins from the sender are consumed and if there are bitcoins missing, they are taken from the specified fee source. Change is sent to the fee source!\n"
 
             "\nArguments:\n"
             "1. fromaddress          (string, required) the address to send from\n"
@@ -92,7 +92,7 @@ UniValue omni_funded_sendall(const UniValue& params, bool fHelp)
 
             "\nCreates and sends a transaction that transfers all available tokens in the given ecosystem to the recipient.\n"
 
-            "\nAll coins from the sender are consumed and if there are coins missing, they are taken from the specified fee source. Change is sent to the fee source!\n"
+            "\nAll bitcoins from the sender are consumed and if there are bitcoins missing, they are taken from the specified fee source. Change is sent to the fee source!\n"
 
             "\nArguments:\n"
             "1. fromaddress          (string, required) the address to send from\n"


### PR DESCRIPTION
It may not be clear, whether tokens or bitcoins were meant in the help descriptions of the new funding RPCs.