### PR TITLE
Support adding a receiver address for "any data" transactions

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -788,12 +788,15 @@ $ omnicore-cli "omni_sendunfreeze" "3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY" "3HTHRxu
 
 Create and broadcast a transaction with an arbitrary payload.
 
+When no receiver is specified, the sender is also considered as receiver.
+
 **Arguments:**
 
 | Name                | Type    | Presence | Description                                                                                  |
 |---------------------|---------|----------|----------------------------------------------------------------------------------------------|
 | `fromaddress`       | string  | required | the address to send from                                                                     |
 | `data`              | string  | required | the hex-encoded data                                                                         |
+| `toaddress`         | string  | optional | the optional address of the receiver                                                                  |
 
 **Result:**
 ```js
@@ -804,6 +807,10 @@ Create and broadcast a transaction with an arbitrary payload.
 
 ```bash
 $ omnicore-cli "omni_sendanydata" "3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY" "646578782032303230"
+```
+
+```bash
+$ omnicore-cli "omni_sendanydata" "3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY" "646578782032303230" "3HTHRxu3aSDV4deakjC7VmsiUp7c6dfbvs"
 ```
 
 ---

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -1661,13 +1661,14 @@ static UniValue omni_sendanydata(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     std::unique_ptr<interfaces::Wallet> pwallet = interfaces::MakeWallet(wallet);
 
-    if (request.fHelp || request.params.size() != 2)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
         throw runtime_error(
             RPCHelpMan{"omni_sendanydata",
-               "\nCreate and broadcast a transaction with an arbitrary payload.\n",
+               "\nCreate and broadcast a transaction with an arbitrary payload.\nWhen no receiver is specified, the sender is also considered as receiver.\n",
                {
                    {"fromaddress", RPCArg::Type::STR, RPCArg::Optional::NO, "the address to send from\n"},
                    {"data", RPCArg::Type::STR, RPCArg::Optional::NO, "the hex-encoded data\n"},
+                   {"toaddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "the optional address of the receiver\n"},
                },
                RPCResult{
                    "\"hash\"                  (string) the hex-encoded transaction hash\n"
@@ -1681,6 +1682,10 @@ static UniValue omni_sendanydata(const JSONRPCRequest& request)
     // obtain parameters
     std::string fromAddress = ParseAddress(request.params[0]);
     std::vector<unsigned char> data = ParseHexV(request.params[1], "data");
+    std::string toAddress;
+    if (request.params.size() > 2) {
+        toAddress = ParseAddressOrEmpty(request.params[2]);
+    }
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_AnyData(data);
@@ -1688,7 +1693,7 @@ static UniValue omni_sendanydata(const JSONRPCRequest& request)
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
-    int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit, pwallet.get());
+    int result = WalletTxBuilder(fromAddress, toAddress, "", 0, payload, txid, rawHex, autoCommit, pwallet.get());
 
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
@@ -1963,7 +1968,7 @@ static const CRPCCommand commands[] =
     { "omni layer (transaction creation)", "omni_senddisablefreezing",     &omni_senddisablefreezing,     {"fromaddress", "propertyid"} },
     { "omni layer (transaction creation)", "omni_sendfreeze",              &omni_sendfreeze,              {"fromaddress", "toaddress", "propertyid", "amount"} },
     { "omni layer (transaction creation)", "omni_sendunfreeze",            &omni_sendunfreeze,            {"fromaddress", "toaddress", "propertyid", "amount"} },
-    { "omni layer (transaction creation)", "omni_sendanydata",             &omni_sendanydata,             {"fromaddress", "data"} },
+    { "omni layer (transaction creation)", "omni_sendanydata",             &omni_sendanydata,             {"fromaddress", "data", "toaddress"} },
     { "hidden",                            "omni_senddeactivation",        &omni_senddeactivation,        {"fromaddress", "featureid"} },
     { "hidden",                            "omni_sendactivation",          &omni_sendactivation,          {"fromaddress", "featureid", "block", "minclientversion"} },
     { "hidden",                            "omni_sendalert",               &omni_sendalert,               {"fromaddress", "alerttype", "expiryvalue", "message"} },

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -278,7 +278,7 @@ bool showRefForTx(uint32_t txType)
         case MSC_TYPE_DISABLE_FREEZING: return false;
         case MSC_TYPE_FREEZE_PROPERTY_TOKENS: return true;
         case MSC_TYPE_UNFREEZE_PROPERTY_TOKENS: return true;
-        case MSC_TYPE_ANYDATA: return false;
+        case MSC_TYPE_ANYDATA: return true;
         case OMNICORE_MESSAGE_TYPE_ACTIVATION: return false;
     }
     return true; // default to true, shouldn't be needed but just in case

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -795,6 +795,7 @@ bool CMPTransaction::interpret_AnyData()
 
     if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
         PrintToLog("\t       data: %s\n", "...");
+        PrintToLog("\t   receiver: %s\n", receiver);
     }
 
     return true;


### PR DESCRIPTION
The new transaction 200 now supports also an optional receiver address.

### Example: No receiver specified

```
omni_sendanydata "2MsKdZp2EztZZXv3P17dmjEt9VUdb698wiL" "0101"
```
```
fdc754f8f4931412f8398ff76e518cc29d403acddf995a9f5efb5c98451c9ee9
```

```
omni_gettransaction "fdc754f8f4931412f8398ff76e518cc29d403acddf995a9f5efb5c98451c9ee9"
```
```
{
  "txid": "fdc754f8f4931412f8398ff76e518cc29d403acddf995a9f5efb5c98451c9ee9",
  "fee": "0.00003100",
  "sendingaddress": "2MsKdZp2EztZZXv3P17dmjEt9VUdb698wiL",
  "referenceaddress": "2MsKdZp2EztZZXv3P17dmjEt9VUdb698wiL", # <-- with no receiver given, receiver = sender
  "ismine": true,
  "version": 0,
  "type_int": 200,
  "type": "Embed any data",
  "data": "0101",
  "confirmations": 0
}
```

### Example: One receiver specified

```
omni_sendanydata "2MsKdZp2EztZZXv3P17dmjEt9VUdb698wiL" "0202" "2N85ZZpYLqEvTRbuVzFzfXMRWqxbQm3v46Q"
```
```
b259dba9dcedecfb095a00f1540a09fcffc0fc3d5863c5a408d206886a24d2d9
```

```
omni_gettransaction "b259dba9dcedecfb095a00f1540a09fcffc0fc3d5863c5a408d206886a24d2d9"
```
```
{
  "txid": "b259dba9dcedecfb095a00f1540a09fcffc0fc3d5863c5a408d206886a24d2d9",
  "fee": "0.00003740",
  "sendingaddress": "2MsKdZp2EztZZXv3P17dmjEt9VUdb698wiL",
  "referenceaddress": "2N85ZZpYLqEvTRbuVzFzfXMRWqxbQm3v46Q", # <-- the specified receiver
  "ismine": true,
  "version": 0,
  "type_int": 200,
  "type": "Embed any data",
  "data": "0202",
  "confirmations": 0
}
```