### PR TITLE
Fix RPC edge case of not identifying crowdsale purchase

### DIFF
--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -315,7 +315,6 @@ bool mastercore::isCrowdsalePurchase(const uint256& txid, const std::string& add
         for (uint32_t loopPropertyId = startPropertyId; loopPropertyId < _my_sps->peekNextSPID(ecosystem); loopPropertyId++) {
             CMPSPInfo::Entry sp;
             if (!_my_sps->getSP(loopPropertyId, sp)) continue;
-            if (sp.issuer != address) continue;
             for (std::map<uint256, std::vector<int64_t> >::const_iterator it = sp.historicalData.begin(); it != sp.historicalData.end(); it++) {
                 if (it->first == txid) {
                     *propertyId = loopPropertyId;


### PR DESCRIPTION
To reproduce the issue:

1. Create a crowdsale from addr1
2. Participate in crowdsale (tx1)
3. Close the crowdsale
4. Change issuer of crowdsale to addr2

When now checking tx1 with omni_gettransaction, the transaction type should show "Crowdsale Purchase" and not "Simple Send".

This resolves #846.