### PR TITLE
Avoid overflow on reindex with debug enabled

### DIFF
--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -174,6 +174,8 @@ std::string mastercore::strMPProperty(uint32_t propertyId)
 
 std::string FormatDivisibleShortMP(int64_t n)
 {
+    if (n == std::numeric_limits<int64_t>::min()) // Avoids overflow when getting absolute value
+        return "ErrorAmount";
     int64_t n_abs = (n > 0 ? n : -n);
     int64_t quotient = n_abs / COIN;
     int64_t remainder = n_abs % COIN;
@@ -193,6 +195,8 @@ std::string FormatDivisibleMP(int64_t n, bool fSign)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
+    if (n == std::numeric_limits<int64_t>::min()) // Avoids overflow when getting absolute value
+        return "ErrorAmount";
     int64_t n_abs = (n > 0 ? n : -n);
     int64_t quotient = n_abs / COIN;
     int64_t remainder = n_abs % COIN;

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -459,10 +459,9 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
         p += spstr.back().size() + 1;
     }
     int i = 0;
-    size_t nNameSize = std::min(spstr[2].length(), sizeof(name)-1);
     memcpy(category, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(category)-1)); i++;
     memcpy(subcategory, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(subcategory)-1)); i++;
-    memcpy(name, spstr[i].c_str(), nNameSize); i++;
+    memcpy(name, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(name)-1)); i++;
     memcpy(url, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(url)-1)); i++;
     memcpy(data, spstr[i].c_str(), std::min(spstr[i].length(), sizeof(data)-1)); i++;
     memcpy(&nValue, p, 8);
@@ -479,9 +478,7 @@ bool CMPTransaction::interpret_CreatePropertyFixed()
         PrintToLog("\t            name: %s\n", name);
         PrintToLog("\t             url: %s\n", url);
         PrintToLog("\t            data: %s\n", data);
-        PrintToLog("\t           value: %s\n",
-                   nNameSize == 6 && strncmp(name, "errtok", nNameSize) == 0 ?
-                       "ErrorAmount" : FormatByType(nValue, prop_type));
+        PrintToLog("\t           value: %s\n", FormatByType(nValue, prop_type));
     }
 
     if (isOverrun(p)) {


### PR DESCRIPTION
When reindexing mainnet with --debug-enabled which sets -ftrapv, exceptions are generated from an overflow in FormatDivisibleMP, this happens when Omni TXs that are in error and have the value -9223372036854775808 hit the following line in FormatDivisibleMP.

https://github.com/OmniLayer/omnicore/blob/master/src/omnicore/omnicore.cpp#L196

-9223372036854775808 when negated as 9223372036854775808 is in overflow and crashes with trapv set.

This was avoided in the past for a normal sync with the following commit.

https://github.com/OmniLayer/omnicore/commit/eb8a9865c2793ae47123668bbba40b57b0345e23

This commit reverts the commit above and if the value passed to FormatDivisibleMP or FormatDivisibleShortMP is the minimum possible value then the string "ErrorAmount" is returned and the code generating the exception is skipped.