### PR TITLE
Store historical issuers and use that data

### DIFF
--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -3,6 +3,7 @@ OMNICORE_TEST_H = \
 
 OMNICORE_TEST_CPP = \
   omnicore/test/alert_tests.cpp \
+  omnicore/test/change_issuer_tests.cpp \
   omnicore/test/checkpoint_tests.cpp \
   omnicore/test/create_payload_tests.cpp \
   omnicore/test/create_tx_tests.cpp \

--- a/src/omnicore/dbspinfo.cpp
+++ b/src/omnicore/dbspinfo.cpp
@@ -92,6 +92,7 @@ CMPSPInfo::CMPSPInfo(const boost::filesystem::path& path, bool fWipe)
 
     // special cases for constant SPs OMN and TOMN
     implied_omni.issuer = ExodusAddress().ToString();
+    implied_omni.updateIssuer(0, 0, implied_omni.issuer);
     implied_omni.prop_type = MSC_PROPERTY_TYPE_DIVISIBLE;
     implied_omni.num_tokens = 700000;
     implied_omni.category = "N/A";
@@ -99,7 +100,9 @@ CMPSPInfo::CMPSPInfo(const boost::filesystem::path& path, bool fWipe)
     implied_omni.name = "Omni tokens";
     implied_omni.url = "http://www.omnilayer.org";
     implied_omni.data = "Omni tokens serve as the binding between Bitcoin, smart properties and contracts created on the Omni Layer.";
+
     implied_tomni.issuer = ExodusAddress().ToString();
+    implied_tomni.updateIssuer(0, 0, implied_tomni.issuer);
     implied_tomni.prop_type = MSC_PROPERTY_TYPE_DIVISIBLE;
     implied_tomni.num_tokens = 700000;
     implied_tomni.category = "N/A";

--- a/src/omnicore/dbspinfo.cpp
+++ b/src/omnicore/dbspinfo.cpp
@@ -49,6 +49,42 @@ void CMPSPInfo::Entry::print() const
             category, subcategory, url, data);
 }
 
+/**
+ * Stores a new issuer in the DB.
+ *
+ * @param block  The block of the update
+ * @param idx    The position within the block of the update
+ * @param newIssuer  The new issuer
+ */
+void CMPSPInfo::Entry::updateIssuer(int block, int idx, const std::string& newIssuer)
+{
+    historicalIssuers[std::make_pair(block, idx)] = newIssuer;
+}
+
+/**
+ * Returns the issuer for the given block.
+ *
+ * @param block  The block to check
+ * @return The issuer of that block
+ */
+std::string CMPSPInfo::Entry::getIssuer(int block) const
+{
+    std::string _issuer = issuer;
+
+    for (auto const& entry : historicalIssuers) {
+        int currentBlock = entry.first.first;
+        std::string currentIssuer = entry.second;
+
+        if (currentBlock > block) {
+            break;
+        }
+
+        _issuer = currentIssuer;
+    }
+
+    return _issuer;
+}
+
 CMPSPInfo::CMPSPInfo(const boost::filesystem::path& path, bool fWipe)
 {
     leveldb::Status status = Open(path, fWipe);

--- a/src/omnicore/dbspinfo.h
+++ b/src/omnicore/dbspinfo.h
@@ -84,6 +84,10 @@ public:
         //   txid -> granted amount, revoked amount
         std::map<uint256, std::vector<int64_t> > historicalData;
 
+        // Historical issuers:
+        //   (block, idx) -> issuer
+        std::map<std::pair<int, int>, std::string > historicalIssuers;
+
         Entry();
 
         ADD_SERIALIZE_METHODS;
@@ -114,10 +118,17 @@ public:
             READWRITE(fixed);
             READWRITE(manual);
             READWRITE(historicalData);
+            READWRITE(historicalIssuers);
         }
 
         bool isDivisible() const;
         void print() const;
+
+        /** Stores a new issuer in the DB. */
+        void updateIssuer(int block, int idx, const std::string& newIssuer);
+
+        /** Returns the issuer for the given block. */
+        std::string getIssuer(int block) const;
     };
 
 private:

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -30,7 +30,7 @@ int const STORE_EVERY_N_BLOCK = 10000;
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 
 // increment this value to force a refresh of the state (similar to --startclean)
-#define DB_VERSION 6
+#define DB_VERSION 7
 
 // could probably also use: int64_t maxInt64 = std::numeric_limits<int64_t>::max();
 // maximum numeric values from the spec:

--- a/src/omnicore/test/change_issuer_tests.cpp
+++ b/src/omnicore/test/change_issuer_tests.cpp
@@ -1,0 +1,80 @@
+#include "omnicore/dbspinfo.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <stdint.h>
+
+BOOST_FIXTURE_TEST_SUITE(omnicore_change_issuer_tests, BasicTestingSetup)
+
+/**
+ * Even if no updateIssuer was called, it falls back to the currently
+ * set issuer.
+ */
+BOOST_AUTO_TEST_CASE(fallback_issuer)
+{
+    CMPSPInfo::Entry e;
+    e.issuer = "ABC";
+
+    BOOST_CHECK_EQUAL(e.getIssuer(0), "ABC");
+    BOOST_CHECK_EQUAL(e.getIssuer(1), "ABC");
+    BOOST_CHECK_EQUAL(e.getIssuer(574202), "ABC");
+}
+
+/**
+ * There are two issuer changes in different blocks.
+ */
+BOOST_AUTO_TEST_CASE(two_issuer_changes)
+{
+
+    CMPSPInfo::Entry e;
+    e.issuer = "JUNK";
+
+    e.updateIssuer(123, 5, "First");
+    BOOST_CHECK_EQUAL(e.getIssuer(123), "First");
+    BOOST_CHECK_EQUAL(e.getIssuer(574202), "First");
+
+    e.updateIssuer(9999, 77, "Second");
+    BOOST_CHECK_EQUAL(e.getIssuer(123), "First");
+    BOOST_CHECK_EQUAL(e.getIssuer(9999), "Second");
+    BOOST_CHECK_EQUAL(e.getIssuer(574202), "Second");
+}
+
+/**
+ * There are multiple issuer changes per block.
+ */
+BOOST_AUTO_TEST_CASE(multiple_per_block)
+{
+
+    CMPSPInfo::Entry e;
+    e.issuer = "JUNK";
+
+    e.updateIssuer(123, 5, "One");
+    BOOST_CHECK_EQUAL(e.getIssuer(123), "One");
+    BOOST_CHECK_EQUAL(e.getIssuer(574202), "One");
+
+    e.updateIssuer(126, 3, "Two");
+    BOOST_CHECK_EQUAL(e.getIssuer(123), "One");
+    BOOST_CHECK_EQUAL(e.getIssuer(126), "Two");
+    BOOST_CHECK_EQUAL(e.getIssuer(99999), "Two");
+    
+    e.updateIssuer(126, 55, "Three");
+    BOOST_CHECK_EQUAL(e.getIssuer(123), "One");
+    BOOST_CHECK_EQUAL(e.getIssuer(126), "Three");
+    BOOST_CHECK_EQUAL(e.getIssuer(127), "Three");
+
+    // Position within block 126 is lower than "Three"
+    e.updateIssuer(126, 4, "Four");
+    BOOST_CHECK_EQUAL(e.getIssuer(123), "One");
+    BOOST_CHECK_EQUAL(e.getIssuer(126), "Three");
+    BOOST_CHECK_EQUAL(e.getIssuer(574202), "Three");
+
+    e.updateIssuer(99999, 2, "Five");
+    BOOST_CHECK_EQUAL(e.getIssuer(123), "One");
+    BOOST_CHECK_EQUAL(e.getIssuer(126), "Three");
+    BOOST_CHECK_EQUAL(e.getIssuer(574202), "Five");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1629,6 +1629,7 @@ int CMPTransaction::logicMath_CreatePropertyFixed()
 
     CMPSPInfo::Entry newSP;
     newSP.issuer = sender;
+    newSP.updateIssuer(block, tx_idx, sender);
     newSP.txid = txid;
     newSP.prop_type = prop_type;
     newSP.num_tokens = nValue;
@@ -1727,6 +1728,7 @@ int CMPTransaction::logicMath_CreatePropertyVariable()
 
     CMPSPInfo::Entry newSP;
     newSP.issuer = sender;
+    newSP.updateIssuer(block, tx_idx, sender);
     newSP.txid = txid;
     newSP.prop_type = prop_type;
     newSP.num_tokens = nValue;
@@ -1863,6 +1865,7 @@ int CMPTransaction::logicMath_CreatePropertyManaged()
 
     CMPSPInfo::Entry newSP;
     newSP.issuer = sender;
+    newSP.updateIssuer(block, tx_idx, sender);
     newSP.txid = txid;
     newSP.prop_type = prop_type;
     newSP.category.assign(category);
@@ -1926,7 +1929,7 @@ int CMPTransaction::logicMath_GrantTokens()
         return (PKT_ERROR_TOKENS -42);
     }
 
-    if (sender != sp.issuer) {
+    if (sender != sp.getIssuer(block)) {
         PrintToLog("%s(): rejected: sender %s is not issuer of property %d [issuer=%s]\n", __func__, sender, property, sp.issuer);
         return (PKT_ERROR_TOKENS -43);
     }
@@ -2073,7 +2076,7 @@ int CMPTransaction::logicMath_ChangeIssuer()
     CMPSPInfo::Entry sp;
     assert(pDbSpInfo->getSP(property, sp));
 
-    if (sender != sp.issuer) {
+    if (sender != sp.getIssuer(block)) {
         PrintToLog("%s(): rejected: sender %s is not issuer of property %d [issuer=%s]\n", __func__, sender, property, sp.issuer);
         return (PKT_ERROR_TOKENS -43);
     }
@@ -2094,6 +2097,8 @@ int CMPTransaction::logicMath_ChangeIssuer()
     }
 
     // ------------------------------------------
+
+    sp.updateIssuer(block, tx_idx, receiver);
 
     sp.issuer = receiver;
     sp.update_block = blockHash;
@@ -2141,7 +2146,7 @@ int CMPTransaction::logicMath_EnableFreezing()
         return (PKT_ERROR_TOKENS -42);
     }
 
-    if (sender != sp.issuer) {
+    if (sender != sp.getIssuer(block)) {
         PrintToLog("%s(): rejected: sender %s is not issuer of property %d [issuer=%s]\n", __func__, sender, property, sp.issuer);
         return (PKT_ERROR_TOKENS -43);
     }
@@ -2202,7 +2207,7 @@ int CMPTransaction::logicMath_DisableFreezing()
         return (PKT_ERROR_TOKENS -42);
     }
 
-    if (sender != sp.issuer) {
+    if (sender != sp.getIssuer(block)) {
         PrintToLog("%s(): rejected: sender %s is not issuer of property %d [issuer=%s]\n", __func__, sender, property, sp.issuer);
         return (PKT_ERROR_TOKENS -43);
     }
@@ -2255,7 +2260,7 @@ int CMPTransaction::logicMath_FreezeTokens()
         return (PKT_ERROR_TOKENS -42);
     }
 
-    if (sender != sp.issuer) {
+    if (sender != sp.getIssuer(block)) {
         PrintToLog("%s(): rejected: sender %s is not issuer of property %d [issuer=%s]\n", __func__, sender, property, sp.issuer);
         return (PKT_ERROR_TOKENS -43);
     }
@@ -2313,7 +2318,7 @@ int CMPTransaction::logicMath_UnfreezeTokens()
         return (PKT_ERROR_TOKENS -42);
     }
 
-    if (sender != sp.issuer) {
+    if (sender != sp.getIssuer(block)) {
         PrintToLog("%s(): rejected: sender %s is not issuer of property %d [issuer=%s]\n", __func__, sender, property, sp.issuer);
         return (PKT_ERROR_TOKENS -43);
     }


### PR DESCRIPTION
During startup, when reloading the effect of freeze transactions, it is checked, whether the sender of a freeze transaction is the issuer of that token and thus allowed to freeze tokens. However, if the issuer of the token has been changed in the meantime, that check fails. Such a fail is interpreted as state inconsistency, which is critical and causes a shutdown of the client.

With this change, historical issuers are persisted and can be accessed for any given block. When there is an issuer check, it now checks against the issuer *at that point*.

Please note: the internal database of Omni Core is upgraded, which triggers a reparse of Omni Layer transactions the first time this version is started. This can take between 30 minutes and a few hours of processing time, during which Omni Core is unusable!

This pull request resolves #922.