### PR TITLE
Remove OpenSSL usage from Omni source

### DIFF
--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -20,8 +20,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <openssl/sha.h>
-
 #include <stdint.h>
 
 #include <fstream>

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -6,10 +6,9 @@
 #include <omnicore/tx.h>
 
 #include <amount.h>
+#include <hash.h>
 #include <tinyformat.h>
 #include <uint256.h>
-
-#include <openssl/sha.h>
 
 #include <stdint.h>
 #include <fstream>
@@ -87,7 +86,7 @@ public:
     {
     }
 
-    void saveOffer(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& address) const
+    void saveOffer(std::ofstream& file, const std::string& address, CHash256& hasher) const
     {
         std::string lineOut = strprintf("%s,%d,%d,%d,%d,%d,%d,%d,%s",
                 address,
@@ -102,7 +101,7 @@ public:
         );
 
         // add the line to the hash
-        SHA256_Update(shaCtx, lineOut.c_str(), lineOut.length());
+        hasher.Write((unsigned char*)lineOut.c_str(), lineOut.length());
 
         // write the line
         file << lineOut << std::endl;
@@ -195,7 +194,7 @@ public:
         return bRet;
     }
 
-    void saveAccept(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& address, const std::string& buyer) const
+    void saveAccept(std::ofstream& file, const std::string& address, const std::string& buyer, CHash256& hasher) const
     {
         std::string lineOut = strprintf("%s,%d,%s,%d,%d,%d,%d,%d,%d,%s",
                 address,
@@ -210,7 +209,7 @@ public:
                 offer_txid.ToString());
 
         // add the line to the hash
-        SHA256_Update(shaCtx, lineOut.c_str(), lineOut.length());
+        hasher.Write((unsigned char*)lineOut.c_str(), lineOut.length());
 
         // write the line
         file << lineOut << std::endl;

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -10,6 +10,7 @@
 
 #include <arith_uint256.h>
 #include <chain.h>
+#include <hash.h>
 #include <validation.h>
 #include <tinyformat.h>
 #include <uint256.h>
@@ -18,8 +19,6 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/rational.hpp>
-
-#include <openssl/sha.h>
 
 #include <assert.h>
 #include <stdint.h>
@@ -425,7 +424,7 @@ std::string CMPMetaDEx::ToString() const
         property, FormatMP(property, amount_forsale), desired_property, FormatMP(desired_property, amount_desired));
 }
 
-void CMPMetaDEx::saveOffer(std::ofstream& file, SHA256_CTX* shaCtx) const
+void CMPMetaDEx::saveOffer(std::ofstream& file, CHash256& hasher) const
 {
     std::string lineOut = strprintf("%s,%d,%d,%d,%d,%d,%d,%d,%s,%d",
         addr,
@@ -441,7 +440,7 @@ void CMPMetaDEx::saveOffer(std::ofstream& file, SHA256_CTX* shaCtx) const
     );
 
     // add the line to the hash
-    SHA256_Update(shaCtx, lineOut.c_str(), lineOut.length());
+    hasher.Write((unsigned char*)lineOut.c_str(), lineOut.length());
 
     // write the line
     file << lineOut << std::endl;

--- a/src/omnicore/mdex.h
+++ b/src/omnicore/mdex.h
@@ -10,14 +10,14 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/rational.hpp>
 
-#include <openssl/sha.h>
-
 #include <stdint.h>
 
 #include <fstream>
 #include <map>
 #include <set>
 #include <string>
+
+class CHash256;
 
 typedef boost::rational<boost::multiprecision::checked_int128_t> rational_t;
 
@@ -99,7 +99,7 @@ public:
     /** Used for display of unit prices with 50 decimal places at RPC layer. */
     std::string displayFullUnitPrice() const;
 
-    void saveOffer(std::ofstream& file, SHA256_CTX* shaCtx) const;
+    void saveOffer(std::ofstream& file, CHash256 &hasher) const;
 };
 
 namespace mastercore

--- a/src/omnicore/parsing.cpp
+++ b/src/omnicore/parsing.cpp
@@ -14,9 +14,6 @@
 #include <uint256.h>
 #include <util/strencodings.h>
 
-// TODO: use crypto/sha256 instead of openssl
-#include <openssl/sha.h>
-
 #include <boost/algorithm/string.hpp>
 
 #include <assert.h>
@@ -122,7 +119,7 @@ void PrepareObfuscatedHashes(const std::string& strSeed, int hashCount, std::str
     // Do only as many re-hashes as there are data packets, 255 per specification
     for (int j = 1; j <= hashCount; ++j)
     {
-        SHA256(sha_input, strlen((const char *)sha_input), sha_result);
+        CSHA256().Write(sha_input, strlen((const char *)sha_input)).Finalize(sha_result);
         vec_chars.resize(32);
         memcpy(&vec_chars[0], &sha_result[0], 32);
         vstrHashes[j] = HexStr(vec_chars);

--- a/src/omnicore/persistence.cpp
+++ b/src/omnicore/persistence.cpp
@@ -16,6 +16,7 @@
 
 #include <chain.h>
 #include <fs.h>
+#include <hash.h>
 #include <validation.h>
 #include <tinyformat.h>
 #include <uint256.h>
@@ -24,8 +25,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
-
-#include <openssl/sha.h>
 
 #include <stdint.h>
 
@@ -74,7 +73,7 @@ static bool is_state_prefix(std::string const &str)
     return false;
 }
 
-static int write_msc_balances(std::ofstream& file, SHA256_CTX* shaCtx)
+static int write_msc_balances(std::ofstream& file, CHash256& hasher)
 {
     std::unordered_map<std::string, CMPTally>::iterator iter;
     for (iter = mp_tally_map.begin(); iter != mp_tally_map.end(); ++iter) {
@@ -109,7 +108,7 @@ static int write_msc_balances(std::ofstream& file, SHA256_CTX* shaCtx)
 
         if (false == emptyWallet) {
             // add the line to the hash
-            SHA256_Update(shaCtx, lineOut.c_str(), lineOut.length());
+            hasher.Write((unsigned char*)lineOut.c_str(), lineOut.length());
 
             // write the line
             file << lineOut << std::endl;
@@ -119,7 +118,7 @@ static int write_msc_balances(std::ofstream& file, SHA256_CTX* shaCtx)
     return 0;
 }
 
-static int write_mp_offers(std::ofstream& file, SHA256_CTX* shaCtx)
+static int write_mp_offers(std::ofstream& file, CHash256& hasher)
 {
     OfferMap::const_iterator iter;
     for (iter = my_offers.begin(); iter != my_offers.end(); ++iter) {
@@ -127,13 +126,13 @@ static int write_mp_offers(std::ofstream& file, SHA256_CTX* shaCtx)
         std::vector<std::string> vstr;
         boost::split(vstr, iter->first, boost::is_any_of("-"), boost::token_compress_on);
         const CMPOffer& offer = iter->second;
-        offer.saveOffer(file, shaCtx, vstr[0]);
+        offer.saveOffer(file, vstr[0], hasher);
     }
 
     return 0;
 }
 
-static int write_mp_accepts(std::ofstream& file, SHA256_CTX* shaCtx)
+static int write_mp_accepts(std::ofstream& file, CHash256& hasher)
 {
     AcceptMap::const_iterator iter;
     for (iter = my_accepts.begin(); iter != my_accepts.end(); ++iter) {
@@ -141,13 +140,13 @@ static int write_mp_accepts(std::ofstream& file, SHA256_CTX* shaCtx)
         std::vector<std::string> vstr;
         boost::split(vstr, iter->first, boost::is_any_of("-+"), boost::token_compress_on);
         const CMPAccept& accept = iter->second;
-        accept.saveAccept(file, shaCtx, vstr[0], vstr[2]);
+        accept.saveAccept(file, vstr[0], vstr[2], hasher);
     }
 
     return 0;
 }
 
-static int write_globals_state(std::ofstream& file, SHA256_CTX* shaCtx)
+static int write_globals_state(std::ofstream& file, CHash256& hasher)
 {
     uint32_t nextSPID = pDbSpInfo->peekNextSPID(OMNI_PROPERTY_MSC);
     uint32_t nextTestSPID = pDbSpInfo->peekNextSPID(OMNI_PROPERTY_TMSC);
@@ -157,7 +156,7 @@ static int write_globals_state(std::ofstream& file, SHA256_CTX* shaCtx)
             nextTestSPID);
 
     // add the line to the hash
-    SHA256_Update(shaCtx, lineOut.c_str(), lineOut.length());
+    hasher.Write((unsigned char*)lineOut.c_str(), lineOut.length());
 
     // write the line
     file << lineOut << std::endl;
@@ -165,18 +164,18 @@ static int write_globals_state(std::ofstream& file, SHA256_CTX* shaCtx)
     return 0;
 }
 
-static int write_mp_crowdsales(std::ofstream& file, SHA256_CTX* shaCtx)
+static int write_mp_crowdsales(std::ofstream& file, CHash256& hasher)
 {
     for (CrowdMap::const_iterator it = my_crowds.begin(); it != my_crowds.end(); ++it) {
         // decompose the key for address
         const CMPCrowd& crowd = it->second;
-        crowd.saveCrowdSale(file, shaCtx, it->first);
+        crowd.saveCrowdSale(file, it->first, hasher);
     }
 
     return 0;
 }
 
-static int write_mp_metadex(std::ofstream &file, SHA256_CTX* shaCtx)
+static int write_mp_metadex(std::ofstream &file, CHash256& hasher)
 {
     for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it) {
         md_PricesMap& prices = my_it->second;
@@ -184,7 +183,7 @@ static int write_mp_metadex(std::ofstream &file, SHA256_CTX* shaCtx)
             md_Set& indexes = (it->second);
             for (md_Set::iterator it = indexes.begin(); it != indexes.end(); ++it) {
                 const CMPMetaDEx& meta = *it;
-                meta.saveOffer(file, shaCtx);
+                meta.saveOffer(file, hasher);
             }
         }
     }
@@ -408,43 +407,40 @@ static int write_state_file(const CBlockIndex* pBlockIndex, int what)
     std::ofstream file;
     file.open(strFile.c_str());
 
-    SHA256_CTX shaCtx;
-    SHA256_Init(&shaCtx);
+    CHash256 hasher;
 
     int result = 0;
 
     switch (what) {
         case FILETYPE_BALANCES:
-            result = write_msc_balances(file, &shaCtx);
+            result = write_msc_balances(file, hasher);
             break;
 
         case FILETYPE_OFFERS:
-            result = write_mp_offers(file, &shaCtx);
+            result = write_mp_offers(file, hasher);
             break;
 
         case FILETYPE_ACCEPTS:
-            result = write_mp_accepts(file, &shaCtx);
+            result = write_mp_accepts(file, hasher);
             break;
 
         case FILETYPE_GLOBALS:
-            result = write_globals_state(file, &shaCtx);
+            result = write_globals_state(file, hasher);
             break;
 
         case FILETYPE_CROWDSALES:
-            result = write_mp_crowdsales(file, &shaCtx);
+            result = write_mp_crowdsales(file, hasher);
             break;
 
         case FILETYPE_MDEXORDERS:
-            result = write_mp_metadex(file, &shaCtx);
+            result = write_mp_metadex(file, hasher);
             break;
     }
 
     // generate and wite the double hash of all the contents written
-    uint256 hash1;
-    SHA256_Final((unsigned char*) &hash1, &shaCtx);
-    uint256 hash2;
-    SHA256((unsigned char*) &hash1, sizeof (hash1), (unsigned char*) &hash2);
-    file << "!" << hash2.ToString() << std::endl;
+    uint256 hash;
+    hasher.Finalize(hash.begin());
+    file << "!" << hash.ToString() << std::endl;
 
     file.flush();
     file.close();
@@ -569,8 +565,7 @@ int RestoreInMemoryState(const std::string& filename, int what, bool verifyHash)
     int lines = 0;
     int (*inputLineFunc)(const std::string&) = nullptr;
 
-    SHA256_CTX shaCtx;
-    SHA256_Init(&shaCtx);
+    CHash256 hasher;
 
     switch (what) {
         case FILETYPE_BALANCES:
@@ -641,7 +636,7 @@ int RestoreInMemoryState(const std::string& filename, int what, bool verifyHash)
 
         // update hash?
         if (verifyHash) {
-            SHA256_Update(&shaCtx, line.c_str(), line.length());
+            hasher.Write((unsigned char*)line.c_str(), line.length());
         }
 
         if (inputLineFunc) {
@@ -658,12 +653,10 @@ int RestoreInMemoryState(const std::string& filename, int what, bool verifyHash)
 
     if (verifyHash && res == 0) {
         // generate and wite the double hash of all the contents written
-        uint256 hash1;
-        SHA256_Final((unsigned char*) &hash1, &shaCtx);
-        uint256 hash2;
-        SHA256((unsigned char*) &hash1, sizeof (hash1), (unsigned char*) &hash2);
+        uint256 hash;
+        hasher.Finalize(hash.begin());
 
-        if (false == boost::iequals(hash2.ToString(), fileHash)) {
+        if (false == boost::iequals(hash.ToString(), fileHash)) {
             PrintToLog("File %s loaded, but failed hash validation!\n", filename);
             res = -1;
         }

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -21,8 +21,6 @@
 #include <uint256.h>
 #include <ui_interface.h>
 
-#include <openssl/sha.h>
-
 #include <stdint.h>
 #include <limits>
 #include <string>

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -7,6 +7,7 @@
 #include <omnicore/uint256_extensions.h>
 
 #include <arith_uint256.h>
+#include <hash.h>
 #include <validation.h>
 #include <tinyformat.h>
 #include <uint256.h>
@@ -53,7 +54,7 @@ void CMPCrowd::print(const std::string& address, FILE* fp) const
     fprintf(fp, "%s\n", toString(address).c_str());
 }
 
-void CMPCrowd::saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& addr) const
+void CMPCrowd::saveCrowdSale(std::ofstream& file, const std::string& addr, CHash256& hasher) const
 {
     // compose the outputline
     // addr,propertyId,nValue,property_desired,deadline,early_bird,percentage,created,mined
@@ -85,7 +86,7 @@ void CMPCrowd::saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std:
     }
 
     // add the line to the hash
-    SHA256_Update(shaCtx, lineOut.c_str(), lineOut.length());
+    hasher.Write((unsigned char*)lineOut.c_str(), lineOut.length());
 
     // write the line
     file << lineOut << std::endl;

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -6,9 +6,8 @@
 #include <omnicore/log.h>
 
 class CBlockIndex;
+class CHash256;
 class uint256;
-
-#include <openssl/sha.h>
 
 #include <stdint.h>
 #include <stdio.h>
@@ -62,7 +61,7 @@ public:
 
     std::string toString(const std::string& address) const;
     void print(const std::string& address, FILE* fp = stdout) const;
-    void saveCrowdSale(std::ofstream& file, SHA256_CTX* shaCtx, const std::string& addr) const;
+    void saveCrowdSale(std::ofstream& file, const std::string& addr, CHash256 &hasher) const;
 };
 
 namespace mastercore


### PR DESCRIPTION
OpenSSL has been removed in Bitcoin 0.20. The commit here is to remove OpenSSL usage from Omnicore to prepare for versions of Omnicore based on Bitcoin 0.20+.