### PR TITLE
Remove previous releases build from Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,13 +83,6 @@ task:
   env:
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
 
-task:
-  name: '[previous releases, uses qt5 dev package and some depends packages] [unsigned char] [bionic]'
-  << : *GLOBAL_TASK_TEMPLATE
-  container:
-    image: ubuntu:bionic
-  env:
-    FILE_ENV: "./ci/test/00_setup_env_native_qt5.sh"
 
 task:
   name: '[no depends, only system libx, sanitizers: thread (TSan), no wallet] [xenial]'
@@ -125,4 +118,3 @@ task:
     image: ubuntu:bionic
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_omnij.sh"
-

--- a/ci/test/00_setup_env_native_omnij.sh
+++ b/ci/test/00_setup_env_native_omnij.sh
@@ -15,5 +15,5 @@ export RUN_UNIT_TESTS="false"
 export RUN_OMNIJ_TESTS="true"
 export RUN_FUNCTIONAL_TESTS="true"
 export GOAL="install"
-export TEST_PREVIOUS_RELEASES=true
+# export TEST_PREVIOUS_RELEASES=true
 export BITCOIN_CONFIG="--with-gui=no"


### PR DESCRIPTION
This pull request removes previous releases build from Cirrus CI, which caused sometimes build failures. Also, CI should be faster now.