### PR TITLE
Gitian Linux confi8g: replace arm 32-bit with arm64 (aarch64)

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -40,7 +40,7 @@ script: |
   set -e -o pipefail
 
   WRAP_DIR=$HOME/wrapped
-  HOSTS="x86_64-linux-gnu arm-linux-gnueabihf"
+  HOSTS="x86_64-linux-gnu aarch64-linux-gnu"
   CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"


### PR DESCRIPTION
See Issue #1230 

My recommendation is that we only support 64-bit ARM, so this PR replaces 32-bit with 64-bit. I suppose we could do both, but unless there is someone who is really going to use (and test!) the 32-bit version, we should probably not release it.

