### PR TITLE
Allow any token to be traded for Bitcoin

### DIFF
--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -205,6 +205,13 @@ int DEx_offerCreate(const std::string& addressSeller, uint32_t propertyId, int64
         return (DEX_ERROR_SELLOFFER -10); // offer already exists
     }
 
+    // Ensure further there can only be one active offer
+    if (IsFeatureActivated(FEATURE_FREEDEX, block)) {
+        if (DEx_hasOffer(addressSeller)) {
+            return (DEX_ERROR_SELLOFFER -10); // offer already exists
+        }
+    }
+
     const std::string key = STR_SELLOFFER_ADDR_PROP_COMBO(addressSeller, propertyId);
     if (msc_debug_dex) PrintToLog("%s(%s|%s), nValue=%d)\n", __func__, addressSeller, key, amountOffered);
 

--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -43,6 +43,20 @@ bool DEx_offerExists(const std::string& addressSeller, uint32_t propertyId)
 }
 
 /**
+ * Checks, if the seller has any open offer.
+ */
+bool DEx_hasOffer(const std::string& addressSeller)
+{
+    for (auto const& offer : my_offers) {
+        if (offer.first.find(addressSeller) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Retrieves a sell offer.
  *
  * @return The sell offer, or NULL, if no match was found

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -231,6 +231,7 @@ extern AcceptMap my_accepts;
 int64_t calculateDesiredBTC(const int64_t amountOffered, const int64_t amountDesired, const int64_t amountAvailable);
 
 bool DEx_offerExists(const std::string& addressSeller, uint32_t propertyId);
+bool DEx_hasOffer(const std::string& addressSeller);
 CMPOffer* DEx_getOffer(const std::string& addressSeller, uint32_t propertyId);
 bool DEx_acceptExists(const std::string& addressSeller, uint32_t propertyId, const std::string& addressBuyer);
 CMPAccept* DEx_getAccept(const std::string& addressSeller, uint32_t propertyId, const std::string& addressBuyer);

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -232,6 +232,7 @@ int64_t calculateDesiredBTC(const int64_t amountOffered, const int64_t amountDes
 
 bool DEx_offerExists(const std::string& addressSeller, uint32_t propertyId);
 bool DEx_hasOffer(const std::string& addressSeller);
+bool DEx_getTokenForSale(const std::string& addressSeller, uint32_t& retTokenId);
 CMPOffer* DEx_getOffer(const std::string& addressSeller, uint32_t propertyId);
 bool DEx_acceptExists(const std::string& addressSeller, uint32_t propertyId, const std::string& addressBuyer);
 CMPAccept* DEx_getAccept(const std::string& addressSeller, uint32_t propertyId, const std::string& addressBuyer);

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -98,7 +98,7 @@ static UniValue omni_createpayload_dexsell(const JSONRPCRequest& request)
     int64_t minAcceptFee = 0;  // depending on action
 
     if (action <= CMPTransaction::UPDATE) { // actions 3 permit zero values, skip check
-        amountForSale = ParseAmount(request.params[1], true); // TMSC/MSC is divisible
+        amountForSale = ParseAmount(request.params[1], isPropertyDivisible(propertyIdForSale));
         amountDesired = ParseAmount(request.params[2], true); // BTC is divisible
         paymentWindow = ParseDExPaymentWindow(request.params[3]);
         minAcceptFee = ParseDExFee(request.params[4]);

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -118,7 +118,7 @@ void RequireMatchingDExOffer(const std::string& address, uint32_t propertyId)
 void RequireNoOtherDExOffer(const std::string& address, uint32_t propertyId)
 {
     LOCK(cs_tally);
-    if (mastercore::DEx_offerExists(address, propertyId)) {
+    if (mastercore::DEx_hasOffer(address)) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Another active sell offer from the given address already exists on the distributed exchange");
     }
 }

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -115,7 +115,7 @@ void RequireMatchingDExOffer(const std::string& address, uint32_t propertyId)
     }
 }
 
-void RequireNoOtherDExOffer(const std::string& address, uint32_t propertyId)
+void RequireNoOtherDExOffer(const std::string& address)
 {
     LOCK(cs_tally);
     if (mastercore::DEx_hasOffer(address)) {

--- a/src/omnicore/rpcrequirements.h
+++ b/src/omnicore/rpcrequirements.h
@@ -15,7 +15,7 @@ void RequireActiveCrowdsale(uint32_t propertyId);
 void RequireManagedProperty(uint32_t propertyId);
 void RequireTokenIssuer(const std::string& address, uint32_t propertyId);
 void RequireMatchingDExOffer(const std::string& address, uint32_t propertyId);
-void RequireNoOtherDExOffer(const std::string& address, uint32_t propertyId);
+void RequireNoOtherDExOffer(const std::string& address);
 void RequireSaneReferenceAmount(int64_t amount);
 void RequireSaneDExPaymentWindow(const std::string& address, uint32_t propertyId);
 void RequireSaneDExFee(const std::string& address, uint32_t propertyId);

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -11,8 +11,10 @@
 #include <omnicore/pending.h>
 #include <omnicore/rpcrequirements.h>
 #include <omnicore/rpcvalues.h>
+#include <omnicore/rules.h>
 #include <omnicore/sp.h>
 #include <omnicore/tx.h>
+#include <omnicore/utilsbitcoin.h>
 #include <omnicore/wallettxbuilder.h>
 
 #include <interfaces/wallet.h>
@@ -356,7 +358,7 @@ static UniValue omni_senddexsell(const JSONRPCRequest& request)
 
     // perform conversions
     if (action <= CMPTransaction::UPDATE) { // actions 3 permit zero values, skip check
-        amountForSale = ParseAmount(request.params[2], true); // TMSC/MSC is divisible
+        amountForSale = ParseAmount(request.params[2], isPropertyDivisible(propertyIdForSale));
         amountDesired = ParseAmount(request.params[3], true); // BTC is divisible
         paymentWindow = ParseDExPaymentWindow(request.params[4]);
         minAcceptFee = ParseDExFee(request.params[5]);
@@ -368,7 +370,7 @@ static UniValue omni_senddexsell(const JSONRPCRequest& request)
         {
             RequirePrimaryToken(propertyIdForSale);
             RequireBalance(fromAddress, propertyIdForSale, amountForSale);
-            RequireNoOtherDExOffer(fromAddress, propertyIdForSale);
+            RequireNoOtherDExOffer(fromAddress);
             break;
         }
         case CMPTransaction::UPDATE:
@@ -441,7 +443,7 @@ static UniValue omni_senddexaccept(const JSONRPCRequest& request)
     std::string fromAddress = ParseAddress(request.params[0]);
     std::string toAddress = ParseAddress(request.params[1]);
     uint32_t propertyId = ParsePropertyId(request.params[2]);
-    int64_t amount = ParseAmount(request.params[3], true); // MSC/TMSC is divisible
+    int64_t amount = ParseAmount(request.params[3], isPropertyDivisible(propertyId));
     bool override = (request.params.size() > 4) ? request.params[4].get_bool(): false;
 
     // perform checks

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -365,24 +365,25 @@ static UniValue omni_senddexsell(const JSONRPCRequest& request)
     }
 
     // perform checks
+    if (!IsFeatureActivated(FEATURE_FREEDEX, GetHeight())) {
+        RequirePrimaryToken(propertyIdForSale);
+    }
+
     switch (action) {
         case CMPTransaction::NEW:
         {
-            RequirePrimaryToken(propertyIdForSale);
             RequireBalance(fromAddress, propertyIdForSale, amountForSale);
             RequireNoOtherDExOffer(fromAddress);
             break;
         }
         case CMPTransaction::UPDATE:
         {
-            RequirePrimaryToken(propertyIdForSale);
             RequireBalance(fromAddress, propertyIdForSale, amountForSale);
             RequireMatchingDExOffer(fromAddress, propertyIdForSale);
             break;
         }
         case CMPTransaction::CANCEL:
         {
-            RequirePrimaryToken(propertyIdForSale);
             RequireMatchingDExOffer(fromAddress, propertyIdForSale);
             break;
         }

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -253,6 +253,7 @@ CMainConsensusParams::CMainConsensusParams()
     TRADEALLPAIRS_FEATURE_BLOCK = 438500;
     FEES_FEATURE_BLOCK = 999999;
     FREEZENOTICE_FEATURE_BLOCK = 999999;
+    FREEDEX_FEATURE_BLOCK = 999999;
 }
 
 /**
@@ -294,6 +295,7 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     TRADEALLPAIRS_FEATURE_BLOCK = 0;
     FEES_FEATURE_BLOCK = 0;
     FREEZENOTICE_FEATURE_BLOCK = 0;
+    FREEDEX_FEATURE_BLOCK = 0;
 }
 
 /**
@@ -335,6 +337,7 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     TRADEALLPAIRS_FEATURE_BLOCK = 999999;
     FEES_FEATURE_BLOCK = 999999;
     FREEZENOTICE_FEATURE_BLOCK = 999999;
+    FREEDEX_FEATURE_BLOCK = 999999;
 }
 
 //! Consensus parameters for mainnet
@@ -500,6 +503,9 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
         case FEATURE_FREEZENOTICE:
             MutableConsensusParams().FREEZENOTICE_FEATURE_BLOCK = activationBlock;
         break;
+        case FEATURE_FREEDEX:
+            MutableConsensusParams().FREEDEX_FEATURE_BLOCK = activationBlock;
+        break;
         default:
             supported = false;
         break;
@@ -571,6 +577,9 @@ bool DeactivateFeature(uint16_t featureId, int transactionBlock)
         case FEATURE_FREEZENOTICE:
             MutableConsensusParams().FREEZENOTICE_FEATURE_BLOCK = 999999;
         break;
+        case FEATURE_FREEDEX:
+            MutableConsensusParams().FREEDEX_FEATURE_BLOCK = 999999;
+        break;
         default:
             return false;
         break;
@@ -602,6 +611,7 @@ std::string GetFeatureName(uint16_t featureId)
         case FEATURE_FEES: return "Fee system (inc 0.05% fee from trades of non-Omni pairs)";
         case FEATURE_STOV1: return "Cross-property Send To Owners";
         case FEATURE_FREEZENOTICE: return "Activate the waiting period for enabling freezing";
+        case FEATURE_FREEDEX: return "Activate trading of any token on the distributed exchange";
 
         default: return "Unknown feature";
     }
@@ -648,6 +658,9 @@ bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
             break;
         case FEATURE_FREEZENOTICE:
             activationBlock = params.FREEZENOTICE_FEATURE_BLOCK;
+        break;
+        case FEATURE_FREEDEX:
+            activationBlock = params.FREEDEX_FEATURE_BLOCK;
         break;
         default:
             return false;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -36,6 +36,8 @@ const uint16_t FEATURE_FEES = 9;
 const uint16_t FEATURE_STOV1 = 10;
 //! Feature identifier to activate the waiting period for enabling managed property address freezing
 const uint16_t FEATURE_FREEZENOTICE = 14;
+//! Feature identifier to activate trading of any token on the distributed exchange
+const uint16_t FEATURE_FREEDEX = 15;
 
 //! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
 const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
@@ -141,6 +143,8 @@ public:
     int FEES_FEATURE_BLOCK;
     //! Block to activate the waiting period for enabling managed property address freezing
     int FREEZENOTICE_FEATURE_BLOCK;
+    //! Block to activate the waiting period to activate trading of any token on the distributed exchange
+    int FREEDEX_FEATURE_BLOCK;
 
     /** Returns a mapping of transaction types, and the blocks at which they are enabled. */
     virtual std::vector<TransactionRestriction> GetRestrictions() const;

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1275,9 +1275,12 @@ int CMPTransaction::logicMath_TradeOffer()
         return (PKT_ERROR_TRADEOFFER -23);
     }
 
-    if (OMNI_PROPERTY_TMSC != property && OMNI_PROPERTY_MSC != property) {
-        PrintToLog("%s(): rejected: property for sale %d must be OMN or TOMN\n", __func__, property);
-        return (PKT_ERROR_TRADEOFFER -47);
+    // Ensure only OMNI and TOMNI are allowed, when the DEx is not yet free
+    if (!IsFeatureActivated(FEATURE_FREEDEX, block)) {
+        if (OMNI_PROPERTY_TMSC != property && OMNI_PROPERTY_MSC != property) {
+            PrintToLog("%s(): rejected: property for sale %d must be OMN or TOMN\n", __func__, property);
+            return (PKT_ERROR_TRADEOFFER -47);
+        }
     }
 
     // ------------------------------------------


### PR DESCRIPTION
This pull request updates the traditional distributed exchange, where users can trade Omni and Test Omni for Bitcoin.

When this feature is activated, any token can be traded and it's no longer limited to the two primary native tokens of the Omni Layer protocol.