### PR TITLE
Add error text for omni_decodetransaction, when inputs are missing

### DIFF
--- a/src/omnicore/errors.h
+++ b/src/omnicore/errors.h
@@ -33,6 +33,7 @@ enum MPRPCErrorCode
     MP_INVALID_TX_IN_DB_FOUND     = -3335,  // Potential database corruption: Invalid transaction found.
     MP_TX_IS_NOT_OMNI_PROTOCOL    = -3336,  // No Omni Layer Protocol transaction.
     MP_TXINDEX_STILL_SYNCING      = -3337,  // No such mempool transaction. Blockchain transactions are still in the process of being indexed.
+    MP_RPC_DECODE_INPUTS_MISSING  = -3338,  // Transaction inputs missing
 };
 
 inline std::string error_str(int ec) {

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -89,6 +89,8 @@ void PopulateFailure(int error)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No Omni Layer Protocol transaction");
         case MP_TXINDEX_STILL_SYNCING:
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No such mempool transaction. Blockchain transactions are still in the process of being indexed.");
+        case MP_RPC_DECODE_INPUTS_MISSING:
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction inputs were not found. Please provide inputs explicitly (see help description) or fully synchronize node.");
 
     }
     throw JSONRPCError(RPC_INTERNAL_ERROR, "Generic transaction population failure");

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -93,7 +93,12 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
     // attempt to parse the transaction
     CMPTransaction mp_obj;
     int parseRC = ParseTransaction(tx, blockHeight, 0, mp_obj, blockTime);
-    if (parseRC < 0) return MP_TX_IS_NOT_OMNI_PROTOCOL;
+    if (parseRC == -101) {
+        return MP_RPC_DECODE_INPUTS_MISSING;
+    }
+    if (parseRC < 0) {
+        return MP_TX_IS_NOT_OMNI_PROTOCOL;
+    }
 
     const uint256& txid = tx.GetHash();
 


### PR DESCRIPTION
When the node is not synchronized, transaction inputs need to be provided explicitly. When this is not the case, a proper error is now shown:

> "Transaction inputs were not found. Please provide inputs explicitly (see help description) or fully synchronize node."

It resolves #1110.