### PR TITLE
Trim Gitian build targets

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -40,7 +40,7 @@ script: |
   set -e -o pipefail
 
   WRAP_DIR=$HOME/wrapped
-  HOSTS="x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu"
+  HOSTS="x86_64-linux-gnu arm-linux-gnueabihf"
   CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"

--- a/src/omnicore/doc/release-notes.md
+++ b/src/omnicore/doc/release-notes.md
@@ -113,6 +113,7 @@ The following list includes relevant pull requests merged into this release:
 - #1213 If watermark not in block index load from state files
 - #1214 Bump version and tests to 0.10
 - #1215 Add release notes for Omni Core 0.10
+- #1219 Trim Gitian build targets
 ```
 
 


### PR DESCRIPTION
Only build x86_64-linux-gnu arm-linux-gnueabihf when building Gitian binaries.