### PR TITLE
Move lock to blockOnchainActive

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -551,9 +551,6 @@ UniValue getblockhashes(const JSONRPCRequest& request)
 
     std::vector<std::pair<uint256, unsigned int> > blockHashes;
 
-    if (fActiveOnly)
-        LOCK(cs_main);
-
     if (!GetTimestampIndex(high, low, fActiveOnly, blockHashes)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for block hashes");
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -405,6 +405,7 @@ bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, 
 }
 
 bool CBlockTreeDB::blockOnchainActive(const uint256 &hash) {
+    LOCK(cs_main);
     CBlockIndex* pblockindex = mapBlockIndex[hash];
 
     if (!chainActive.Contains(pblockindex)) {


### PR DESCRIPTION
Currently cs_main in getblockhashes is only held in the scope of the fActiveOnly conditional and is immediately released. cs_main is supposed to be held for the call to blockOnchainActive based on fActiveOnly being true.

This is the path from getblockhashes to blockOnchainActive when fActiveOnly is true.

getblockhashes > GetTimestampIndex > ReadTimestampIndex > blockOnchainActive

This commit removes the cs_main lock from getblockhashes and moves it to blockOnchainActive before BlockIndex() and ChainActive() is used. blockOnchainActive needs to hold cs_main for BlockIndex() and ChainActive().