### PR TITLE
Add more information when listing tokens

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -1212,6 +1212,8 @@ $ omnicore-cli "omni_getactivedexsells"
 
 Lists all tokens or smart properties.
 
+To get the total number of tokens, please use omni_getproperty.
+
 **Arguments:**
 
 *None*
@@ -1227,6 +1229,10 @@ Lists all tokens or smart properties.
     "data" : "information",         // (string) additional information or a description
     "url" : "uri",                  // (string) an URI, for example pointing to a website
     "divisible" : true|false        // (boolean) whether the tokens are divisible
+    "issuer" : "address",           // (string) the Bitcoin address of the issuer on record
+    "creationtxid" : "hash",        // (string) the hex-encoded creation transaction hash
+    "fixedissuance" : true|false,   // (boolean) whether the token supply is fixed
+    "managedissuance" : true|false, // (boolean) whether the token supply is managed by the issuer
   },
   ...
 ]

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -102,6 +102,10 @@ void PropertyToJSON(const CMPSPInfo::Entry& sProperty, UniValue& property_obj)
     property_obj.pushKV("data", sProperty.data);
     property_obj.pushKV("url", sProperty.url);
     property_obj.pushKV("divisible", sProperty.isDivisible());
+    property_obj.pushKV("issuer", sProperty.issuer);
+    property_obj.pushKV("creationtxid", sProperty.txid.GetHex());
+    property_obj.pushKV("fixedissuance", sProperty.fixed);
+    property_obj.pushKV("managedissuance", sProperty.manual);
 }
 
 void MetaDexObjectToJSON(const CMPMetaDEx& obj, UniValue& metadex_obj)
@@ -1208,6 +1212,7 @@ static UniValue omni_getproperty(const JSONRPCRequest& request)
                    "  \"creationtxid\" : \"hash\",         (string) the hex-encoded creation transaction hash\n"
                    "  \"fixedissuance\" : true|false,    (boolean) whether the token supply is fixed\n"
                    "  \"managedissuance\" : true|false,    (boolean) whether the token supply is managed\n"
+                   "  \"freezingenabled\" : true|false,    (boolean) whether freezing is enabled for the property (managed properties only)\n"
                    "  \"totaltokens\" : \"n.nnnnnnnn\"     (string) the total number of tokens in existence\n"
                    "}\n"
                },
@@ -1229,16 +1234,12 @@ static UniValue omni_getproperty(const JSONRPCRequest& request)
         }
     }
     int64_t nTotalTokens = getTotalTokens(propertyId);
-    std::string strCreationHash = sp.txid.GetHex();
     std::string strTotalTokens = FormatMP(propertyId, nTotalTokens);
 
     UniValue response(UniValue::VOBJ);
     response.pushKV("propertyid", (uint64_t) propertyId);
-    PropertyToJSON(sp, response); // name, category, subcategory, data, url, divisible
-    response.pushKV("issuer", sp.issuer);
-    response.pushKV("creationtxid", strCreationHash);
-    response.pushKV("fixedissuance", sp.fixed);
-    response.pushKV("managedissuance", sp.manual);
+    PropertyToJSON(sp, response); // name, category, subcategory, ...
+
     if (sp.manual) {
         int currentBlock = GetHeight();
         LOCK(cs_tally);
@@ -1254,7 +1255,7 @@ static UniValue omni_listproperties(const JSONRPCRequest& request)
     if (request.fHelp)
         throw runtime_error(
             RPCHelpMan{"omni_listproperties",
-               "\nLists all tokens or smart properties.\n",
+               "\nLists all tokens or smart properties. To get the total number of tokens, please use omni_getproperty.\n",
                {},
                RPCResult{
                    "[                                (array of JSON objects)\n"
@@ -1266,6 +1267,10 @@ static UniValue omni_listproperties(const JSONRPCRequest& request)
                    "    \"data\" : \"information\",          (string) additional information or a description\n"
                    "    \"url\" : \"uri\",                   (string) an URI, for example pointing to a website\n"
                    "    \"divisible\" : true|false         (boolean) whether the tokens are divisible\n"
+                   "    \"issuer\" : \"address\",            (string) the Bitcoin address of the issuer on record\n"
+                   "    \"creationtxid\" : \"hash\",         (string) the hex-encoded creation transaction hash\n"
+                   "    \"fixedissuance\" : true|false,    (boolean) whether the token supply is fixed\n"
+                   "    \"managedissuance\" : true|false,    (boolean) whether the token supply is managed\n"
                    "  },\n"
                    "  ...\n"
                    "]\n"
@@ -1286,7 +1291,7 @@ static UniValue omni_listproperties(const JSONRPCRequest& request)
         if (pDbSpInfo->getSP(propertyId, sp)) {
             UniValue propertyObj(UniValue::VOBJ);
             propertyObj.pushKV("propertyid", (uint64_t) propertyId);
-            PropertyToJSON(sp, propertyObj); // name, category, subcategory, data, url, divisible
+            PropertyToJSON(sp, propertyObj); // name, category, subcategory, ...
 
             response.push_back(propertyObj);
         }
@@ -1298,7 +1303,7 @@ static UniValue omni_listproperties(const JSONRPCRequest& request)
         if (pDbSpInfo->getSP(propertyId, sp)) {
             UniValue propertyObj(UniValue::VOBJ);
             propertyObj.pushKV("propertyid", (uint64_t) propertyId);
-            PropertyToJSON(sp, propertyObj); // name, category, subcategory, data, url, divisible
+            PropertyToJSON(sp, propertyObj); // name, category, subcategory, ...
 
             response.push_back(propertyObj);
         }


### PR DESCRIPTION
The fields "issuer", "creationtxid", "fixedissuance" and "managedissuance" are now included, when using "omni_listproperties".

The call now returns similar results as "omni_getproperty".