### PR TITLE
Fix rescan minutes

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1443,7 +1443,7 @@ private:
     {
         int64_t secondsTotal = 0.001 * remainingTime;
         int64_t hours = secondsTotal / 3600;
-        int64_t minutes = secondsTotal / 60;
+        int64_t minutes = (secondsTotal / 60) % 60;
         int64_t seconds = secondsTotal % 60;
 
         if (hours > 0) {


### PR DESCRIPTION
Fix message like
```
Progress: 75.63 % (about 2:121:57 hours remaining)
```