### PR TITLE
Add new RPC: omni_listblockstransactions

### DIFF
--- a/src/omnicore/dbtxlist.h
+++ b/src/omnicore/dbtxlist.h
@@ -36,6 +36,8 @@ public:
     bool getSendAllDetails(const uint256& txid, int subSend, uint32_t& propertyId, int64_t& amount);
     int getMPTransactionCountTotal();
     int getMPTransactionCountBlock(int block);
+    /** Returns a list of all Omni transactions in the given block range. */
+    int GetOmniTxsInBlockRange(int blockFirst, int blockLast, std::set<uint256>& retTxs);
 
     int getDBVersion();
     int setDBVersion();

--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -46,6 +46,7 @@ All available commands can be listed with `"help"`, and information about a spec
   - [omni_gettransaction](#omni_gettransaction)
   - [omni_listtransactions](#omni_listtransactions)
   - [omni_listblocktransactions](#omni_listblocktransactions)
+  - [omni_listblockstransactions](#omni_listblockstransactions)
   - [omni_listpendingtransactions](#omni_listpendingtransactions)
   - [omni_getactivedexsells](#omni_getactivedexsells)
   - [omni_listproperties](#omni_listproperties)
@@ -1063,6 +1064,35 @@ Lists all Omni transactions in a block.
 
 ```bash
 $ omnicore-cli "omni_listblocktransactions" 279007
+```
+
+---
+
+### omni_listblockstransactions
+
+Lists all Omni transactions in a given range of blocks.
+
+Note: the list of transactions is unordered and can contain invalid transactions!
+
+**Arguments:**
+
+| Name                | Type    | Presence | Description                                                                                  |
+|---------------------|---------|----------|----------------------------------------------------------------------------------------------|
+| `firstblock`        | number  | required | the index of the first block to consider                                                     |
+| `lastblock`         | number  | required | the index of the last block to consider                                                      |
+
+**Result:**
+```js
+[      // (array of string)
+  "hash",  // (string) the hash of the transaction
+  ...
+]
+```
+
+**Example:**
+
+```bash
+$ omnicore-cli "omni_omni_listblocktransactions" 279007 300000
 ```
 
 ---

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1891,6 +1891,45 @@ UniValue omni_listblocktransactions(const UniValue& params, bool fHelp)
     }
 
     return response;
+}    
+
+UniValue omni_listblockstransactions(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+            "omni_listblocktransactions firstblock lastblock\n"
+            "\nLists all Omni transactions in a given range of blocks.\n"
+            "\nNote: the list of transactions is unordered and can contain invalid transactions!\n"
+            "\nArguments:\n"
+            "1. firstblock           (number, required) the index of the first block to consider\n"
+            "2. lastblock            (number, required) the index of the last block to consider\n"
+            "\nResult:\n"
+            "[                       (array of string)\n"
+            "  \"hash\",                 (string) the hash of the transaction\n"
+            "  ...\n"
+            "]\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("omni_listblocktransactions", "279007 300000")
+            + HelpExampleRpc("omni_listblocktransactions", "279007, 300000")
+        );
+
+    int blockFirst = params[0].get_int();
+    int blockLast = params[1].get_int();
+
+    std::set<uint256> txs;
+    UniValue response(UniValue::VARR);
+
+    LOCK(cs_tally);
+    {
+        p_txlistdb->GetOmniTxsInBlockRange(blockFirst, blockLast, txs);
+    }
+
+    BOOST_FOREACH(const uint256& tx, txs) {
+        response.push_back(tx.GetHex());
+    }
+
+    return response;
 }
 
 UniValue omni_gettransaction(const UniValue& params, bool fHelp)
@@ -2447,6 +2486,7 @@ static const CRPCCommand commands[] =
     { "omni layer (data retrieval)", "omni_gettrade",                  &omni_gettrade,                   false },
     { "omni layer (data retrieval)", "omni_getsto",                    &omni_getsto,                     false },
     { "omni layer (data retrieval)", "omni_listblocktransactions",     &omni_listblocktransactions,      false },
+    { "omni layer (data retrieval)", "omni_listblockstransactions",    &omni_listblockstransactions,     false },
     { "omni layer (data retrieval)", "omni_listpendingtransactions",   &omni_listpendingtransactions,    false },
     { "omni layer (data retrieval)", "omni_getallbalancesforaddress",  &omni_getallbalancesforaddress,   false },
     { "omni layer (data retrieval)", "omni_gettradehistoryforaddress", &omni_gettradehistoryforaddress,  false },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -125,6 +125,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_listtransactions", 4 },
     { "omni_getallbalancesforid", 0 },
     { "omni_listblocktransactions", 0 },
+    { "omni_listblockstransactions", 0 },
+    { "omni_listblockstransactions", 1 },
     { "omni_getorderbook", 0 },
     { "omni_getorderbook", 1 },
     { "omni_getseedblocks", 0 },


### PR DESCRIPTION
The new RPC omni_listblockstransactions can be used to retrieve an unordered list of Omni transactions within a range of blocks:

---

### omni_listblockstransactions

Lists all Omni transactions in a given range of blocks.

Note: the list of transactions is unordered and can contain invalid transactions!

**Arguments:**

| Name                | Type    | Presence | Description                                                                                  |
|---------------------|---------|----------|----------------------------------------------------------------------------------------------|
| `firstblock`        | number  | required | the index of the first block to consider                                                     |
| `lastblock`         | number  | required | the index of the last block to consider                                                      |

**Result:**
```js
[      // (array of string)
  "hash",  // (string) the hash of the transaction
  ...
]
```

**Example:**

```bash
$ omnicore-cli "omni_omni_listblocktransactions" 279007 300000
```

---