### PR TITLE
If watermark not in block index load from state files

### DIFF
--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -25,9 +25,9 @@ class Coin;
 #include <set>
 #include <unordered_map>
 
-// Keep the state of the last 50 blocks to roll back quickly
+// Keep the state of the last 200 blocks to roll back quickly
 // in case of a block reorganization
-int const MAX_STATE_HISTORY = 50;
+int const MAX_STATE_HISTORY = 200;
 // Also store the state every 5000 blocks to be able to recover
 // from a crash or shutdown during reparse more quickly
 int const STORE_EVERY_N_BLOCK = 5000;

--- a/src/omnicore/persistence.cpp
+++ b/src/omnicore/persistence.cpp
@@ -688,25 +688,67 @@ int LoadMostRelevantInMemoryState()
 
     }
 
+    // Try and get watermark block
     CBlockIndex const *spBlockIndex = GetBlockIndex(spWatermark);
-    if (nullptr == spBlockIndex) {
-        // trigger a full reparse, if the watermark isn't a real block
-        PrintToLog("Failed to load historical state: watermark isn't a real block\n");
-        return -1;
+
+    // Watermark block not found.
+    if (nullptr == spBlockIndex)
+    {
+        PrintToLog("spWatermark not found: %s\n", spWatermark.ToString());
+
+        // Try and load an historical state
+        fs::directory_iterator dIter(pathStateFiles);
+        fs::directory_iterator endIter;
+        std::map<int, const CBlockIndex*> foundBlocks;
+
+        for (; dIter != endIter; ++dIter) {
+            if (false == fs::is_regular_file(dIter->status()) || dIter->path().empty()) {
+                // skip funny business
+                continue;
+            }
+
+            std::string fName = (*--dIter->path().end()).string();
+            std::vector<std::string> vstr;
+            boost::split(vstr, fName, boost::is_any_of("-."), boost::token_compress_on);
+            if (vstr.size() == 3 && boost::equals(vstr[2], "dat")) {
+                uint256 blockHash;
+                blockHash.SetHex(vstr[1]);
+                CBlockIndex *pBlockIndex = GetBlockIndex(blockHash);
+                if (pBlockIndex == nullptr) {
+                    continue;
+                }
+
+                // Add to found blocks
+                foundBlocks.emplace(pBlockIndex->nHeight, pBlockIndex);
+            }
+        }
+
+        // Was unable to find valid previous state, full reparse required.
+        if (foundBlocks.empty()) {
+            PrintToLog("Failed to load historical state: watermark isn't a real block\n");
+            return -1;
+        }
+
+        spBlockIndex = foundBlocks.rbegin()->second;
+        pDbSpInfo->setWatermark(spBlockIndex->GetBlockHash());
+
+        PrintToLog("Watermark not found. New one set from state files: %s\n", spBlockIndex->GetBlockHash().ToString());
     }
 
     std::set<uint256> persistedBlocks;
     {
         LOCK2(cs_main, cs_tally);
+
+        PrintToLog("Rolling back blocks to active chain.\n");
+
         while (nullptr != spBlockIndex && false == chainActive.Contains(spBlockIndex)) {
             int remainingSPs = pDbSpInfo->popBlock(spBlockIndex->GetBlockHash());
             if (remainingSPs < 0) {
                 // trigger a full reparse, if the levelDB cannot roll back
                 PrintToLog("Failed to load historical state: no valid state found after rolling back SP database\n");
                 return -1;
-            } /*else if (remainingSPs == 0) {
-          // potential optimization here?
-        }*/
+            }
+
             spBlockIndex = spBlockIndex->pprev;
             if (spBlockIndex != nullptr) {
                 pDbSpInfo->setWatermark(spBlockIndex->GetBlockHash());


### PR DESCRIPTION
When starting after a unexpected shutdown the stored watermark may not be found in the block index, this causes full reparse which can take a long time. Instead of performing a full reparse the local state files should be checked first for any that relate to blocks in the block index and if any are found then the one highest in the chain is chosen. State files are increased to 200 blocks to go back a further period to enable this recovery.