### PR TITLE
Fix edge case, where no fee is selected

### DIFF
--- a/src/omnicore/wallettxbuilder.cpp
+++ b/src/omnicore/wallettxbuilder.cpp
@@ -105,6 +105,10 @@ int WalletTxBuilder(
     CAmount nFeeRet{0};
     bool createTX{true};
 
+    if (outputAmount + nFeeRequired == 0) {
+        outputAmount = 1;
+    }
+
     while (createTX) {
         // Select the inputs
         auto selected = mastercore::SelectCoins(*iWallet, senderAddress, coinControl, outputAmount + nFeeRequired);

--- a/src/omnicore/walletutils.cpp
+++ b/src/omnicore/walletutils.cpp
@@ -223,8 +223,9 @@ int64_t SelectCoins(interfaces::Wallet& iWallet, const std::string& fromAddress,
 
         if (status->second.depth_in_main_chain == 0) {
             LOCK(mempool.cs);
-            if (!mempool.exists(txid))
+            if (!mempool.exists(txid)) {
                 continue;
+            }
         }
 
         if (!it->available_credit) {
@@ -255,8 +256,6 @@ int64_t SelectCoins(interfaces::Wallet& iWallet, const std::string& fromAddress,
             }
 
             std::string sAddress = EncodeDestination(dest);
-            if (msc_debug_tokens)
-                PrintToLog("%s: sender: %s, outpoint: %s:%d, value: %d\n", __func__, sAddress, txid.GetHex(), n, txOut.nValue);
 
             // only use funds from the sender's address
             if (fromAddress == sAddress) {
@@ -265,11 +264,19 @@ int64_t SelectCoins(interfaces::Wallet& iWallet, const std::string& fromAddress,
 
                 nTotal += txOut.nValue;
 
-                if (amountRequired <= nTotal) break;
+                if (msc_debug_tokens) {
+                    PrintToLog("%s: selecting sender: %s, outpoint: %s:%d, value: %d\n", __func__, sAddress, txid.GetHex(), n, txOut.nValue);
+                }
+
+                if (amountRequired <= nTotal) {
+                    break;
+                }
             }
         }
 
-        if (amountRequired <= nTotal) break;
+        if (amountRequired <= nTotal) {
+            break;
+        }
     }
 
     return nTotal;


### PR DESCRIPTION
In some edge cases when testing in regtest mode, no fee is selected, which results in failing transaction creation.

This pull request fixes this and shouldn't have an impact on mainnet.