### PR TITLE
Only evaluate fee cache, when it's activated

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -583,8 +583,10 @@ uint32_t mastercore::GetNextPropertyId(bool maineco)
 // Perform any actions that need to be taken when the total number of tokens for a property ID changes
 void NotifyTotalTokensChanged(uint32_t propertyId, int block)
 {
-    pDbFeeCache->UpdateDistributionThresholds(propertyId);
-    pDbFeeCache->EvalCache(propertyId, block);
+    if (IsFeatureActivated(FEATURE_FEES, block)) {
+        pDbFeeCache->UpdateDistributionThresholds(propertyId);
+        pDbFeeCache->EvalCache(propertyId, block);
+    }
 }
 
 void CheckWalletUpdate(bool forceUpdate)


### PR DESCRIPTION
The fee cache used for the fee distribution is only needed, when the feature of fee distribution is activated. When this is not the case, it's just a performance burdon, which can easily take 0.3 additional seconds, when a new block is processed.