### PR TITLE
Travis OmniJ tests: upgrade to jdk 11 (from JDK 8)

### DIFF
--- a/ci/test/00_setup_env_native_omnij.sh
+++ b/ci/test/00_setup_env_native_omnij.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_omnij
-export PACKAGES="python3-zmq openjdk-8-jdk"
+export PACKAGES="python3-zmq openjdk-11-jdk"
 export DEP_OPTS="NO_QT=1 NO_UPNP=1"
 export RUN_UNIT_TESTS_SEQUENTIAL="false"
 export RUN_UNIT_TESTS="false"


### PR DESCRIPTION
Upgrade Travis CI to install OpenJDK 11 (rather than OpenJDK 8) for OmniJ tests.

Based on @msgilligan PR https://github.com/OmniLayer/omnicore/pull/1146