### PR TITLE
Change default address type to wrapped SW

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -126,10 +126,10 @@ enum WalletFeature
 };
 
 //! Default for -addresstype
-constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::LEGACY};
+constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::P2SH_SEGWIT};
 
 //! Default for -changetype
-constexpr OutputType DEFAULT_CHANGE_TYPE{OutputType::LEGACY};
+constexpr OutputType DEFAULT_CHANGE_TYPE{OutputType::CHANGE_AUTO};
 
 enum WalletFlags : uint64_t {
     // wallet flags in the upper section (> 1 << 31) will lead to not opening the wallet if flag is unknown


### PR DESCRIPTION
This commit changes the default address generation to SegWit wrapped in P2SH. When using `getnewaddress`, a wrapped SW address is generated.

This default can be reverted by using the configuration option `-addresstype=legacy`.