### PR TITLE
Show "ecosystem" = "all", when all tokens are moved

### DIFF
--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -307,8 +307,13 @@ void populateRPCTypeSendToOwners(CMPTransaction& omniObj, UniValue& txobj, bool 
 void populateRPCTypeSendAll(CMPTransaction& omniObj, UniValue& txobj, int confirmations)
 {
     UniValue subSends(UniValue::VARR);
-    if (omniObj.getEcosystem() == 1) txobj.push_back(Pair("ecosystem", "main"));
-    if (omniObj.getEcosystem() == 2) txobj.push_back(Pair("ecosystem", "test"));
+    if (omniObj.getEcosystem() == 1)
+        txobj.push_back(Pair("ecosystem", "main"));
+    else if (omniObj.getEcosystem() == 2)
+        txobj.push_back(Pair("ecosystem", "test"));
+    else
+        txobj.push_back(Pair("ecosystem", "all"));
+
     if (confirmations > 0) {
         if (populateRPCSendAllSubSends(omniObj.getHash(), subSends) > 0) txobj.push_back(Pair("subsends", subSends));
     }


### PR DESCRIPTION
When moving all tokens with the "send all" transaction and no specific ecosystem is selected, show "all" for "ecosystem", when getting information about such a transaction with "omni_gettransaction".