### PR TITLE
Omni overview updates

### DIFF
--- a/src/omnicore/walletutils.h
+++ b/src/omnicore/walletutils.h
@@ -27,7 +27,7 @@ bool CheckFee(interfaces::Wallet& iWallet, const std::string& fromAddress, size_
 bool CheckInput(const CTxOut& txOut, int nHeight, CTxDestination& dest);
 
 /** IsMine wrapper to determine whether the address is in the wallet. */
-int IsMyAddress(const std::string& address, interfaces::Wallet* iWallet = nullptr);
+int IsMyAddress(const std::string& address, interfaces::Wallet* iWallet);
 
 /** IsMine wrapper to determine whether the address is in the wallet. */
 int IsMyAddressAllWallets(const std::string& address, const bool matchAny = false, const isminefilter& filter = ISMINE_SPENDABLE);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -161,6 +161,7 @@ public:
                             CMPTransaction mp_obj;
                             int parseRC = ParseTransaction(*wtx, blockHeight, 0, mp_obj);
                             if (0 < parseRC) { //positive RC means DEx payment
+                                valid = true;
                                 std::string tmpBuyer, tmpSeller;
                                 uint64_t total = 0, tmpVout = 0, tmpNValue = 0, tmpPropertyId = 0;
                                 {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -77,12 +77,22 @@ Q_DECLARE_METATYPE(interfaces::WalletBalances)
 class TxViewDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT
+
+    WalletModel *walletModel;
+
 public:
     explicit TxViewDelegate(const PlatformStyle *_platformStyle, QObject *parent=nullptr):
-        QAbstractItemDelegate(parent), unit(BitcoinUnits::BTC),
+        QAbstractItemDelegate(parent),
+        walletModel(nullptr),
+        unit(BitcoinUnits::BTC),
         platformStyle(_platformStyle)
     {
 
+    }
+
+    void setWalletModel(WalletModel *model)
+    {
+        this->walletModel = model;
     }
 
     inline void paint(QPainter *painter, const QStyleOptionViewItem &option,
@@ -168,7 +178,7 @@ public:
                                     LOCK(cs_tally);
                                     pDbTransactionList->getPurchaseDetails(hash,1,&tmpBuyer,&tmpSeller,&tmpVout,&tmpPropertyId,&tmpNValue);
                                 }
-                                bool bIsBuy = IsMyAddress(tmpBuyer);
+                                bool bIsBuy = IsMyAddress(tmpBuyer, &walletModel->wallet());
                                 LOCK(cs_tally);
                                 int numberOfPurchases=pDbTransactionList->getNumberOfSubRecords(hash);
                                 if (0<numberOfPurchases) { // calculate total bought/sold
@@ -195,9 +205,9 @@ public:
                                         omniAmountStr = QString::fromStdString(FormatIndivisibleMP(omniAmount) + getTokenLabel(omniPropertyId));
                                     }
                                     if (!mp_obj.getReceiver().empty()) {
-                                        if (IsMyAddress(mp_obj.getReceiver())) {
+                                        if (IsMyAddress(mp_obj.getReceiver(), &walletModel->wallet())) {
                                             omniOutbound = false;
-                                            if (IsMyAddress(mp_obj.getSender())) omniSendToSelf = true;
+                                            if (IsMyAddress(mp_obj.getSender(), &walletModel->wallet())) omniSendToSelf = true;
                                         }
                                         address = QString::fromStdString(mp_obj.getReceiver());
                                     } else {
@@ -556,6 +566,7 @@ void OverviewPage::setClientModel(ClientModel *model)
 void OverviewPage::setWalletModel(WalletModel *model)
 {
     this->walletModel = model;
+    txdelegate->setWalletModel(model);
     if(model && model->getOptionsModel())
     {
         // Set up transaction list


### PR DESCRIPTION
DEx transactions always show as invalid on the overview page. When ParseTransaction returns more than 0 indicating a DEx TX the code works out whether it is an outbound or inbound TX to update the icon but without setting valid to true an invalid icon is shown instead.

The other change here is to pass a wallet to IsMyAddress, without this IsMyAddress will always return false so TXs on the overview page always appear to be outgoing, not incoming. The second wallet argument for IsMyAddress no longer has a default nullptr argument so a wallet must always be passed when calling it.