### PR TITLE
Show Omni version in Qt and CLI

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -22,7 +22,9 @@
 #include <util/translation.h>
 
 #include <functional>
+
 #include <omnicore/utilsui.h>
+#include <omnicore/version.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
@@ -60,7 +62,7 @@ static bool AppInit(int argc, char* argv[])
 
     // Process help and version before taking care about datadir
     if (HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
-        std::string strUsage = PACKAGE_NAME " version " + FormatFullVersion() + "\n";
+        std::string strUsage = PACKAGE_NAME " version " + OmniCoreVersion() + "\n";
 
         if (gArgs.IsArgSet("-version"))
         {

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -15,6 +15,8 @@
 #include <util/system.h>
 #include <util/strencodings.h>
 
+#include <omnicore/version.h>
+
 #include <stdio.h>
 
 #include <QCloseEvent>
@@ -32,7 +34,7 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
 {
     ui->setupUi(this);
 
-    QString version = QString{PACKAGE_NAME} + " " + tr("version") + " " + QString::fromStdString(FormatFullVersion());
+    QString version = QString{PACKAGE_NAME} + " " + tr("version") + " " + QString::fromStdString(OmniCoreVersion());
 
     if (about)
     {


### PR DESCRIPTION
Show the Omnicore version in the GUI about page and CLI --version output instead of the underlying Bitcoin codebase version.