### PR TITLE
[tests] Add tests for CreateFundedTransaction

### DIFF
--- a/src/Makefile.omnitest.include
+++ b/src/Makefile.omnitest.include
@@ -35,6 +35,10 @@ OMNICORE_TEST_CPP = \
   omnicore/test/utils_tx.cpp \
   omnicore/test/version_tests.cpp
 
+if ENABLE_WALLET
+OMNICORE_TEST_CPP += omnicore/test/funded_send_tests.cpp
+endif
+
 BITCOIN_TESTS += \
   $(OMNICORE_TEST_CPP) \
   $(OMNICORE_TEST_H)

--- a/src/omnicore/test/funded_send_tests.cpp
+++ b/src/omnicore/test/funded_send_tests.cpp
@@ -1,0 +1,159 @@
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <omnicore/createpayload.h>
+#include <omnicore/script.h>
+#include <omnicore/wallettxbuilder.h>
+
+#include <consensus/validation.h>
+#include <interfaces/chain.h>
+#include <interfaces/wallet.h>
+#include <key_io.h>
+#include <script/standard.h>
+#include <validation.h>
+#include <wallet/coincontrol.h>
+#include <wallet/wallet.h>
+
+#include <vector>
+
+class FundedSendTestingSetup : public TestChain100Setup
+{
+public:
+    FundedSendTestingSetup()
+    {
+        CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        wallet = std::make_shared<CWallet>(m_chain.get(), WalletLocation(), WalletDatabase::CreateMock());
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->SetLastBlockProcessed(::ChainActive().Height(), ::ChainActive().Tip()->GetBlockHash());
+        }
+        bool firstRun;
+        wallet->LoadWallet(firstRun);
+        auto spk_man = wallet->GetOrCreateLegacyScriptPubKeyMan();
+        {
+            LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
+            spk_man->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        }
+        WalletRescanReserver reserver(wallet.get());
+        reserver.reserve();
+        wallet->ScanForWalletTransactions(::ChainActive().Genesis()->GetBlockHash(), {}, reserver, false);
+        interface_wallet = interfaces::MakeWallet(wallet);
+        wallet->m_fallback_fee = CFeeRate(1000);
+    }
+
+    ~FundedSendTestingSetup()
+    {
+        wallet.reset();
+    }
+
+    void AddTx(std::vector<CRecipient>& recipients)
+    {
+        CTransactionRef tx;
+        CAmount fee;
+        int changePos = -1;
+        std::string error;
+        CCoinControl dummy;
+        {
+            auto locked_chain = m_chain->lock();
+            BOOST_CHECK(wallet->CreateTransaction(*locked_chain, recipients, tx, fee, changePos, error, dummy));
+        }
+        wallet->CommitTransaction(tx, {}, {});
+        CMutableTransaction blocktx;
+        {
+            LOCK(wallet->cs_wallet);
+            blocktx = CMutableTransaction(*wallet->mapWallet.at(tx->GetHash()).tx);
+        }
+        CreateAndProcessBlock({CMutableTransaction(blocktx)}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+
+        std::map<uint256, CWalletTx>::iterator it;
+        {
+            LOCK(wallet->cs_wallet);
+            it = wallet->mapWallet.find(tx->GetHash());
+        }
+
+        CWalletTx::Confirmation confirm(CWalletTx::Status::CONFIRMED, ::ChainActive().Height(), ::ChainActive().Tip()->GetBlockHash(), 1);
+        it->second.m_confirm = confirm;
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->SetLastBlockProcessed(::ChainActive().Height(), ::ChainActive().Tip()->GetBlockHash());
+        }
+    }
+
+    // For dust set entry in amounts to -1
+    std::vector<CTxDestination> CreateDestinations(std::vector<CAmount> amounts) {
+        std::vector<CRecipient> recipients;
+        std::vector<CTxDestination> destinations;
+        for (auto amount : amounts) {
+            CTxDestination dest;
+            {
+                LOCK(wallet->cs_wallet);
+                std::string error;
+                wallet->GetNewDestination(OutputType::LEGACY, "", dest, error);
+            }
+            destinations.push_back(dest);
+            if (amount > 0) {
+                recipients.push_back({GetScriptForDestination(dest), amount, false});
+            } else if (amount == -1) {
+                recipients.push_back({GetScriptForDestination(dest), OmniGetDustThreshold(GetScriptForDestination(dest)), false});
+            }
+        }
+        AddTx(recipients);
+
+        BOOST_CHECK_EQUAL(destinations.size(), amounts.size());
+
+        return destinations;
+    }
+
+    std::unique_ptr<interfaces::Chain> m_chain = interfaces::MakeChain(m_node);
+    std::shared_ptr<CWallet> wallet;
+    std::unique_ptr<interfaces::Wallet> interface_wallet;
+};
+
+static std::vector<unsigned char> dummy_payload() {
+    return CreatePayload_SimpleSend(1, 1);
+}
+
+static void check_outputs(uint256& hash, int expected_number) {
+    CTransactionRef tx;
+    uint256 hash_block;
+    BOOST_CHECK(GetTransaction(hash, tx, Params().GetConsensus(), hash_block, nullptr));
+    BOOST_CHECK_EQUAL(tx->vout.size(), expected_number);
+}
+
+BOOST_FIXTURE_TEST_SUITE(omnicore_funded_send_tests, FundedSendTestingSetup)
+
+BOOST_AUTO_TEST_CASE(create_token_funded_by_source)
+{
+    std::vector<CTxDestination> destinations = CreateDestinations({1 * COIN, 0});
+
+    uint256 hash;
+    BOOST_CHECK_EQUAL(CreateFundedTransaction(EncodeDestination(destinations[0] /* source */), EncodeDestination(destinations[1] /* receiver */), EncodeDestination(destinations[1] /* receiver */), dummy_payload(), hash, interface_wallet.get(), m_node), 0);
+
+    // Expect two outputs
+    check_outputs(hash, 2);
+}
+
+BOOST_AUTO_TEST_CASE(create_token_funded_by_receiver_address)
+{
+    std::vector<CTxDestination> destinations = CreateDestinations({-1 /* Dust */, 1 * COIN});
+
+    uint256 hash;
+    BOOST_CHECK_EQUAL(CreateFundedTransaction(EncodeDestination(destinations[0] /* source */), EncodeDestination(destinations[1] /* receiver */), EncodeDestination(destinations[1] /* receiver */), dummy_payload(), hash, interface_wallet.get(), m_node), 0);
+
+    // Expect two outputs
+    check_outputs(hash, 2);
+}
+
+BOOST_AUTO_TEST_CASE(create_token_funded_by_fee_address)
+{
+    std::vector<CTxDestination> destinations = CreateDestinations({-1 /* Dust */, 0, 1 * COIN});
+
+    uint256 hash;
+    BOOST_CHECK_EQUAL(CreateFundedTransaction(EncodeDestination(destinations[0] /* source */), EncodeDestination(destinations[1] /* receiver */), EncodeDestination(destinations[2] /* fee */), dummy_payload(), hash, interface_wallet.get(), m_node), 0);
+
+    // Expect three outputs
+    check_outputs(hash, 3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2903,6 +2903,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                         CAmount nAmount = nValueIn - nValueToSelect;
                         CAmount nDust = GetDustThreshold(CTxOut(nAmount, scriptChange), discard_rate);
                         while (nAmount < nDust) {
+                            coin_selection_params.use_bnb = false;
                             nValueToSelect = nValueIn + (nDust - nAmount);
                             nValueIn = 0;
                             if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, coin_control, coin_selection_params, bnb_used))


### PR DESCRIPTION
Adds three test cases for CreateFundedTransaction, funding with source address, funding with receiver address and funding with fee address. Expected number of the outputs are also checked.

Also restore default behaviour in bespoke CreateTransaction code to make sure we have a change output with at least the dust threshold. Previously use_bnb would have been set to false inside of SelectCoins and the KnapSack solver would have been used, this is no longer set and BnB fails to find us an output to use. Setting use_bnb to false before entering SelectCoins allows KnapSack to run and find the coins marked available by AvailableCoins.