### PR TITLE
Use legacy signing provider

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -129,11 +129,10 @@ public:
     }
     CKeyID getKeyForDestination(const CTxDestination& dest) const override
     {
-        auto script = GetScriptForDestination(dest);
-        std::unique_ptr<SigningProvider> provider = m_wallet->GetSolvingProvider(script);
+        auto spk_man = m_wallet->GetLegacyScriptPubKeyMan();
 
-        if (provider) {
-            return GetKeyForDestination(*provider, dest);
+        if (spk_man) {
+            return GetKeyForDestination(*spk_man, dest);
         }
 
         return CKeyID();
@@ -274,10 +273,9 @@ public:
     }
     bool produceSignature(const BaseSignatureCreator& creator, const CScript& scriptPubKey, SignatureData& sigdata) override
     {
-        std::unique_ptr<SigningProvider> provider = m_wallet->GetSolvingProvider(scriptPubKey);
-
-        if (provider) {
-            return ProduceSignature(*provider, creator, scriptPubKey, sigdata);
+        auto spk_man = m_wallet->GetLegacyScriptPubKeyMan();
+        if (spk_man) {
+            return ProduceSignature(*spk_man, creator, scriptPubKey, sigdata);
         }
 
         return false;

--- a/src/omnicore/wallettxbuilder.cpp
+++ b/src/omnicore/wallettxbuilder.cpp
@@ -354,7 +354,6 @@ int CreateFundedTransaction(
         }
     }
 
-    uint256 txid;
     std::string err_string;
 
     const TransactionError err = BroadcastTransaction(node, ctx, err_string, iWallet->getDefaultMaxTxFee(), true, false);
@@ -362,7 +361,7 @@ int CreateFundedTransaction(
         LogPrintf("%s: BroadcastTransaction failed error: %s\n", __func__, err_string);
     }
 
-    retTxid = txid;
+    retTxid = ctx->GetHash();
 
     return 0;
 }


### PR DESCRIPTION
Use the OutputType::LEGACY address signing provider LegacyScriptPubKeyMan. 

The SigningProvider which is the signing provider base class and does not actually provide any private keys so failed to sign transactions created by Omni. Both the wallet interface calls updated in this PR are only used by Omni.