### PR TITLE
Fix non issuer data and other RPC bugs

### DIFF
--- a/src/omnicore/errors.h
+++ b/src/omnicore/errors.h
@@ -339,6 +339,46 @@ inline std::string error_str(int ec) {
           ec_str = "Address is already frozen";
           break;
 
+      case PKT_ERROR_NFT -20:
+          ec_str = "Non-fungible tokens are not yet activated";
+          break;
+      case PKT_ERROR_NFT -21:
+          ec_str = "Property %d is of type non-fungible";
+          break;
+      case PKT_ERROR_NFT -23:
+          ec_str = "Type or version not permitted for property";
+          break;
+      case PKT_ERROR_NFT -24:
+          ec_str = "Property is not of type non-fungible";
+          break;
+      case PKT_ERROR_NFT -25:
+          ec_str = "Non-fungible token range start value out of range or zero";
+          break;
+      case PKT_ERROR_NFT -26:
+          ec_str = "Non-fungible token range end value out of range or zero";
+          break;
+      case PKT_ERROR_NFT -27:
+          ec_str = "Non-fungible token range start value is less than or equal to range end value";
+          break;
+      case PKT_ERROR_NFT -28:
+          ec_str = "Non-fungible token range amount out of range or zero";
+          break;
+      case PKT_ERROR_NFT -29:
+          ec_str = "Property does not exist";
+          break;
+      case PKT_ERROR_NFT -30:
+          ec_str = "Sender does not own the range data is being set on";
+          break;
+      case PKT_ERROR_NFT -31:
+          ec_str = "Sender is not the issuer of property";
+          break;
+      case PKT_ERROR_NFT -32:
+          ec_str = "Sender has insufficient balance of property";
+          break;
+      case PKT_ERROR_NFT -33:
+          ec_str = "Sender %s does not own the range being sent";
+          break;
+
       default:
           ec_str = "Unknown error";
   }

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -118,6 +118,7 @@ enum TransactionType {
 #define PKT_ERROR_TOKENS      (-82000)
 #define PKT_ERROR_SEND_ALL    (-83000)
 #define PKT_ERROR_ANYDATA     (-84000)
+#define PKT_ERROR_NFT         (-85000)
 
 #define OMNI_PROPERTY_BTC   0
 #define OMNI_PROPERTY_MSC   1

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -769,7 +769,7 @@ static const CRPCCommand commands[] =
     { "omni layer (payload creation)", "omni_createpayload_removedelegate",      &omni_createpayload_removedelegate,      {"propertyid"} },
     { "omni layer (payload creation)", "omni_createpayload_anydata",             &omni_createpayload_anydata,             {"data"} },
     { "omni layer (payload creation)", "omni_createpayload_sendnonfungible",     &omni_createpayload_sendnonfungible,     {"propertyid", "tokenstart", "tokenend"} },
-    { "omni layer (payload creation)", "omni_createpayload_setnonfungibledata",  &omni_createpayload_setnonfungibledata,  {"propertyid", "tokenid", "issuer", "data"} },
+    { "omni layer (payload creation)", "omni_createpayload_setnonfungibledata",  &omni_createpayload_setnonfungibledata,  {"propertyid", "tokenstart", "tokenend", "issuer", "data"} },
 };
 
 void RegisterOmniPayloadCreationRPCCommands(CRPCTable &tableRPC)

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -584,7 +584,8 @@ void populateRPCTypeSetNonFungibleData(CMPTransaction& omniObj, UniValue& txobj)
 {
     uint32_t propertyId = omniObj.getProperty();
     txobj.pushKV("propertyid", (uint64_t)propertyId);
-    txobj.pushKV("tokenid", omniObj.getNonFungibleTokenStart());
+    txobj.pushKV("tokenstart", omniObj.getNonFungibleTokenStart());
+    txobj.pushKV("tokenend", omniObj.getNonFungibleTokenEnd());
     txobj.pushKV("issuer", omniObj.getNonFungibleDataType() == 1 ? "true" : "false");
     txobj.pushKV("data", omniObj.getNonFungibleData());
 }

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -263,6 +263,7 @@ CMainConsensusParams::CMainConsensusParams()
     FEES_FEATURE_BLOCK = 999999;
     FREEZENOTICE_FEATURE_BLOCK = 999999;
     FREEDEX_FEATURE_BLOCK = 999999;
+    NONFUNGIBLETOKEN_ISSUER_DATA = 999999;
 }
 
 /**
@@ -308,6 +309,7 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     FEES_FEATURE_BLOCK = 0;
     FREEZENOTICE_FEATURE_BLOCK = 0;
     FREEDEX_FEATURE_BLOCK = 0;
+    NONFUNGIBLETOKEN_ISSUER_DATA = 0;
 }
 
 /**
@@ -353,6 +355,7 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     FEES_FEATURE_BLOCK = 999999;
     FREEZENOTICE_FEATURE_BLOCK = 999999;
     FREEDEX_FEATURE_BLOCK = 999999;
+    NONFUNGIBLETOKEN_ISSUER_DATA = 999999;
 }
 
 //! Consensus parameters for mainnet
@@ -524,6 +527,9 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
         case FEATURE_NONFUNGIBLE:
             MutableConsensusParams().MSC_NONFUNGIBLE_BLOCK = activationBlock;
         break;
+        case FEATURE_NONFUNGIBLE_ISSUER:
+            MutableConsensusParams().NONFUNGIBLETOKEN_ISSUER_DATA = activationBlock;
+        break;
         case FEATURE_DELEGATEDISSUANCE:
             MutableConsensusParams().MSC_DELEGATED_ISSUANCE_BLOCK = activationBlock;
         break;
@@ -604,6 +610,9 @@ bool DeactivateFeature(uint16_t featureId, int transactionBlock)
         case FEATURE_NONFUNGIBLE:
             MutableConsensusParams().MSC_NONFUNGIBLE_BLOCK = 999999;
         break;
+        case FEATURE_NONFUNGIBLE_ISSUER:
+            MutableConsensusParams().NONFUNGIBLETOKEN_ISSUER_DATA = 999999;
+        break;
         case FEATURE_DELEGATEDISSUANCE:
             MutableConsensusParams().MSC_DELEGATED_ISSUANCE_BLOCK = 999999;
         break;
@@ -640,6 +649,7 @@ std::string GetFeatureName(uint16_t featureId)
         case FEATURE_FREEZENOTICE: return "Activate the waiting period for enabling freezing";
         case FEATURE_FREEDEX: return "Activate trading of any token on the distributed exchange";
         case FEATURE_NONFUNGIBLE: return "Uniquely identifiable tokens";
+        case FEATURE_NONFUNGIBLE_ISSUER: return "NFT issuer data update by issuers only";
         case FEATURE_DELEGATEDISSUANCE: return "Activate delegated issuance of tokens";
 
         default: return "Unknown feature";
@@ -694,6 +704,9 @@ bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
         case FEATURE_NONFUNGIBLE:
             activationBlock = params.MSC_NONFUNGIBLE_BLOCK;
         break;
+        case FEATURE_NONFUNGIBLE_ISSUER:
+            activationBlock = params.NONFUNGIBLETOKEN_ISSUER_DATA;
+            break;
         case FEATURE_DELEGATEDISSUANCE:
             activationBlock = params.MSC_DELEGATED_ISSUANCE_BLOCK;
         break;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -42,6 +42,8 @@ const uint16_t FEATURE_FREEDEX = 15;
 const uint16_t FEATURE_NONFUNGIBLE = 16;
 //! Feature identifier to enable delegated issuance support
 const uint16_t FEATURE_DELEGATEDISSUANCE = 17;
+//! Feature identifier to enable NFT issuer data update by issuers only
+const uint16_t FEATURE_NONFUNGIBLE_ISSUER = 18;
 
 //! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
 const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
@@ -155,6 +157,8 @@ public:
     int FREEZENOTICE_FEATURE_BLOCK;
     //! Block to activate the waiting period to activate trading of any token on the distributed exchange
     int FREEDEX_FEATURE_BLOCK;
+    //! Block to activate the ability for only issuers to update issuer data on NFTs
+    int NONFUNGIBLETOKEN_ISSUER_DATA;
 
     /** Returns a mapping of transaction types, and the blocks at which they are enabled. */
     virtual std::vector<TransactionRestriction> GetRestrictions() const;

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -2814,6 +2814,10 @@ int CMPTransaction::logicMath_NonFungibleData()
                     __func__,
                     sender,
                     property);
+
+            if (IsFeatureActivated(FEATURE_NONFUNGIBLE_ISSUER, block)) {
+                return (PKT_ERROR_SP -22);
+            }
         }
     }
 

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -1190,7 +1190,7 @@ int CMPTransaction::logicMath_SimpleSend(uint256& blockHash)
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (nValue <= 0 || MAX_INT_8_BYTES < nValue) {
@@ -1241,7 +1241,7 @@ int CMPTransaction::logicMath_SendToOwners()
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (nValue <= 0 || MAX_INT_8_BYTES < nValue) {
@@ -1373,7 +1373,7 @@ int CMPTransaction::logicMath_SendAll()
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     // ------------------------------------------
@@ -1431,38 +1431,38 @@ int CMPTransaction::logicMath_SendNonFungible()
                 version,
                 property,
                 block);
-        return (PKT_ERROR_SEND -22);
+        return (PKT_ERROR_NFT -23);
     }
 
     if (!isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is not of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -24);
     }
 
     if (nonfungible_token_start <= 0 || MAX_INT_8_BYTES < nonfungible_token_start) {
         PrintToLog("%s(): rejected: non-fungible token range start value out of range or zero: %d", __func__, nonfungible_token_start);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -25);
     }
 
     if (nonfungible_token_end <= 0 || MAX_INT_8_BYTES < nonfungible_token_end) {
         PrintToLog("%s(): rejected: non-fungible token range end value out of range or zero: %d", __func__, nonfungible_token_end);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -26);
     }
 
     if (nonfungible_token_start > nonfungible_token_end) {
         PrintToLog("%s(): rejected: non-fungible token range start value: %d is less than or equal to range end value: %d", __func__, nonfungible_token_start, nonfungible_token_end);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -27);
     }
 
     int64_t amount = (nonfungible_token_end - nonfungible_token_start) + 1;
     if (amount <= 0) {
         PrintToLog("%s(): rejected: non-fungible token range amount out of range or zero: %d", __func__, amount);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -28);
     }
 
     if (!pDbSpInfo->hasSP(property)) {
         PrintToLog("%s(): rejected: property %d does not exist\n", __func__, property);
-        return (PKT_ERROR_SEND -24);
+        return (PKT_ERROR_NFT -29);
     }
 
     int64_t nBalance = GetAvailableTokenBalance(sender, property);
@@ -1473,7 +1473,7 @@ int CMPTransaction::logicMath_SendNonFungible()
                 property,
                 FormatMP(property, nBalance),
                 FormatMP(property, amount));
-        return (PKT_ERROR_SEND -25);
+        return (PKT_ERROR_NFT -32);
     }
 
     std::string rangeStartOwner = pDbNFT->GetNonFungibleTokenOwner(property, nonfungible_token_start);
@@ -1483,7 +1483,7 @@ int CMPTransaction::logicMath_SendNonFungible()
         PrintToLog("%s(): rejected: sender %s does not own the range being sent\n",
                 __func__,
                 sender);
-        return (PKT_ERROR_SEND -26);
+        return (PKT_ERROR_NFT -33);
     }
 
     // ------------------------------------------
@@ -1517,7 +1517,7 @@ int CMPTransaction::logicMath_TradeOffer()
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (MAX_INT_8_BYTES < nValue) {
@@ -1621,7 +1621,7 @@ int CMPTransaction::logicMath_AcceptOffer_BTC()
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (nValue <= 0 || MAX_INT_8_BYTES < nValue) {
@@ -1652,7 +1652,7 @@ int CMPTransaction::logicMath_MetaDExTrade()
 
     if (isPropertyNonFungible(property) || isPropertyNonFungible(desired_property)) {
         PrintToLog("%s(): rejected: property %d or %d is of type non-fungible\n", __func__, property, desired_property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (property == desired_property) {
@@ -1733,7 +1733,7 @@ int CMPTransaction::logicMath_MetaDExCancelPrice()
 
     if (isPropertyNonFungible(property) || isPropertyNonFungible(desired_property)) {
         PrintToLog("%s(): rejected: property %d or %d is of type non-fungible\n", __func__, property, desired_property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (property == desired_property) {
@@ -1794,7 +1794,7 @@ int CMPTransaction::logicMath_MetaDExCancelPair()
 
     if (isPropertyNonFungible(property) || isPropertyNonFungible(desired_property)) {
         PrintToLog("%s(): rejected: property %d or %d is of type non-fungible\n", __func__, property, desired_property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (property == desired_property) {
@@ -2036,7 +2036,7 @@ int CMPTransaction::logicMath_CloseCrowdsale(CBlockIndex* pindex)
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (!IsPropertyIdValid(property)) {
@@ -2112,7 +2112,7 @@ int CMPTransaction::logicMath_CreatePropertyManaged(CBlockIndex* pindex)
 
     if (MSC_PROPERTY_TYPE_NONFUNGIBLE == prop_type && !IsFeatureActivated(FEATURE_NONFUNGIBLE, block)) {
         PrintToLog("%s(): rejected: non-fungible tokens are not yet activated (property type: %d)\n", __func__, prop_type);
-        return (PKT_ERROR_SP -22);
+        return (PKT_ERROR_NFT -20);
     }
 
     if ('\0' == name[0]) {
@@ -2277,7 +2277,7 @@ int CMPTransaction::logicMath_RevokeTokens(CBlockIndex* pindex)
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (nValue <= 0 || MAX_INT_8_BYTES < nValue) {
@@ -2346,7 +2346,7 @@ int CMPTransaction::logicMath_ChangeIssuer(CBlockIndex* pindex)
 
     if (isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -21);
     }
 
     if (!IsPropertyIdValid(property)) {
@@ -2757,38 +2757,38 @@ int CMPTransaction::logicMath_NonFungibleData()
                 version,
                 property,
                 block);
-        return (PKT_ERROR_SEND -22);
+        return (PKT_ERROR_NFT -23);
     }
 
     if (!isPropertyNonFungible(property)) {
         PrintToLog("%s(): rejected: property %d is not of type non-fungible\n", __func__, property);
-        return (PKT_ERROR_TOKENS -27);
+        return (PKT_ERROR_NFT -24);
     }
 
     if (nonfungible_token_start <= 0 || MAX_INT_8_BYTES < nonfungible_token_start) {
         PrintToLog("%s(): rejected: non-fungible token range start value out of range or zero: %d", __func__, nonfungible_token_start);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -25);
     }
 
     if (nonfungible_token_end <= 0 || MAX_INT_8_BYTES < nonfungible_token_end) {
         PrintToLog("%s(): rejected: non-fungible token range end value out of range or zero: %d", __func__, nonfungible_token_end);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -26);
     }
 
     if (nonfungible_token_start > nonfungible_token_end) {
         PrintToLog("%s(): rejected: non-fungible token range start value: %d is less than or equal to range end value: %d", __func__, nonfungible_token_start, nonfungible_token_end);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -27);
     }
 
     int64_t amount = (nonfungible_token_end - nonfungible_token_start) + 1;
     if (amount <= 0) {
         PrintToLog("%s(): rejected: non-fungible token range amount out of range or zero: %d", __func__, amount);
-        return (PKT_ERROR_SEND -23);
+        return (PKT_ERROR_NFT -28);
     }
 
     if (!pDbSpInfo->hasSP(property)) {
         PrintToLog("%s(): rejected: property %d does not exist\n", __func__, property);
-        return (PKT_ERROR_SEND -24);
+        return (PKT_ERROR_NFT -29);
     }
 
     NonFungibleStorage type = nonfungible_data_type ? NonFungibleStorage::IssuerData : NonFungibleStorage::HolderData;
@@ -2802,7 +2802,7 @@ int CMPTransaction::logicMath_NonFungibleData()
             PrintToLog("%s(): rejected: sender %s does not own the range data is being set on\n",
                     __func__,
                     sender);
-            return (PKT_ERROR_SEND -26);
+            return (PKT_ERROR_NFT -30);
         }
     }
     else
@@ -2816,7 +2816,7 @@ int CMPTransaction::logicMath_NonFungibleData()
                     property);
 
             if (IsFeatureActivated(FEATURE_NONFUNGIBLE_ISSUER, block)) {
-                return (PKT_ERROR_SP -22);
+                return (PKT_ERROR_NFT -31);
             }
         }
     }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -218,6 +218,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_getwalletaddressbalances", 0, "includewatchonly" },
     { "omni_getnonfungibletokens", 1, "propertyid"},
     { "omni_getnonfungibletokendata", 0, "propertyid"},
+    { "omni_getnonfungibletokendata", 1, "tokenidstart"},
     { "omni_getnonfungibletokendata", 2, "tokenidend"},
     { "omni_getnonfungibletokenranges", 0, "propertyid"},
     { "omni_getnonfungibletokenranges", 0, "propertyid"},
@@ -335,8 +336,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_createpayload_sendnonfungible", 1, "tokenstart"},
     { "omni_createpayload_sendnonfungible", 2, "tokenend"},
     { "omni_createpayload_setnonfungibledata", 0, "propertyid"},
-    { "omni_createpayload_setnonfungibledata", 1, "tokenid"},
-    { "omni_createpayload_setnonfungibledata", 2, "issuer"},
+    { "omni_createpayload_setnonfungibledata", 1, "tokenstart"},
+    { "omni_createpayload_setnonfungibledata", 2, "tokenend"},
+    { "omni_createpayload_setnonfungibledata", 3, "issuer"},
 
     /* Omni Core - backwards compatibility */
     { "getcrowdsale_MP", 0, "propertyid" },


### PR DESCRIPTION
Creates a feature release to prevent non-isuers from updating the issuer data in NFTs.

Also fixes `omni_getnonfungibletokendata` not being able to get the specified ranges, `omni_gettransaction` not showing the range for `omni_setnonfungibledata` TXs and 'omni_createpayload_setnonfungibledata' failing to convert some non-string arguments.