### PR TITLE
Fix typo: depreciated -> deprecated

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -99,7 +99,7 @@ All available commands can be listed with `"help"`, and information about a spec
   - [omni_getfeedistributions](#omni_getfeedistributions)
 - [Configuration](#configuration)
   - [omni_setautocommit](#omni_setautocommit)
-- [Depreciated API calls](#depreciated-api-calls)
+- [Deprecated API calls](#deprecated-api-calls)
 
 ---
 
@@ -799,7 +799,7 @@ Result:
 {
   "omnicoreversion_int" : xxxxxxx,      // (number) client version as integer
   "omnicoreversion" : "x.x.x.x-xxx",    // (string) client version
-  "mastercoreversion" : "x.x.x.x-xxx",  // (string) client version (DEPRECIATED)
+  "mastercoreversion" : "x.x.x.x-xxx",  // (string) client version (DEPRECATED)
   "bitcoincoreversion" : "x.x.x",       // (string) Bitcoin Core version
   "commitinfo" : "xxxxxxx",             // (string) build commit identifier
   "block" : nnnnnn,                     // (number) index of the last processed block
@@ -2742,9 +2742,9 @@ $ omnicore-cli "omni_setautocommit" false
 
 ---
 
-## Depreciated API calls
+## Deprecated API calls
 
-To ensure backwards compatibility, depreciated RPCs are kept for at least one major version.
+To ensure backwards compatibility, deprecated RPCs are kept for at least one major version.
 
 The following calls are replaced in Omni Core 0.0.10, and queries with the old command are forwarded.
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -2272,7 +2272,7 @@ static UniValue omni_getinfo(const JSONRPCRequest& request)
                    "{\n"
                    "  \"omnicoreversion_int\" : xxxxxxx,       (number) client version as integer\n"
                    "  \"omnicoreversion\" : \"x.x.x.x-xxx\",     (string) client version\n"
-                   "  \"mastercoreversion\" : \"x.x.x.x-xxx\",   (string) client version (DEPRECIATED)\n"
+                   "  \"mastercoreversion\" : \"x.x.x.x-xxx\",   (string) client version (DEPRECATED)\n"
                    "  \"bitcoincoreversion\" : \"x.x.x\",        (string) Bitcoin Core version\n"
                    "  \"block\" : nnnnnn,                      (number) index of the last processed block\n"
                    "  \"blocktime\" : nnnnnnnnnn,              (number) timestamp of the last processed block\n"
@@ -2707,7 +2707,7 @@ static const CRPCCommand commands[] =
 #endif
     { "hidden",                      "mscrpc",                         &mscrpc,                          {"extra", "extra2", "extra3"}  },
 
-    /* depreciated: */
+    /* deprecated: */
     { "hidden",                      "getinfo_MP",                     &omni_getinfo,                    {}  },
     { "hidden",                      "getbalance_MP",                  &omni_getbalance,                 {"address", "propertyid"} },
     { "hidden",                      "getallbalancesforaddress_MP",    &omni_getallbalancesforaddress,   {"address"} },

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -1612,7 +1612,7 @@ static UniValue trade_MP(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 6)
         throw runtime_error(
             RPCHelpMan{"trade_MP",
-               "\nNote: this command is depreciated, and was replaced by:\n",
+               "\nNote: this command is deprecated, and was replaced by:\n",
                {
                    {"fromaddress", RPCArg::Type::STR, RPCArg::Optional::NO, "the address to send from\n"},
                    {"propertyidforsale", RPCArg::Type::NUM, RPCArg::Optional::NO, "the identifier of the tokens to list for sale\n"},
@@ -1713,7 +1713,7 @@ static const CRPCCommand commands[] =
     { "omni layer (transaction creation)", "omni_funded_send",             &omni_funded_send,             {"fromaddress", "toaddress", "propertyid", "amount", "feeaddress"} },
     { "omni layer (transaction creation)", "omni_funded_sendall",          &omni_funded_sendall,          {"fromaddress", "toaddress", "ecosystem", "feeaddress"} },
 
-    /* depreciated: */
+    /* deprecated: */
     { "hidden",                            "sendrawtx_MP",                 &omni_sendrawtx,               {"fromaddress", "rawtransaction", "referenceaddress", "redeemaddress", "referenceamount"} },
     { "hidden",                            "send_MP",                      &omni_send,                    {"fromaddress", "toaddress", "propertyid", "amount", "redeemaddress", "referenceamount"} },
     { "hidden",                            "sendtoowners_MP",              &omni_sendsto,                 {"fromaddress", "propertyid", "amount", "redeemaddress", "distributionproperty"} },

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -355,7 +355,7 @@ bool CMPTransaction::interpret_MetaDExTrade()
     memcpy(&desired_value, &pkt[20], 8);
     SwapByteOrder64(desired_value);
 
-    action = CMPTransaction::ADD; // depreciated
+    action = CMPTransaction::ADD; // deprecated
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
@@ -383,7 +383,7 @@ bool CMPTransaction::interpret_MetaDExCancelPrice()
     memcpy(&desired_value, &pkt[20], 8);
     SwapByteOrder64(desired_value);
 
-    action = CMPTransaction::CANCEL_AT_PRICE; // depreciated
+    action = CMPTransaction::CANCEL_AT_PRICE; // deprecated
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
@@ -406,10 +406,10 @@ bool CMPTransaction::interpret_MetaDExCancelPair()
     memcpy(&desired_property, &pkt[8], 4);
     SwapByteOrder32(desired_property);
 
-    nValue = 0; // depreciated
-    nNewValue = nValue; // depreciated
-    desired_value = 0; // depreciated
-    action = CMPTransaction::CANCEL_ALL_FOR_PAIR; // depreciated
+    nValue = 0; // deprecated
+    nNewValue = nValue; // deprecated
+    desired_value = 0; // deprecated
+    action = CMPTransaction::CANCEL_ALL_FOR_PAIR; // deprecated
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
@@ -427,12 +427,12 @@ bool CMPTransaction::interpret_MetaDExCancelEcosystem()
     }
     memcpy(&ecosystem, &pkt[4], 1);
 
-    property = ecosystem; // depreciated
-    desired_property = ecosystem; // depreciated
-    nValue = 0; // depreciated
-    nNewValue = nValue; // depreciated
-    desired_value = 0; // depreciated
-    action = CMPTransaction::CANCEL_EVERYTHING; // depreciated
+    property = ecosystem; // deprecated
+    desired_property = ecosystem; // deprecated
+    nValue = 0; // deprecated
+    nNewValue = nValue; // deprecated
+    desired_value = 0; // deprecated
+    action = CMPTransaction::CANCEL_EVERYTHING; // deprecated
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       ecosystem: %d\n", (int)ecosystem);

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -75,7 +75,7 @@ private:
     // MetaDEx
     unsigned int desired_property;
     uint64_t desired_value;
-    unsigned char action; // depreciated
+    unsigned char action; // deprecated
 
     // TradeOffer
     uint64_t amount_desired;


### PR DESCRIPTION
See https://www.merriam-webster.com/dictionary/deprecate

This change only affects comments, documentation, 
and RPC Help messages.