### PR TITLE
Add Free DEx and fee cache tests

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -384,7 +384,7 @@ void SetupServerArgs()
 
     // Hidden Options
     std::vector<std::string> hidden_args = {
-        "-dbcrashratio", "-forcecompactdb",
+        "-dbcrashratio", "-forcecompactdb", "-disabledevmsc",
         // GUI args. These will be overwritten by SetupUIArgs for the GUI
         "-choosedatadir", "-lang=<lang>", "-min", "-resetguisettings", "-splash", "-uiplatform"};
 

--- a/src/omnicore/dbfees.cpp
+++ b/src/omnicore/dbfees.cpp
@@ -250,7 +250,7 @@ void COmniFeeCache::PruneCache(const uint32_t &propertyId, int block)
         std::set<feeCacheItem>::iterator startIt = sCacheHistoryItems.begin();
         feeCacheItem firstItem = *startIt;
         if (firstItem.first >= pruneBlock) {
-            if (msc_debug_fees) PrintToLog("Endingg PruneCache - no matured entries found.\n");
+            if (msc_debug_fees) PrintToLog("Ending PruneCache - no matured entries found.\n");
             return; // all entries are above supplied block value, nothing to do
         }
         std::string newValue;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -530,6 +530,11 @@ bool mastercore::update_tally_map(const std::string& who, uint32_t propertyId, i
  */
 static int64_t calculate_and_update_devmsc(unsigned int nTime, int block)
 {
+    // Allow disable of Dev MSC for fee cache test on regtest only
+    if (Params().NetworkIDString() == CBaseChainParams::REGTEST && gArgs.GetBoolArg("-disabledevmsc", false)) {
+        return 0;
+    }
+
     // do nothing if before end of fundraiser
     if (nTime < 1377993874) return 0;
 
@@ -583,8 +588,8 @@ uint32_t mastercore::GetNextPropertyId(bool maineco)
 // Perform any actions that need to be taken when the total number of tokens for a property ID changes
 void NotifyTotalTokensChanged(uint32_t propertyId, int block)
 {
+    pDbFeeCache->UpdateDistributionThresholds(propertyId);
     if (IsFeatureActivated(FEATURE_FEES, block)) {
-        pDbFeeCache->UpdateDistributionThresholds(propertyId);
         pDbFeeCache->EvalCache(propertyId, block);
     }
 }

--- a/test/functional/omni_clientexpiry.py
+++ b/test/functional/omni_clientexpiry.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     client_shutdown = False
     try:
         OmniClientExpiry().main()
-    except AssertionError:
+    except:
         client_shutdown = True
     finally:
         if not client_shutdown:

--- a/test/functional/omni_dexversionsspec.py
+++ b/test/functional/omni_dexversionsspec.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test DEx versions spec using free DEx."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.authproxy import JSONRPCException
+
+# Transaction format tests for traditional DEx offer
+#
+# Traditional DEx orders with version 0 have an implicit action value,
+# based on the global state, whereby transactions with version 1 have an
+# explicit action value. Other versions are currently not valid.
+
+class OmniFreeDExVersionsSpec(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [['-omniactivationallowsender=any']]
+
+    def run_test(self):
+        self.log.info("test dex versions spec using free dex")
+
+        # Preparing some mature Bitcoins
+        coinbase_address = self.nodes[0].getnewaddress()
+        self.nodes[0].generatetoaddress(110, coinbase_address)
+
+        # Obtaining a master address to work with
+        address = self.nodes[0].getnewaddress()
+
+        # Funding the address with some testnet BTC for fees
+        self.nodes[0].sendtoaddress(address, 10)
+        self.nodes[0].sendtoaddress(address, 10)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Activating Free DEx...
+        activation_block = self.nodes[0].getblockcount() + 8
+        txid = self.nodes[0].omni_sendactivation(address, 15, activation_block, 0)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Mining 10 blocks to forward past the activation block
+        self.nodes[0].generatetoaddress(10, coinbase_address)
+
+        # Checking the activation went live as expected...
+        featureid = self.nodes[0].omni_getactivations()['completedactivations']
+        freeDEx = False
+        for ids in featureid:
+            if ids['featureid'] == 15:
+                freeDEx = True
+        assert_equal(freeDEx, True)
+
+        # Create a fixed property
+        txid = self.nodes[0].omni_sendissuancefixed(address, 1, 2, 0, "Test Category", "Test Subcategory", "TST", "http://www.omnilayer.org", "This is a test for managed properties", "100000")
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Get currency ID
+        currencyOffered = result['propertyid']
+
+        # DEx transactions with version 0 have no explicit action value
+
+        # Created funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, "0.1")
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, "0.5")
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        #    {
+        #        "version": 0,
+        #        "type_int": 20,
+        #        "propertyid": 3,
+        #        "amount": "0.40000000",currently
+        #        "bitcoindesired": "0.80000000",
+        #        "timelimit": 15,
+        #        "feerequired": "0.00000100"
+        #    }
+
+        payload = "00000014000000030000000002625a000000000004c4b4000f0000000000000064"
+
+        offerTxid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction...
+        offerTx = self.nodes[0].omni_gettransaction(offerTxid)
+        assert_equal(offerTx['valid'], True)
+        assert_equal(offerTx['action'], "new") # implicit
+
+        # DEx transactions with version 1 have an explicit action value
+
+        # Created funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, "0.1")
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, "0.3")
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        #    {
+        #        "version": 1,
+        #        "type_int": 20,
+        #        "propertyid": 3,
+        #        "amount": "0.10000000",
+        #        "bitcoindesired": "0.10000000",
+        #        "timelimit": 20,
+        #        "feerequired": "0.00000000",
+        #        "action": 1
+        #    }
+
+        payload = "00010014000000030000000000989680000000000098968014000000000000000001"
+
+        offerTxid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction...
+        offerTx = self.nodes[0].omni_gettransaction(offerTxid)
+        assert_equal(offerTx['valid'], True)
+        assert_equal(offerTx['action'], "new") # explicit
+
+        # DEx transactions with version 1 must be sent with action value
+
+        # Created funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, "0.1")
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, "0.3")
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        #    {
+        #        "version": 1,
+        #        "type_int": 20,
+        #        "propertyid": 3,
+        #        "amount": "0.30000000",
+        #        "bitcoindesired": "0.30000000",
+        #        "timelimit": 7,
+        #        "feerequired": "0.00000050"
+        #    }
+
+        payload = "00010014000000030000000001c9c3800000000001c9c380070000000000000032"
+
+        offerTxid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Transaction should be invalid, omni_gettransaction will throw
+        thrown = False
+        try:
+            offerTx = self.nodes[0].omni_gettransaction(offerTxid)
+        except JSONRPCException:
+            thrown = True
+        assert_equal(thrown, True)
+
+        # DEx transactions with versions greater than 1 are currently not valid
+
+        # Created funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, "0.1")
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, "0.3")
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        #    {
+        #        "version": 2,
+        #        "type_int": 20,
+        #        "propertyid": 3,
+        #        "amount": "0.00000001",
+        #        "bitcoindesired": "0.00000001",
+        #        "timelimit": 255,
+        #        "feerequired": "0.00000001",
+        #        "action": 1
+        #    }
+
+        payload = "000200140000000300000000000000010000000000000001ff000000000000000101"
+
+        offerTxid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction...
+        offerTx = self.nodes[0].omni_gettransaction(offerTxid)
+        assert_equal(offerTx['valid'], False)
+
+if __name__ == '__main__':
+    OmniFreeDExVersionsSpec().main()

--- a/test/functional/omni_feecache.py
+++ b/test/functional/omni_feecache.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test Omni fee cache."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class OmniFeeCache(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [['-omniactivationallowsender=any', '-disabledevmsc=1']]
+
+    def run_test(self):
+        self.log.info("test fee cache")
+
+        node = self.nodes[0]
+
+        # Preparing some mature Bitcoins
+        coinbase_address = node.getnewaddress()
+        node.generatetoaddress(102, coinbase_address)
+
+        # Obtaining a master address to work with
+        address = node.getnewaddress()
+
+        # Funding the address with some testnet BTC for fees
+        node.sendtoaddress(address, 20)
+        node.sendtoaddress(address, 20)
+        node.sendtoaddress(address, 20)
+        node.generatetoaddress(1, coinbase_address)
+
+        # Participating in the Exodus crowdsale to obtain some OMNI
+        txid = node.sendmany("", {"moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP": 10, address: 4})
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid.
+        result = node.gettransaction(txid)
+        assert_equal(result['confirmations'], 1)
+
+        # Creating an indivisible test property
+        node.omni_sendissuancefixed(address, 1, 1, 0, "Z_TestCat", "Z_TestSubCat", "Z_IndivisTestProperty", "Z_TestURL", "Z_TestData", "10000000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Creating a second indivisible test property
+        node.omni_sendissuancefixed(address, 1, 1, 0, "Z_TestCat", "Z_TestSubCat", "Z_IndivisTestProperty", "Z_TestURL", "Z_TestData", "10000000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Creating a divisible test property
+        node.omni_sendissuancefixed(address, 1, 2, 0, "Z_TestCat", "Z_TestSubCat", "Z_DivisTestProperty", "Z_TestURL", "Z_TestData", "10000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Creating a second divisible test property
+        node.omni_sendissuancefixed(address, 1, 2, 0, "Z_TestCat", "Z_TestSubCat", "Z_DivisTestProperty", "Z_TestURL", "Z_TestData", "10000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Creating an indivisible test property in the test ecosystem
+        node.omni_sendissuancefixed(address, 2, 1, 0, "Z_TestCat", "Z_TestSubCat", "Z_IndivisTestProperty", "Z_TestURL", "Z_TestData", "10000000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Creating a divisible test property in the test ecosystem
+        node.omni_sendissuancefixed(address, 2, 2, 0, "Z_TestCat", "Z_TestSubCat", "Z_DivisTestProperty", "Z_TestURL", "Z_TestData", "10000000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Generating addresses to use as fee recipients (OMN holders)
+        addresses = []
+        for _ in range(6):
+            addresses.append(node.getnewaddress())
+
+        # Seeding with 50.00 OMNI
+        txid = node.omni_send(address, addresses[1], 1, "50")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Seeding with 100.00 OMNI
+        txid = node.omni_send(address, addresses[2], 1, "100")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Seeding with 150.00 OMNI
+        txid = node.omni_send(address, addresses[3], 1, "150")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Seeding with 200.00 OMNI
+        txid = node.omni_send(address, addresses[4], 1, "200")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Sending the fee system activation & checking it was valid...
+        activation_block = node.getblockcount() + 8
+        txid = node.omni_sendactivation(address, 9, activation_block, 999)
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Mining 10 blocks to forward past the activation block
+        node.generatetoaddress(10, coinbase_address)
+
+        # Checking the activation went live as expected...
+        featureid = node.omni_getactivations()['completedactivations']
+        found = False
+        for ids in featureid:
+            if ids['featureid'] == 9:
+                found = True
+        assert_equal(found, True)
+
+        # Checking share of fees for recipients...
+        # Checking 5 percent share of fees...
+        feeshare = node.omni_getfeeshare(addresses[1])
+        assert_equal(feeshare[0]['feeshare'], "5.0000%")
+
+        # Checking 10 percent share of fees...
+        feeshare = node.omni_getfeeshare(addresses[2])
+        assert_equal(feeshare[0]['feeshare'], "10.0000%")
+
+        # Checking 15 percent share of fees...
+        feeshare = node.omni_getfeeshare(addresses[3])
+        assert_equal(feeshare[0]['feeshare'], "15.0000%")
+
+        # Checking 20 percent share of fees...
+        feeshare = node.omni_getfeeshare(addresses[4])
+        assert_equal(feeshare[0]['feeshare'], "20.0000%")
+
+        # Checking 50 percent share of fees...
+        feeshare = node.omni_getfeeshare(address)
+        assert_equal(feeshare[0]['feeshare'], "50.0000%")
+
+        # Checking 100 percent share of fees...
+        feeshare = node.omni_getfeeshare(address, 2)
+        assert_equal(feeshare[0]['feeshare'], "100.0000%")
+
+        # Testing a trade against self where the first token is OMNI
+        txida = node.omni_sendtrade(address, 3, "2000", 1, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Testing a trade against self where the first token is OMNI
+        txidb = node.omni_sendtrade(address, 1, "1.0", 3, "2000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Checking the original trade matches to confirm trading fee was 0...
+        result = node.omni_gettrade(txida)
+        assert_equal(result['matches'][0]['tradingfee'], "0.00000000")
+
+        # Checking the new trade matches to confirm trading fee was 0...
+        result = node.omni_gettrade(txidb)
+        assert_equal(result['matches'][0]['tradingfee'], "0")
+
+        # Checking the fee cache is empty for property 1...
+        result = node.omni_getfeecache(1)
+        assert_equal(result[0]['cachedfees'], "0.00000000")
+
+        # Checking the fee cache is empty for property 3...
+        result = node.omni_getfeecache(3)
+        assert_equal(result[0]['cachedfees'], "0")
+
+        # Checking the trading address didn't lose any #1 tokens after trade...
+        result = node.omni_getbalance(address, 1)
+        assert_equal(result['balance'], "500.00000000")
+
+        # Checking the trading address didn't lose any #3 tokens after trade...
+        result = node.omni_getbalance(address, 3)
+        assert_equal(result['balance'], "10000000")
+
+        # Sending the all pair activation & checking it was valid...
+        activation_block = node.getblockcount() + 8
+        txid = node.omni_sendactivation(address, 8, activation_block, 999)
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Mining 10 blocks to forward past the activation block
+        node.generatetoaddress(10, coinbase_address)
+
+        # Checking the activation went live as expected...
+        featureid = node.omni_getactivations()['completedactivations']
+        found = False
+        for ids in featureid:
+            if ids['featureid'] == 8:
+                found = True
+        assert_equal(found, True)
+
+        # Testing a trade against self that results in a 1 willet fee for property 3 (1.0 #5 for 2000 #3)
+        txida = node.omni_sendtrade(address, 3, "2000", 5, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txida)
+        assert_equal(result['valid'], True)
+
+        txidb = node.omni_sendtrade(address, 5, "1.0", 3, "2000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txidb)
+        assert_equal(result['valid'], True)
+
+        # Checking the original trade matches to confirm trading fee was 0...
+        result = node.omni_gettrade(txida)
+        assert_equal(result['matches'][0]['tradingfee'], "0.00000000")
+
+        # Checking the new trade matches to confirm trading fee was 1...
+        result = node.omni_gettrade(txidb)
+        assert_equal(result['matches'][0]['tradingfee'], "1")
+
+        # Checking the fee cache now has 1 fee cached for property 3...
+        result = node.omni_getfeecache(3)
+        assert_equal(result[0]['cachedfees'], "1")
+
+        # Checking the trading address now owns 9999999 of property 3...
+        result = node.omni_getbalance(address, 3)
+        assert_equal(result['balance'], "9999999")
+
+        # Testing another trade against self that results in a 5 willet fee for property 3 (1.0 #5 for 10000 #3)
+        txida = node.omni_sendtrade(address, 3, "10000", 5, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txida)
+        assert_equal(result['valid'], True)
+
+        txidb = node.omni_sendtrade(address, 5, "1.0", 3, "10000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txidb)
+        assert_equal(result['valid'], True)
+
+        # Checking the original trade matches to confirm trading fee was 0...
+        result = node.omni_gettrade(txida)
+        assert_equal(result['matches'][0]['tradingfee'], "0.00000000")
+
+        # Checking the new trade matches to confirm trading fee was 5...
+        result = node.omni_gettrade(txidb)
+        assert_equal(result['matches'][0]['tradingfee'], "5")
+
+        # Checking the fee cache now has 6 fee cached for property 3...
+        result = node.omni_getfeecache(3)
+        assert_equal(result[0]['cachedfees'], "6")
+
+        # Checking the trading address now owns 9999994 of property 3...
+        result = node.omni_getbalance(address, 3)
+        assert_equal(result['balance'], "9999994")
+
+        # Testing a trade against self that results in a 1 willet fee for property 6 (1.0 #5 for 0.00002 #6)
+        txida = node.omni_sendtrade(address, 6, "0.00002000", 5, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txida)
+        assert_equal(result['valid'], True)
+
+        txidb = node.omni_sendtrade(address, 5, "1.0", 6, "0.00002000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txidb)
+        assert_equal(result['valid'], True)
+
+        # Checking the original trade matches to confirm trading fee was 0...
+        result = node.omni_gettrade(txida)
+        assert_equal(result['matches'][0]['tradingfee'], "0.00000000")
+
+        # Checking the new trade matches to confirm trading fee was 0.00000001...
+        result = node.omni_gettrade(txidb)
+        assert_equal(result['matches'][0]['tradingfee'], "0.00000001")
+
+        # Checking the fee cache now has 0.00000001 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.00000001")
+
+        # Checking the trading address now owns 9999.99999999 of property 6...
+        result = node.omni_getbalance(address, 6)
+        assert_equal(result['balance'], "9999.99999999")
+
+        # Testing a trade against self that results in a 5000 willet fee for property 6 (1.0 #5 for 0.1 #6)
+        txida = node.omni_sendtrade(address, 6, "0.1", 5, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txida)
+        assert_equal(result['valid'], True)
+
+        txidb = node.omni_sendtrade(address, 5, "1.0", 6, "0.1")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the original trade matches to confirm trading fee was 0...
+        result = node.omni_gettrade(txida)
+        assert_equal(result['matches'][0]['tradingfee'], "0.00000000")
+
+        # Checking the new trade matches to confirm trading fee was 0.00005000...
+        result = node.omni_gettrade(txidb)
+        assert_equal(result['matches'][0]['tradingfee'], "0.00005000")
+
+        # Checking the fee cache now has 0.00005001 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.00005001")
+
+        # Checking the trading address now owns 9999.99994999 of property 3...
+        result = node.omni_getbalance(address, 6)
+        assert_equal(result['balance'], "9999.99994999")
+
+        # Increasing volume to get close to 10000000 fee trigger point for property 6
+        for x in range(5):
+            result = node.omni_sendtrade(address, 6, "39.96", 5, "1.0")
+            node.generatetoaddress(1, coinbase_address)
+
+            # Checking the transaction was valid...
+            result= node.omni_gettransaction(result)
+            assert_equal(result['valid'], True)
+
+            result = node.omni_sendtrade(address, 5, "1.0", 6, "39.96")
+            node.generatetoaddress(1, coinbase_address)
+
+            # Checking the transaction was valid...
+            result = node.omni_gettransaction(result)
+            assert_equal(result['valid'], True)
+
+        # Checking the fee cache now has 0.09995001 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.09995001")
+
+        # Checking the trading address now owns 9999.90004999 of property 3...
+        result = node.omni_getbalance(address, 6)
+        assert_equal(result['balance'], "9999.90004999")
+
+        # Performing a small trade to take fee cache to 0.1 and trigger distribution for property 6
+        txida = node.omni_sendtrade(address, 6, "0.09999999", 5, "0.8")
+        txidb = node.omni_sendtrade(address, 5, "0.8", 6, "0.09999999")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txida)
+        assert_equal(result['valid'], True)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txidb)
+        assert_equal(result['valid'], True)
+
+        # Checking distribution was triggered and the fee cache is now empty for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.00000000")
+
+        # Checking received 0.00500000 fee share...
+        result = node.omni_getbalance(addresses[1], 6)
+        assert_equal(result['balance'], "0.00500000")
+
+        # Checking received 0.01000000 fee share...
+        result = node.omni_getbalance(addresses[2], 6)
+        assert_equal(result['balance'], "0.01000000")
+
+        # Checking received 0.01500000 fee share...
+        result = node.omni_getbalance(addresses[3], 6)
+        assert_equal(result['balance'], "0.01500000")
+
+        # Checking received 0.02000000 fee share...
+        result = node.omni_getbalance(addresses[4], 6)
+        assert_equal(result['balance'], "0.02000000")
+
+        # Checking received 0.05000000 fee share...
+        result = node.omni_getbalance(address, 6)
+        assert_equal(result['balance'], "9999.95000000")
+
+        # Rolling back the chain to test ability to roll back a distribution during reorg (disconnecting 1 block from tip and mining a replacement)
+        block = node.getblockcount()
+        blockhash = node.getblockhash(block)
+        node.invalidateblock(blockhash)
+        prevblock = node.getblockcount()
+
+        # Clearing the mempool
+        node.clearmempool()
+
+        # Checking the block count has been reduced by 1...
+        expblock = block - 1
+        assert_equal(expblock, prevblock)
+
+        # Mining a replacement block
+        node.generatetoaddress(1, coinbase_address)
+
+        # Verifiying the results
+        newblock = node.getblockcount()
+        newblockhash = node.getblockhash(newblock)
+
+        # Checking the block count is the same as before the rollback...
+        assert_equal(block, newblock)
+
+        # Checking the block hash is different from before the rollback...
+        assert_equal(blockhash == newblockhash, False)
+
+        # Checking the fee cache now again has 0.09995001 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.09995001")
+
+        # Checking balance has been rolled back to 0...
+        result = node.omni_getbalance(addresses[1], 6)
+        assert_equal(result['balance'], "0.00000000")
+
+        # Checking balance has been rolled back to 0...
+        result = node.omni_getbalance(addresses[2], 6)
+        assert_equal(result['balance'], "0.00000000")
+
+        # Checking balance has been rolled back to 0...
+        result = node.omni_getbalance(addresses[3], 6)
+        assert_equal(result['balance'], "0.00000000")
+
+        # Checking balance has been rolled back to 0...
+        result = node.omni_getbalance(addresses[4], 6)
+        assert_equal(result['balance'], "0.00000000")
+
+        # Checking balance has been rolled back to 9999.90004999...
+        result = node.omni_getbalance(address, 6)
+        assert_equal(result['balance'], "9999.90004999")
+
+        # Performing a small trade to take fee cache to 0.1 and retrigger distribution for property 6
+        txida = node.omni_sendtrade(address, 6, "0.09999999", 5, "0.8")
+        txidb = node.omni_sendtrade(address, 5, "0.8", 6, "0.09999999")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txida)
+        assert_equal(result['valid'], True)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(txidb)
+        assert_equal(result['valid'], True)
+
+        # Checking received 0.00500000 fee share...
+        result = node.omni_getbalance(addresses[1], 6)
+        assert_equal(result['balance'], "0.00500000")
+
+        # Checking received 0.01000000 fee share...
+        result = node.omni_getbalance(addresses[2], 6)
+        assert_equal(result['balance'], "0.01000000")
+
+        # Checking received 0.01500000 fee share...
+        result = node.omni_getbalance(addresses[3], 6)
+        assert_equal(result['balance'], "0.01500000")
+
+        # Checking received 0.02000000 fee share...
+        result = node.omni_getbalance(addresses[4], 6)
+        assert_equal(result['balance'], "0.02000000")
+
+        # Checking received 0.05000000 fee share...
+        result = node.omni_getbalance(address, 6)
+        assert_equal(result['balance'], "9999.95000000")
+
+        # Rolling back the chain to test ability to roll back a fee cache change during reorg
+        # Testing a trade against self that results in a 1 willet fee for property 6 (1.0 #6 for 0.00002 #5)
+        result = node.omni_sendtrade(address, 6, "0.00002000", 5, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        result = node.omni_sendtrade(address, 5, "1.0", 6, "0.00002000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        # Checking the fee cache now has 0.00000001 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.00000001")
+
+        # Testing another trade against self that results in a 1 willet fee for property 6 (1.0 #6 for 0.00002 #5)
+        result = node.omni_sendtrade(address, 6, "0.00002000", 5, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        result = node.omni_sendtrade(address, 5, "1.0", 6, "0.00002000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        # Checking the fee cache now has 0.00000002 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.00000002")
+
+        # Rolling back the chain to orphan a block (disconnecting 1 block from tip and mining a replacement)
+        block = node.getblockcount()
+        blockhash = node.getblockhash(block)
+        node.invalidateblock(blockhash)
+        prevblock = node.getblockcount()
+
+        # Clearing the mempool
+        node.clearmempool()
+
+        # Checking the block count has been reduced by 1...
+        expblock = block - 1
+        assert_equal(expblock, prevblock)
+
+        # Mining a replacement block
+        node.generatetoaddress(1, coinbase_address)
+
+        # Verifiying the results
+        newblock = node.getblockcount()
+        newblockhash = node.getblockhash(newblock)
+
+        # Checking the block count is the same as before the rollback...
+        assert_equal(block, newblock)
+
+        # Checking the block hash is different from before the rollback...
+        assert_equal(blockhash == newblockhash, False)
+
+        # Checking the fee cache now again has 0.09995001 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.00000001")
+
+        # Mining 51 blocks to test that fee cache is not affected by fee pruning
+        node.generatetoaddress(51, coinbase_address)
+
+        # Executing a trade to generate 1 willet fee
+        result = node.omni_sendtrade(address, 6, "0.00002000", 5, "1.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        result = node.omni_sendtrade(address, 5, "1.0", 6, "0.00002000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        # Checking the fee cache now has 0.00000002 fee cached for property 6...
+        result = node.omni_getfeecache(6)
+        assert_equal(result[0]['cachedfees'], "0.00000002")
+
+        # Adding some test ecosystem volume to trigger distribution
+        for x in range(9):
+            result = node.omni_sendtrade(address, 2147483651, "20000", 2147483652, "10.0")
+            node.generatetoaddress(1, coinbase_address)
+
+            # Checking the transaction was valid...
+            result = node.omni_gettransaction(result)
+            assert_equal(result['valid'], True)
+
+            result = node.omni_sendtrade(address, 2147483652, "10.0", 2147483651, "20000")
+            node.generatetoaddress(1, coinbase_address)
+
+            # Checking the transaction was valid...
+            result = node.omni_gettransaction(result)
+            assert_equal(result['valid'], True)
+
+        # Checking the fee cache now has 90 fee cached for property 2147483651...
+        result = node.omni_getfeecache(2147483651)
+        assert_equal(result[0]['cachedfees'], "90")
+
+        # Checking the trading address now owns 9999910 of property 2147483651...
+        result = node.omni_getbalance(address, 2147483651)
+        assert_equal(result['balance'], "9999910")
+
+        # Triggering distribution in the test ecosystem for property 2147483651
+        result = node.omni_sendtrade(address, 2147483651, "20000", 2147483652, "10.0")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        result = node.omni_sendtrade(address, 2147483652, "10.0", 2147483651, "20000")
+        node.generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = node.omni_gettransaction(result)
+        assert_equal(result['valid'], True)
+
+        # Checking distribution was triggered and the fee cache is now empty for property 2147483651...
+        result = node.omni_getfeecache(2147483651)
+        assert_equal(result[0]['cachedfees'], "0")
+
+        # Checking received 100 fee share...
+        result = node.omni_getbalance(address, 2147483651)
+        assert_equal(result['balance'], "10000000")
+
+if __name__ == '__main__':
+    OmniFeeCache().main()

--- a/test/functional/omni_freedexspec.py
+++ b/test/functional/omni_freedexspec.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test DEx spec using free DEx."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class OmniFreeDExSpec(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [['-omniactivationallowsender=any']]
+
+    def run_test(self):
+        self.log.info("test dex spec using free dex")
+
+        # Create varaibles that will remain unchanged
+        stdBlockSpan = 10
+        stdCommitFee = "0.00010000"
+        actionNew = 1
+        actionUpdate = 2
+        actionCancel = 3
+
+        # Preparing some mature Bitcoins
+        coinbase_address = self.nodes[0].getnewaddress()
+        self.nodes[0].generatetoaddress(110, coinbase_address)
+
+        # Obtaining a master address to work with
+        address = self.nodes[0].getnewaddress()
+
+        # Funding the address with some testnet BTC for fees
+        self.nodes[0].sendtoaddress(address, 10)
+        self.nodes[0].sendtoaddress(address, 10)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Activating Free DEx...
+        activation_block = self.nodes[0].getblockcount() + 8
+        txid = self.nodes[0].omni_sendactivation(address, 15, activation_block, 0)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Mining 10 blocks to forward past the activation block
+        self.nodes[0].generatetoaddress(10, coinbase_address)
+
+        # Checking the activation went live as expected...
+        featureid = self.nodes[0].omni_getactivations()['completedactivations']
+        freeDEx = False
+        for ids in featureid:
+            if ids['featureid'] == 15:
+                freeDEx = True
+        assert_equal(freeDEx, True)
+
+        # Create a fixed property
+        txid = self.nodes[0].omni_sendissuancefixed(address, 1, 2, 0, "Test Category", "Test Subcategory", "TST", "http://www.omnilayer.org", "This is a test for managed properties", "100000")
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Get currency ID
+        currencyOffered = result['propertyid']
+
+        # A new sell offer can be created with action = 1 (new)
+        activeOffersAtTheStart = self.nodes[0].omni_getactivedexsells()
+        startBTC = 0.1
+        startMSC = "2.5"
+        amountOffered = "1.00000000"
+        desiredBTC = "0.20000000"
+
+        # Created funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, startBTC)
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, startMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # creating an offer with action = 1
+        txid = self.nodes[0].omni_senddexsell(fundedAddress, currencyOffered, amountOffered, desiredBTC, stdBlockSpan, stdCommitFee, actionNew)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Get and check the offer
+        offerTx = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(offerTx['txid'], txid)
+        assert_equal(offerTx['sendingaddress'], fundedAddress)
+        assert_equal(offerTx['version'], 1)
+        assert_equal(offerTx['type_int'], 20)
+        assert_equal(offerTx['type'], "DEx Sell Offer")
+        assert_equal(offerTx['propertyid'], currencyOffered)
+        assert_equal(offerTx['divisible'], True)
+        assert_equal(offerTx['amount'], amountOffered)
+        assert_equal(offerTx['bitcoindesired'], desiredBTC)
+        assert_equal(offerTx['timelimit'], stdBlockSpan)
+        assert_equal(offerTx['feerequired'], stdCommitFee)
+        assert_equal(offerTx['action'], "new")
+        assert_equal(offerTx['valid'], True)
+        assert_equal(offerTx['confirmations'], 1)
+
+        # A new offer is created on the distributed exchange
+        assert_equal(len(self.nodes[0].omni_getactivedexsells()), len(activeOffersAtTheStart) + 1)
+
+        # Offering more tokens than available puts up an offer with the available amount
+
+        # Created new funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, startBTC)
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, startMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Setup variables
+        amountAvailableAtStart = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)['balance']
+        amountOffered = float(amountAvailableAtStart) + 100
+        desiredBTC = "50.00000000"
+
+        # the amount offered for sale exceeds the sending address's available balance
+        payload = self.nodes[0].omni_createpayload_dexsell(currencyOffered, str(amountOffered), desiredBTC, stdBlockSpan, stdCommitFee, actionNew)
+        offerTxid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        offerTx = self.nodes[0].omni_gettransaction(offerTxid)
+        offerAmount = offerTx['amount']
+        amountAvailableNow = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)['balance']
+        assert_equal(offerTx['valid'], True)
+        assert_equal(offerAmount, amountAvailableAtStart)
+        if float(amountOffered) < float(amountAvailableAtStart):
+            minAmount = amountOffered
+        else:
+            minAmount = amountAvailableAtStart
+        assert_equal(offerAmount, minAmount)
+        assert_equal(amountAvailableNow, "0.00000000")
+
+        # The amount offered for sale is reserved from the available balance
+
+        # Setup varaibles
+        startBTC = 0.1
+        startMSC = "100"
+        amountOffered = "90.00000000"
+        desiredBTC = "45.00000000"
+
+        # Created new funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, startBTC)
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, startMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Get balance to compare later
+        balanceAtStart = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+
+        # an amount is offered for sale
+        txid = self.nodes[0].omni_senddexsell(fundedAddress, currencyOffered, amountOffered, desiredBTC, stdBlockSpan, stdCommitFee, actionNew)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Get and check the offer
+        offerTx = self.nodes[0].omni_gettransaction(txid)
+        offerAmount = offerTx['amount']
+        balanceNow = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+
+        assert_equal(float(balanceNow['balance']), float(balanceAtStart['balance']) - float(offerAmount))
+        assert_equal(float(balanceNow['reserved']), float(balanceAtStart['reserved']) + float(offerAmount))
+
+        # Receiving tokens doesn't increase the offered amount of a published offer
+
+        # Setup varaibles
+        startBTC = 0.1
+        startMSC = "2.5"
+        offerMSC = "90.00000000"
+        desiredBTC = "45.00000000"
+        startOtherMSC = "10"
+        additionalMSC = "10"
+
+        # Created new funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, startBTC)
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, startMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # the sell offer is published
+        payload = self.nodes[0].omni_createpayload_dexsell(currencyOffered, offerMSC, desiredBTC, stdBlockSpan, stdCommitFee, actionNew)
+        offerTxid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        offerBeforeReceivingMore = self.nodes[0].omni_gettransaction(offerTxid)
+        assert_equal(offerBeforeReceivingMore['valid'], True)
+
+        # Store balance now before receiving more
+        balanceBeforeReceivingMore = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+
+        # Created new funded other address for test
+        otherAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(otherAddress, startBTC)
+        txid = self.nodes[0].omni_send(address, otherAddress, currencyOffered, startOtherMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # additional tokens are received
+        sendTxid = self.nodes[0].omni_send(otherAddress, fundedAddress, currencyOffered, additionalMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        sendTx = self.nodes[0].omni_gettransaction(sendTxid)
+        assert_equal(sendTx['valid'], True)
+
+        # any tokens received are added to the available balance
+        balanceNow = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+        sendAmount = sendTx['amount']
+        assert_equal(float(balanceNow['balance']), float(balanceBeforeReceivingMore['balance']) + float(sendAmount))
+
+        # are not included in the amount for sale by this sell offer
+        offerNow = self.nodes[0].omni_gettransaction(offerTxid)
+        assert_equal(offerNow['valid'], True)
+        assert_equal(offerNow['amount'], offerBeforeReceivingMore['amount'])
+        assert_equal(balanceNow['reserved'], balanceBeforeReceivingMore['reserved'])
+
+        # There can be only one active offer that accepts BTC
+
+        # Setup varaibles
+        startBTC = 0.1
+        startMSC = "2.5"
+        firstOfferMSC = "1"
+        firstOfferBTC = "0.2"
+        secondOfferMSC = "1.5"
+        secondOfferBTC = "0.3"
+
+        # Created new funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, startBTC)
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, startMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # there is already an active offer accepting BTC
+        txid = self.nodes[0].omni_senddexsell(fundedAddress, currencyOffered, firstOfferMSC, firstOfferBTC, stdBlockSpan, stdCommitFee, actionNew)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # and another offer accepting BTC is made
+        payload = self.nodes[0].omni_createpayload_dexsell(currencyOffered, secondOfferMSC, secondOfferBTC, stdBlockSpan, stdCommitFee, actionNew)
+        txid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], False)
+
+        # An offer can be updated with action = 2 (update), and cancelled with action = 3 (cancel)
+
+        # Setup varaibles
+        startBTC = 0.1
+        startMSC = "1.0"
+        offeredMSC = "0.50000000"
+        desiredBTC = "0.5"
+        updatedMSC = "1.00000000"
+        updatedBTC = "2.0"
+
+        # Created new funded address for test
+        fundedAddress = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(fundedAddress, startBTC)
+        txid = self.nodes[0].omni_send(address, fundedAddress, currencyOffered, startMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # Get balance to compare later
+        balanceAtStart = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+
+        # Get offers
+        offersAtStart = self.nodes[0].omni_getactivedexsells()
+
+        # creating an offer with action 1
+        txid = self.nodes[0].omni_senddexsell(fundedAddress, currencyOffered, offeredMSC, desiredBTC, stdBlockSpan, stdCommitFee, actionNew)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        balanceNow = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+        assert_equal(result['valid'], True)
+        assert_equal(result['amount'], offeredMSC)
+        assert_equal(float(balanceNow['balance']), float(balanceAtStart['balance']) - float(offeredMSC))
+        assert_equal(float(balanceNow['reserved']), float(balanceAtStart['reserved']) + float(offeredMSC))
+        assert_equal(len(self.nodes[0].omni_getactivedexsells()), len(offersAtStart) + 1)
+
+        # updating an offer with action = 2
+        payload = self.nodes[0].omni_createpayload_dexsell(currencyOffered, updatedMSC, updatedBTC, stdBlockSpan, stdCommitFee, actionUpdate)
+        txid = self.nodes[0].omni_sendrawtx(fundedAddress, payload)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        balanceNow = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+        assert_equal(result['valid'], True)
+        assert_equal(result['action'], "update")
+        assert_equal(result['amount'], updatedMSC)
+        assert_equal(float(balanceNow['balance']), float(balanceAtStart['balance']) - float(updatedMSC))
+        assert_equal(float(balanceNow['reserved']), float(balanceAtStart['reserved']) + float(updatedMSC))
+
+        # cancelling an offer with action = 3
+        txid = self.nodes[0].omni_senddexsell(fundedAddress, currencyOffered, "0", "0", 0, "0", actionCancel)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        balanceNow = self.nodes[0].omni_getbalance(fundedAddress, currencyOffered)
+        assert_equal(result['valid'], True)
+        assert_equal(result['action'], "cancel")
+        assert_equal(balanceNow['balance'], balanceAtStart['balance'])
+        assert_equal(balanceNow['reserved'], balanceAtStart['reserved'])
+        assert_equal(len(self.nodes[0].omni_getactivedexsells()), len(offersAtStart))
+
+        # An offer can be accepted with an accept transaction of type 22
+
+        # Setup varaibles
+        startBTC = 0.1
+        startMSC = "0.1"
+        offeredMSC = "0.05000000"
+        desiredBTC = "0.07"
+
+        # Created new funded address for test
+        actorA = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(actorA, startBTC)
+        txid = self.nodes[0].omni_send(address, actorA, currencyOffered, startMSC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        # A offers MSC
+        txid = self.nodes[0].omni_senddexsell(actorA, currencyOffered, offeredMSC, desiredBTC, stdBlockSpan, stdCommitFee, actionNew)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+
+        actorB = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(actorB, startBTC)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # B accepts the offer
+        txid = self.nodes[0].omni_senddexaccept(actorB, actorA, currencyOffered, offeredMSC, False)
+        self.nodes[0].generatetoaddress(1, coinbase_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+        assert_equal(result['txid'], txid)
+        assert_equal(result['sendingaddress'], actorB)
+        assert_equal(result['referenceaddress'], actorA)
+        assert_equal(result['version'], 0)
+        assert_equal(result['type_int'], 22)
+        assert_equal(result['type'], "DEx Accept Offer")
+        assert_equal(result['propertyid'], currencyOffered)
+        assert_equal(result['divisible'], True)
+        assert_equal(result['amount'], offeredMSC)
+        assert_equal(result['confirmations'], 1)
+
+if __name__ == '__main__':
+    OmniFreeDExSpec().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -232,6 +232,7 @@ BASE_SCRIPTS = [
     'omni_deactivation.py',
     'omni_freeze.py',
     'omni_freedexspec.py',
+    'omni_dexversionsspec.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -231,6 +231,7 @@ BASE_SCRIPTS = [
     'omni_stov1.py',
     'omni_deactivation.py',
     'omni_freeze.py',
+    'omni_freedexspec.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -233,6 +233,7 @@ BASE_SCRIPTS = [
     'omni_freeze.py',
     'omni_freedexspec.py',
     'omni_dexversionsspec.py',
+    'omni_feecache.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -23,7 +23,7 @@ CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWallet
 CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb'])
+SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-disabledevmsc'])
 
 
 def lint_missing_argument_documentation():


### PR DESCRIPTION
Adds a Python functional test to check the DEx specification using the Free DEx feature which allows trading of properties other than OMNI and TOMNI.

Minor fix for the omni_clientexpiry.py test as sometimes a JSONRPCException is thrown before an AssertionError.

Adding test for the fee cache feature. Dev MSC needs to be disabled for the tests, this is done with the new option -disabledevmsc that can only be used on regtest.

UpdateDistributionThresholds needs to be called regardless of whether FEATURE_FEES is active, only EvalCache can be skipped. Otherwise distribution thresholds will be set to 0 for all tokens created, granted or revoked before FEATURE_FEES is active and those pre-activation tokens will not have their thresholds updated unless something changes their total supply.