### PR TITLE
Return error, when using bitcore RPCs without addrindex

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -177,6 +177,9 @@ UniValue getaddressdeltas(const JSONRPCRequest& request)
         },
     }.Check(request);
 
+    if (!fAddressIndex) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+    }
 
     UniValue startValue = find_value(request.params[0].get_obj(), "start");
     UniValue endValue = find_value(request.params[0].get_obj(), "end");
@@ -294,6 +297,10 @@ UniValue getaddressbalance(const JSONRPCRequest& request)
         },
     }.Check(request);
 
+    if (!fAddressIndex) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+    }
+
     std::vector<std::pair<uint256, int> > addresses;
 
     if (!getAddressesFromParams(request.params, addresses)) {
@@ -367,6 +374,10 @@ UniValue getaddressutxos(const JSONRPCRequest& request)
             + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"1AMHv5kQ2gG5mLUbhhpLErjuuhk1r53tJ2\"], \"chainInfo\": true}")
         },
     }.Check(request);
+
+    if (!fAddressIndex) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+    }
 
     bool includeChainInfo = false;
     if (request.params[0].isObject()) {
@@ -456,6 +467,10 @@ UniValue getaddressmempool(const JSONRPCRequest& request)
         },
     }.Check(request);
 
+    if (!fAddressIndex) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+    }
+
     std::vector<std::pair<uint256, int> > addresses;
 
     if (!getAddressesFromParams(request.params, addresses)) {
@@ -524,6 +539,10 @@ UniValue getblockhashes(const JSONRPCRequest& request)
         },
     }.Check(request);
 
+    if (!fAddressIndex) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+    }
+
     unsigned int high = request.params[0].get_int();
     unsigned int low = request.params[1].get_int();
     bool fActiveOnly = false;
@@ -590,6 +609,10 @@ UniValue getspentinfo(const JSONRPCRequest& request)
         },
     }.Check(request);
 
+    if (!fAddressIndex) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+    }
+
     UniValue txidValue = find_value(request.params[0].get_obj(), "txid");
     UniValue indexValue = find_value(request.params[0].get_obj(), "index");
 
@@ -646,6 +669,10 @@ UniValue getaddresstxids(const JSONRPCRequest& request)
             + HelpExampleRpc("getaddresstxids", "{\"addresses\": [\"1AMHv5kQ2gG5mLUbhhpLErjuuhk1r53tJ2\"], \"start\": 5000, \"end\": 5500}")
         },
     }.Check(request);
+
+    if (!fAddressIndex) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+    }
 
     std::vector<std::pair<uint256, int> > addresses;
 


### PR DESCRIPTION
Added from the develop branch, original PR by @dexX7 is linked below.

https://github.com/OmniLayer/omnicore/pull/1181

Original PR text.

> When the address index (bitcore patch) isn't enabled, return an error, when using the related RPCs.