### PR TITLE
Query address for all NFTs without specifying property ID

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -1967,22 +1967,29 @@ $ omnicore-cli "omni_getcurrentconsensushash"
 
 ### omni_getnonfungibletokens
 
-Returns the non-fungible tokens for a given address and property.
+Returns the non-fungible tokens for a given address. Optional property ID filter.
 
 **Arguments:**
 
 | Name                | Type    | Presence | Description                                                                                  |
 |---------------------|---------|----------|----------------------------------------------------------------------------------------------|
 | `address`           | string  | required | the address                                                                                  |
-| `propertyid`        | number  | required | the property identifier                                                                      |
+| `propertyid`        | number  | optional | the property identifier                                                                      |
 
 **Result:**
 ```js
-{
-  "tokenstart" : n,            // (number) the first token in this range
-  "tokenend" : n,              // (number) the last token in this range
-  "amount" : n.nnnnnnnn,       // (number) the amount of tokens in the range
-}
+[
+  {
+    "propertyid" : n,
+    "tokens" : [
+      {
+        "tokenstart" : n,            // (number) the first token in this range
+        "tokenend" : n,              // (number) the last token in this range
+        "amount" : n,                // (number) the amount of tokens in the range
+      }...
+    ]
+  }...
+]
 ```
 
 **Example:**

--- a/src/omnicore/nftdb.h
+++ b/src/omnicore/nftdb.h
@@ -66,7 +66,7 @@ public:
     // Adds a range of non-fungible tokens
     void AddRange(const uint32_t &propertyId, const int64_t &tokenIdStart, const int64_t &tokenIdEnd, const std::string &owner, const NonFungibleStorage type);
     // Gets the non-fungible token ranges for a property ID and address
-    std::vector<std::pair<int64_t,int64_t> > GetAddressNonFungibleTokens(const uint32_t &propertyId, const std::string &address);
+    std::map<uint32_t, std::vector<std::pair<int64_t, int64_t>>> GetAddressNonFungibleTokens(const uint32_t &propertyId, const std::string &address);
     // Gets the non-fungible token ranges for a property ID
     std::vector<std::pair<std::string,std::pair<int64_t,int64_t> > > GetNonFungibleTokenRanges(const uint32_t &propertyId);
     // Sanity checks the token counts

--- a/test/functional/omni_nonfungibletokens.py
+++ b/test/functional/omni_nonfungibletokens.py
@@ -68,9 +68,10 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
         assert_equal(result['grantdata'], "")
 
         result = self.nodes[0].omni_getnonfungibletokens(token_address, property_id)
-        assert_equal(result[0]['tokenstart'], 1)
-        assert_equal(result[0]['tokenend'], 100)
-        assert_equal(result[0]['amount'], 100)
+        assert_equal(result[0]['propertyid'], property_id)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 1)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 100)
+        assert_equal(result[0]['tokens'][0]['amount'], 100)
 
         result = self.nodes[0].omni_getnonfungibletokenranges(property_id)
         assert_equal(result[0]['address'], token_address)
@@ -97,9 +98,9 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
         assert_equal(result['grantdata'], "Test grantdata")
 
         result = self.nodes[0].omni_getnonfungibletokens(token_address, property_id)
-        assert_equal(result[0]['tokenstart'], 1)
-        assert_equal(result[0]['tokenend'], 101)
-        assert_equal(result[0]['amount'], 101)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 1)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 101)
+        assert_equal(result[0]['tokens'][0]['amount'], 101)
 
         result = self.nodes[0].omni_getnonfungibletokenranges(property_id)
         assert_equal(result[0]['address'], token_address)
@@ -129,9 +130,9 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
         assert_equal(result['grantdata'], "Different grantdata")
 
         result = self.nodes[0].omni_getnonfungibletokens(token_address, property_id)
-        assert_equal(result[0]['tokenstart'], 1)
-        assert_equal(result[0]['tokenend'], 200)
-        assert_equal(result[0]['amount'], 200)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 1)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 200)
+        assert_equal(result[0]['tokens'][0]['amount'], 200)
 
         result = self.nodes[0].omni_getnonfungibletokenranges(property_id)
         assert_equal(result[0]['address'], token_address)
@@ -172,15 +173,15 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
 
         # No change here
         result = self.nodes[0].omni_getnonfungibletokens(token_address, property_id)
-        assert_equal(result[0]['tokenstart'], 1)
-        assert_equal(result[0]['tokenend'], 200)
-        assert_equal(result[0]['amount'], 200)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 1)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 200)
+        assert_equal(result[0]['tokens'][0]['amount'], 200)
 
         # New tokens appear on this address
         result = self.nodes[0].omni_getnonfungibletokens(grant_address, property_id)
-        assert_equal(result[0]['tokenstart'], 201)
-        assert_equal(result[0]['tokenend'], 300)
-        assert_equal(result[0]['amount'], 100)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 201)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 300)
+        assert_equal(result[0]['tokens'][0]['amount'], 100)
 
         # Two addresses now show for holding this token
         result = self.nodes[0].omni_getnonfungibletokenranges(property_id)
@@ -225,30 +226,30 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
 
         # Check range has changed with gap in the middle
         result = self.nodes[0].omni_getnonfungibletokens(token_address, property_id)
-        assert_equal(result[0]['tokenstart'], 11)
-        assert_equal(result[0]['tokenend'], 100)
-        assert_equal(result[0]['amount'], 90)
-        assert_equal(result[1]['tokenstart'], 102)
-        assert_equal(result[1]['tokenend'], 200)
-        assert_equal(result[1]['amount'], 99)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 11)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 100)
+        assert_equal(result[0]['tokens'][0]['amount'], 90)
+        assert_equal(result[0]['tokens'][1]['tokenstart'], 102)
+        assert_equal(result[0]['tokens'][1]['tokenend'], 200)
+        assert_equal(result[0]['tokens'][1]['amount'], 99)
 
         # Check range has changed
         result = self.nodes[0].omni_getnonfungibletokens(grant_address, property_id)
-        assert_equal(result[0]['tokenstart'], 211)
-        assert_equal(result[0]['tokenend'], 300)
-        assert_equal(result[0]['amount'], 90)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 211)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 300)
+        assert_equal(result[0]['tokens'][0]['amount'], 90)
 
         # New tokens should be present in dest address
         result = self.nodes[0].omni_getnonfungibletokens(destination_address, property_id)
-        assert_equal(result[0]['tokenstart'], 1)
-        assert_equal(result[0]['tokenend'], 10)
-        assert_equal(result[0]['amount'], 10)
-        assert_equal(result[1]['tokenstart'], 101)
-        assert_equal(result[1]['tokenend'], 101)
-        assert_equal(result[1]['amount'], 1)
-        assert_equal(result[2]['tokenstart'], 201)
-        assert_equal(result[2]['tokenend'], 210)
-        assert_equal(result[2]['amount'], 10)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 1)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 10)
+        assert_equal(result[0]['tokens'][0]['amount'], 10)
+        assert_equal(result[0]['tokens'][1]['tokenstart'], 101)
+        assert_equal(result[0]['tokens'][1]['tokenend'], 101)
+        assert_equal(result[0]['tokens'][1]['amount'], 1)
+        assert_equal(result[0]['tokens'][2]['tokenstart'], 201)
+        assert_equal(result[0]['tokens'][2]['tokenend'], 210)
+        assert_equal(result[0]['tokens'][2]['amount'], 10)
 
         # Three addresses now show for holding this token
         result = self.nodes[0].omni_getnonfungibletokenranges(property_id)
@@ -601,6 +602,53 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
         assert_equal(result[99]['grantdata'], 'Different grantdata')
         assert_equal(result[99]['issuerdata'], '')
         assert_equal(result[99]['holderdata'], '')
+
+        # Test omni_getnonfungibletokendata with multiple tokens on an address
+        txid = self.nodes[0].omni_sendissuancemanaged(token_address, 2, 5, 0, "", "", "TESTTOKEN2", "", "")
+        self.nodes[0].generatetoaddress(1, token_address)
+
+        # Checking the transaction was valid...
+        result = self.nodes[0].omni_gettransaction(txid)
+        assert_equal(result['valid'], True)
+        second_property_id = result["propertyid"]
+
+        # Grant tokens to creator
+        txid = self.nodes[0].omni_sendgrant(token_address, "", second_property_id, "100", "")
+        self.nodes[0].generatetoaddress(1, token_address)
+
+        # Check multiple properties returned
+        result = self.nodes[0].omni_getnonfungibletokens(token_address)
+        assert_equal(len(result), 2)
+        assert_equal(result[0]['propertyid'], property_id)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 11)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 100)
+        assert_equal(result[0]['tokens'][0]['amount'], 90)
+        assert_equal(result[0]['tokens'][1]['tokenstart'], 112)
+        assert_equal(result[0]['tokens'][1]['tokenend'], 200)
+        assert_equal(result[0]['tokens'][1]['amount'], 89)
+        assert_equal(result[1]['propertyid'], second_property_id)
+        assert_equal(result[1]['tokens'][0]['tokenstart'], 1)
+        assert_equal(result[1]['tokens'][0]['tokenend'], 100)
+        assert_equal(result[1]['tokens'][0]['amount'], 100)
+
+        # Filter on first property ID
+        result = self.nodes[0].omni_getnonfungibletokens(token_address, property_id)
+        assert_equal(len(result), 1)
+        assert_equal(result[0]['propertyid'], property_id)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 11)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 100)
+        assert_equal(result[0]['tokens'][0]['amount'], 90)
+        assert_equal(result[0]['tokens'][1]['tokenstart'], 112)
+        assert_equal(result[0]['tokens'][1]['tokenend'], 200)
+        assert_equal(result[0]['tokens'][1]['amount'], 89)
+
+        # Filter on second property ID
+        result = self.nodes[0].omni_getnonfungibletokens(token_address, second_property_id)
+        assert_equal(len(result), 1)
+        assert_equal(result[0]['propertyid'], second_property_id)
+        assert_equal(result[0]['tokens'][0]['tokenstart'], 1)
+        assert_equal(result[0]['tokens'][0]['tokenend'], 100)
+        assert_equal(result[0]['tokens'][0]['amount'], 100)
 
 if __name__ == '__main__':
     OmniNonFungibleTokensTest().main()


### PR DESCRIPTION
This PR allows omni_getnonfungibletokens to be called without specifying a property ID returning all NFTs for an address across all properties. A property ID can be provided to filter for just that property.