### PR TITLE
Don't store state every block, when syncing or rescanning

### DIFF
--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -25,8 +25,15 @@ class Coin;
 #include <set>
 #include <unordered_map>
 
+// Keep the state of the last 50 blocks to roll back quickly
+// in case of a block reorganization
 int const MAX_STATE_HISTORY = 50;
-int const STORE_EVERY_N_BLOCK = 10000;
+// Also store the state every 5000 blocks to be able to recover
+// from a crash or shutdown during reparse more quickly
+int const STORE_EVERY_N_BLOCK = 5000;
+// Don't store the state every block on mainnet until block 622000
+// was reached
+int const DONT_STORE_MAINNET_STATE_UNTIL = 622000;
 
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 

--- a/src/omnicore/persistence.cpp
+++ b/src/omnicore/persistence.cpp
@@ -507,11 +507,32 @@ static void prune_state_files(const CBlockIndex* topIndex)
 }
 
 /**
+ * @return The block height at which the state is persisted every block.
+ */
+static int GetWrapModeHeight()
+{
+    if (MainNet()) {
+        return DONT_STORE_MAINNET_STATE_UNTIL;
+    } else {
+        return 0;
+    }
+}
+
+/**
  * Indicates whether persistence is enabled and the state is stored.
  */
-bool IsPersistenceEnabled(int blockHeight) {
+bool IsPersistenceEnabled(int blockHeight)
+{
+    static int nWarpModeHeight = GetWrapModeHeight();
+
+    int nMinHeight = nWarpModeHeight;
+
+    if (nWarpModeHeight == 0) {
+        nMinHeight = GetHeight();
+    }
+
     // if too far away from the top -- do not write
-    if (GetHeight() > (blockHeight + MAX_STATE_HISTORY)
+    if (nMinHeight > (blockHeight + MAX_STATE_HISTORY)
             && (blockHeight % STORE_EVERY_N_BLOCK != 0)) {
         return false;
     }


### PR DESCRIPTION
A major bottle neck during the initial synchronization, rescanning or processing new blocks is due to storing the consensus state to disk.

This is done, so the state can easily be rolled back in case of a block reorganization.

However, during the inital synchronization or when rescanning and reparsing historical blocks, it is only needed in case of a shutdown or crash, but can be skipped otherwise.

Also: store state every 5000 blocks during initial synchronization or rescanning.