### PR TITLE
Rename OMNI and TOMNI to OMN and TOMN

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ http://www.omnilayer.org
 What is Omni Core
 -----------------
 
-Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.13). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.
+Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.13.2). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.
 
 Disclaimer, warning
 -------------------
@@ -35,7 +35,7 @@ Testnet mode allows Omni Core to be run on the Bitcoin testnet blockchain for sa
 
 1. To run Omni Core in testnet mode, run Omni Core with the following option in place: `-testnet`.
 
-2. To receive OMNI (and TOMNI) on testnet please send TBTC to `moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP`. For each 1 TBTC you will receive 100 OMNI and 100 TOMNI.
+2. To receive OMN (and TOMN) on testnet please send TBTC to `moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP`. For each 1 TBTC you will receive 100 OMN and 100 TOMN.
 
 Dependencies
 ------------

--- a/src/omnicore/README.md
+++ b/src/omnicore/README.md
@@ -12,7 +12,7 @@ http://www.omnilayer.org
 What is Omni Core
 -----------------
 
-Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.10.4). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the UI and the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.
+Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.13.2). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the UI and the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.
 
 Disclaimer, warning
 -------------------

--- a/src/omnicore/dbspinfo.cpp
+++ b/src/omnicore/dbspinfo.cpp
@@ -60,17 +60,17 @@ CMPSPInfo::CMPSPInfo(const boost::filesystem::path& path, bool fWipe)
     implied_omni.num_tokens = 700000;
     implied_omni.category = "N/A";
     implied_omni.subcategory = "N/A";
-    implied_omni.name = "Omni";
+    implied_omni.name = "Omni tokens";
     implied_omni.url = "http://www.omnilayer.org";
-    implied_omni.data = "Omni serve as the binding between Bitcoin, smart properties and contracts created on the Omni Layer.";
+    implied_omni.data = "Omni tokens serve as the binding between Bitcoin, smart properties and contracts created on the Omni Layer.";
     implied_tomni.issuer = ExodusAddress().ToString();
     implied_tomni.prop_type = MSC_PROPERTY_TYPE_DIVISIBLE;
     implied_tomni.num_tokens = 700000;
     implied_tomni.category = "N/A";
     implied_tomni.subcategory = "N/A";
-    implied_tomni.name = "Test Omni";
+    implied_tomni.name = "Test Omni tokens";
     implied_tomni.url = "http://www.omnilayer.org";
-    implied_tomni.data = "Test Omni serve as the binding between Bitcoin, smart properties and contracts created on the Omni Layer.";
+    implied_tomni.data = "Test Omni tokens serve as the binding between Bitcoin, smart properties and contracts created on the Omni Layer.";
 
     init();
 }

--- a/src/omnicore/dbspinfo.cpp
+++ b/src/omnicore/dbspinfo.cpp
@@ -54,7 +54,7 @@ CMPSPInfo::CMPSPInfo(const boost::filesystem::path& path, bool fWipe)
     leveldb::Status status = Open(path, fWipe);
     PrintToConsole("Loading smart property database: %s\n", status.ToString());
 
-    // special cases for constant SPs OMNI and TOMNI
+    // special cases for constant SPs OMN and TOMN
     implied_omni.issuer = ExodusAddress().ToString();
     implied_omni.prop_type = MSC_PROPERTY_TYPE_DIVISIBLE;
     implied_omni.num_tokens = 700000;

--- a/src/omnicore/dbspinfo.h
+++ b/src/omnicore/dbspinfo.h
@@ -121,7 +121,7 @@ public:
     };
 
 private:
-    // implied version of OMNI and TOMNI so they don't hit the leveldb
+    // implied version of OMN and TOMN so they don't hit the leveldb
     Entry implied_omni;
     Entry implied_tomni;
 

--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -145,7 +145,7 @@ Place, update or cancel a sell offer on the traditional distributed OMNI/BTC exc
 | Name                | Type    | Presence | Description                                                                                  |
 |---------------------|---------|----------|----------------------------------------------------------------------------------------------|
 | `fromaddress`       | string  | required | the address to send from                                                                     |
-| `propertyidforsale` | number  | required | the identifier of the tokens to list for sale (must be `1` for `OMNI` or `2`for `TOMNI`)     |
+| `propertyidforsale` | number  | required | the identifier of the tokens to list for sale (must be `1` for `OMN` or `2`for `TOMN`)       |
 | `amountforsale`     | string  | required | the amount of tokens to list for sale                                                        |
 | `amountdesired`     | string  | required | the amount of bitcoins desired                                                               |
 | `paymentwindow`     | number  | required | a time limit in blocks a buyer has to pay following a successful accepting order             |
@@ -1408,7 +1408,7 @@ Get information and recipients of a send-to-owners transaction.
   "propertyid" : n,              // (number) the identifier of sent tokens
   "divisible" : true|false,      // (boolean) whether the sent tokens are divisible
   "amount" : "n.nnnnnnnn",       // (string) the number of tokens sent to owners
-  "totalstofee" : "n.nnnnnnnn",  // (string) the fee paid by the sender, nominated in OMNI or TOMNI
+  "totalstofee" : "n.nnnnnnnn",  // (string) the fee paid by the sender, nominated in OMN or TOMN
   "recipients": [                // (array of JSON objects) a list of recipients
     {
       "address" : "address",         // (string) the Bitcoin address of the recipient
@@ -2037,7 +2037,7 @@ Create a payload to place, update or cancel a sell offer on the traditional dist
 
 | Name                | Type    | Presence | Description                                                                                  |
 |---------------------|---------|----------|----------------------------------------------------------------------------------------------|
-| `propertyidforsale` | number  | required | the identifier of the tokens to list for sale (must be 1 for OMNI or 2 for TOMNI)            |
+| `propertyidforsale` | number  | required | the identifier of the tokens to list for sale (must be 1 for OMN or 2 for TOMN)              |
 | `amountforsale`     | string  | required | the amount of tokens to list for sale                                                        |
 | `amountdesired`     | string  | required | the amount of bitcoins desired                                                               |
 | `paymentwindow`     | number  | required | a time limit in blocks a buyer has to pay following a successful accepting order             |

--- a/src/omnicore/errors.h
+++ b/src/omnicore/errors.h
@@ -160,7 +160,7 @@ inline std::string error_str(int ec) {
           ec_str = "Value out of range or zero";
           break;
       case PKT_ERROR_TRADEOFFER -47:
-          ec_str = "Property for sale must be OMNI or TOMNI";
+          ec_str = "Property for sale must be OMN or TOMN";
           break;
       case PKT_ERROR_TRADEOFFER -49:
           ec_str = "Sender has no active sell offer for the property";
@@ -232,7 +232,7 @@ inline std::string error_str(int ec) {
           ec_str = "Amount desired out of range or zero";
           break;
       case PKT_ERROR_METADEX -35:
-          ec_str = "One side of the trade must be OMNI or TOMNI";
+          ec_str = "One side of the trade must be OMN or TOMN";
           break;
 
       case METADEX_ERROR -1:

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -133,7 +133,7 @@ std::string xToString(const rational_t& value)
 // find the best match on the market
 // NOTE: sometimes I refer to the older order as seller & the newer order as buyer, in this trade
 // INPUT: property, desprop, desprice = of the new order being inserted; the new object being processed
-// RETURN: 
+// RETURN:
 static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
 {
     const uint32_t propertyForSale = pnew->getProperty();
@@ -701,7 +701,7 @@ int mastercore::MetaDEx_SHUTDOWN_ALLPAIR()
         for (md_PricesMap::iterator it = prices.begin(); it != prices.end(); ++it) {
             md_Set& indexes = it->second;
             for (md_Set::iterator it = indexes.begin(); it != indexes.end();) {
-                if (it->getDesProperty() > OMNI_PROPERTY_TMSC && it->getProperty() > OMNI_PROPERTY_TMSC) { // no OMNI/TOMNI side to the trade
+                if (it->getDesProperty() > OMNI_PROPERTY_TMSC && it->getProperty() > OMNI_PROPERTY_TMSC) { // no OMN/TOMN side to the trade
                     PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, it->ToString());
                     // move from reserve to balance
                     assert(update_tally_map(it->getAddr(), it->getProperty(), -it->getAmountRemaining(), METADEX_RESERVE));

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -170,9 +170,9 @@ std::string mastercore::strMPProperty(uint32_t propertyId)
         switch (propertyId) {
             case OMNI_PROPERTY_BTC: str = "BTC";
                 break;
-            case OMNI_PROPERTY_MSC: str = "OMNI";
+            case OMNI_PROPERTY_MSC: str = "OMN";
                 break;
-            case OMNI_PROPERTY_TMSC: str = "TOMNI";
+            case OMNI_PROPERTY_TMSC: str = "TOMN";
                 break;
             default:
                 str = strprintf("SP token: %d", propertyId);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1680,7 +1680,7 @@ int mastercore_init()
         if (inconsistentDb) strReason = "INCONSISTENT DB DETECTED!\n"
                 "\n!!! WARNING !!!\n\n"
                 "IF YOU ARE USING AN OVERLAY DB, YOU MAY NEED TO REPROCESS\n"
-                "ALL OMNI TRANSACTIONS TO AVOID INCONSISTENCIES!\n"
+                "ALL OMNI LAYER TRANSACTIONS TO AVOID INCONSISTENCIES!\n"
                 "\n!!! WARNING !!!";
         PrintToConsole("Loading persistent state: NONE (%s)\n", strReason);
     }
@@ -1692,7 +1692,7 @@ int mastercore_init()
 
     if (inconsistentDb) {
         std::string strAlert("INCONSISTENT DB DETECTED! IF YOU ARE USING AN OVERLAY DB, YOU MAY NEED TO REPROCESS"
-                "ALL OMNI TRANSACTIONS TO AVOID INCONSISTENCIES!");
+                "ALL OMNI LAYER TRANSACTIONS TO AVOID INCONSISTENCIES!");
         AddAlert("omnicore", ALERT_CLIENT_VERSION_EXPIRY, std::numeric_limits<uint32_t>::max(), strAlert);
         AlertNotify(strAlert);
     }

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1349,7 +1349,7 @@ UniValue omni_getcrowdsale(const UniValue& params, bool fHelp)
     response.push_back(Pair("amountraised", FormatMP(sp.property_desired, amountRaised)));
     response.push_back(Pair("tokensissued", FormatMP(propertyId, tokensIssued)));
     response.push_back(Pair("issuerbonustokens", FormatMP(propertyId, amountIssuerTokens)));
-    response.push_back(Pair("addedissuertokens", FormatMP(propertyId, sp.missedTokens)));    
+    response.push_back(Pair("addedissuertokens", FormatMP(propertyId, sp.missedTokens)));
 
     // TODO: return fields every time?
     if (!active) response.push_back(Pair("closedearly", sp.close_early));
@@ -1891,7 +1891,7 @@ UniValue omni_listblocktransactions(const UniValue& params, bool fHelp)
     }
 
     return response;
-}    
+}
 
 UniValue omni_listblockstransactions(const UniValue& params, bool fHelp)
 {
@@ -2267,7 +2267,7 @@ UniValue omni_getsto(const UniValue& params, bool fHelp)
             "  \"propertyid\" : n,               (number) the identifier of sent tokens\n"
             "  \"divisible\" : true|false,       (boolean) whether the sent tokens are divisible\n"
             "  \"amount\" : \"n.nnnnnnnn\",        (string) the number of tokens sent to owners\n"
-            "  \"totalstofee\" : \"n.nnnnnnnn\",   (string) the fee paid by the sender, nominated in OMNI or TOMNI\n"
+            "  \"totalstofee\" : \"n.nnnnnnnn\",   (string) the fee paid by the sender, nominated in OMN or TOMN\n"
             "  \"recipients\": [                 (array of JSON objects) a list of recipients\n"
             "    {\n"
             "      \"address\" : \"address\",          (string) the Bitcoin address of the recipient\n"

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -81,7 +81,7 @@ UniValue omni_createpayload_dexsell(const UniValue& params, bool fHelp)
 
             "\nArguments:\n"
 
-            "1. propertyidforsale    (number, required) the identifier of the tokens to list for sale (must be 1 for OMNI or 2 for TOMNI)\n"
+            "1. propertyidforsale    (number, required) the identifier of the tokens to list for sale (must be 1 for OMN or 2 for TOMN)\n"
             "2. amountforsale        (string, required) the amount of tokens to list for sale\n"
             "3. amountdesired        (string, required) the amount of bitcoins desired\n"
             "4. paymentwindow        (number, required) a time limit in blocks a buyer has to pay following a successful accepting order\n"

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -30,7 +30,7 @@ void RequireBalance(const std::string& address, uint32_t propertyId, int64_t amo
 void RequirePrimaryToken(uint32_t propertyId)
 {
     if (propertyId < 1 || 2 < propertyId) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier must be 1 (OMNI) or 2 (TOMNI)");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Property identifier must be 1 (OMN) or 2 (TOMN)");
     }
 }
 

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -292,7 +292,7 @@ UniValue omni_senddexsell(const UniValue& params, bool fHelp)
             "\nArguments:\n"
 
             "1. fromaddress          (string, required) the address to send from\n"
-            "2. propertyidforsale    (number, required) the identifier of the tokens to list for sale (must be 1 for OMNI or 2 for TOMNI)\n"
+            "2. propertyidforsale    (number, required) the identifier of the tokens to list for sale (must be 1 for OMN or 2 for TOMN)\n"
             "3. amountforsale        (string, required) the amount of tokens to list for sale\n"
             "4. amountdesired        (string, required) the amount of bitcoins desired\n"
             "5. paymentwindow        (number, required) a time limit in blocks a buyer has to pay following a successful accepting order\n"

--- a/src/omnicore/test/test_fees.sh
+++ b/src/omnicore/test/test_fees.sh
@@ -50,7 +50,7 @@ $SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
 printf "   * Creating a divisible test property in the test ecosystem\n"
 $SRCDIR/omnicore-cli --regtest omni_sendissuancefixed $ADDR 2 2 0 "Z_TestCat" "Z_TestSubCat" "Z_DivisTestProperty" "Z_TestURL" "Z_TestData" 10000000 >$NUL
 $SRCDIR/omnicore-cli --regtest setgenerate true 1 >$NUL
-printf "   * Generating addresses to use as fee recipients (OMNI holders)\n"
+printf "   * Generating addresses to use as fee recipients (OMN holders)\n"
 ADDRESS=()
 for i in {1..6}
 do
@@ -887,4 +887,3 @@ printf "####################\n"
 printf "\n"
 
 $SRCDIR/omnicore-cli --regtest stop
-

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1276,7 +1276,7 @@ int CMPTransaction::logicMath_TradeOffer()
     }
 
     if (OMNI_PROPERTY_TMSC != property && OMNI_PROPERTY_MSC != property) {
-        PrintToLog("%s(): rejected: property for sale %d must be OMNI or TOMNI\n", __func__, property);
+        PrintToLog("%s(): rejected: property for sale %d must be OMN or TOMN\n", __func__, property);
         return (PKT_ERROR_TRADEOFFER -47);
     }
 
@@ -1432,7 +1432,7 @@ int CMPTransaction::logicMath_MetaDExTrade()
         // Trading non-Omni pairs is not allowed before trading all pairs is activated
         if ((property != OMNI_PROPERTY_MSC) && (desired_property != OMNI_PROPERTY_MSC) &&
             (property != OMNI_PROPERTY_TMSC) && (desired_property != OMNI_PROPERTY_TMSC)) {
-            PrintToLog("%s(): rejected: one side of a trade [%d, %d] must be OMNI or TOMNI\n", __func__, property, desired_property);
+            PrintToLog("%s(): rejected: one side of a trade [%d, %d] must be OMN or TOMN\n", __func__, property, desired_property);
             return (PKT_ERROR_METADEX -35);
         }
     }

--- a/src/qt/lookupaddressdialog.cpp
+++ b/src/qt/lookupaddressdialog.cpp
@@ -245,7 +245,7 @@ void LookupAddressDialog::searchAddress()
                 balances[pItem-1]->setVisible(true);
                 labels[pItem-1]->setText(pName[pItem].c_str());
                 string tokenLabel = " SPT";
-                if (pName[pItem]=="Test Omni (#2)") { tokenLabel = " TOMNI"; }
+                if (pName[pItem]=="Test Omni (#2)") { tokenLabel = " TOMN"; }
                 if (pDivisible[pItem])
                 {
                     balances[pItem-1]->setText(QString::fromStdString(FormatDivisibleMP(pBal[pItem]) + tokenLabel));

--- a/src/qt/lookupspdialog.cpp
+++ b/src/qt/lookupspdialog.cpp
@@ -298,7 +298,7 @@ void LookupSPDialog::updateDisplayedProperty()
     }
     else
     {
-       if (propertyId == 1) { tokenLabel = " OMNI"; } else { tokenLabel = " TOMNI"; }
+       if (propertyId == 1) { tokenLabel = " OMN"; } else { tokenLabel = " TOMN"; }
     }
     if (divisible) { strTotalTokens = FormatDivisibleMP(totalTokens); } else { strTotalTokens = FormatIndivisibleMP(totalTokens); }
     if (divisible) { strWalletTokens = FormatDivisibleMP(walletTokens); } else { strWalletTokens = FormatIndivisibleMP(walletTokens); }

--- a/src/qt/metadexcanceldialog.cpp
+++ b/src/qt/metadexcanceldialog.cpp
@@ -177,7 +177,7 @@ void MetaDExCancelDialog::UpdateCancelCombo()
                     string dataStr = sellId + "/" + desiredId;
                     if (ui->radioCancelPrice->isChecked()) { // append price if needed
                         comboStr += " priced at " + StripTrailingZeros(obj.displayUnitPrice());
-                        if ((obj.getProperty() == OMNI_PROPERTY_MSC) || (obj.getDesProperty() == OMNI_PROPERTY_MSC)) { comboStr += " OMNI/SPT"; } else { comboStr += " TOMNI/SPT"; }
+                        if ((obj.getProperty() == OMNI_PROPERTY_MSC) || (obj.getDesProperty() == OMNI_PROPERTY_MSC)) { comboStr += " OMN/SPT"; } else { comboStr += " TOMN/SPT"; }
                         dataStr += ":" + obj.displayUnitPrice();
                     }
                     int index = ui->cancelCombo->findText(QString::fromStdString(comboStr));
@@ -413,5 +413,3 @@ void MetaDExCancelDialog::SendCancelTransaction()
     }
 **/
 }
-
-


### PR DESCRIPTION
To be more distinctive to other projects, the following changes in wording are made:

- "Omni", referring to the native tokens of the Omni Layer protocol, becomes "Omni tokens"
- "Test Omni", referring to the native test tokens of the Omni Layer protocol, becomes "Test Omni tokens"
- "OMNI", referring to the symbol of Omni tokens, becomes "OMN"
- "TOMNI", referring to the symbol of Test Omni tokens, becomes "TOMN"

While this is change is mostly cosmetic - in particular it changes the code documentation, RPC help messages and RPC documentation - it also has an effect of the RPCS "omni_getproperty 1" and omni_getproperty 2", which now return a text with the updated token and symbol names.