### PR TITLE
Show Omni version on splashscreen

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -42,7 +42,7 @@ SplashScreen::SplashScreen(interfaces::Node& node, Qt::WindowFlags f, const Netw
 
     // define text to place
     QString titleText       = PACKAGE_NAME;
-    QString versionText     = QString("Version %1").arg(QString::fromStdString(FormatFullVersion()));
+    QString versionText     = QString("%1").arg(QString::fromStdString(OmniCoreVersion()));
     QString copyrightText   = QString::fromUtf8(CopyrightHolders(strprintf("\xc2\xA9 %u-%u ", 2009, COPYRIGHT_YEAR)).c_str());
             copyrightText  += QString::fromUtf8("\n\xc2\xA9 2013-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Omni Core developers"));
     QString titleAddText    = networkStyle->getTitleAddText();


### PR DESCRIPTION
Makes the new 0.20 splash screen consistent with the 0.9.0 release which shows the Omni version on the Qt GUI splash screen, not the Bitcoin Core version.