### PR TITLE
Add marker cache to speed up omni_listpendingtransactions

### DIFF
--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -157,6 +157,13 @@ int mastercore_handler_block_begin(int nBlockNow, CBlockIndex const * pBlockInde
 int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex, unsigned int);
 bool mastercore_handler_tx(const CTransaction& tx, int nBlock, unsigned int idx, const CBlockIndex* pBlockIndex);
 
+/** Scans for marker and if one is found, add transaction to marker cache. */
+void TryToAddToMarkerCache(const CTransaction& tx);
+/** Removes transaction from marker cache. */
+void RemoveFromMarkerCache(const CTransaction& tx);
+/** Checks, if transaction is in marker cache. */
+bool IsInMarkerCache(const uint256& txHash);
+
 /** Global handler to total wallet balances. */
 void CheckWalletUpdate(bool forceUpdate = false);
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -2086,6 +2086,10 @@ UniValue omni_listpendingtransactions(const UniValue& params, bool fHelp)
 
     UniValue result(UniValue::VARR);
     BOOST_FOREACH(const uint256& hash, vTxid) {
+        if (!IsInMarkerCache(hash)) {
+            continue;
+        }
+
         UniValue txObj(UniValue::VOBJ);
         if (populateRPCTransactionObject(hash, txObj, filterAddress) == 0) {
             result.push_back(txObj);


### PR DESCRIPTION
When adding a transaction to the mempool, a quick and unsafe check for any Omni Layer markers is done (without checking transaction validity or whether it's malformed), to identify potential Omni Layer transactions.

If the transaction has a potential marker, then it's added to a cache. If the transaction is removed from the mempool, it's also removed from the cache.

When listing pending Omni Layer transactions, only these cached candidates are considered. This should speed up the RPC significantly.