### PR TITLE
Add ability to send and parse send-to-many transactions

### DIFF
--- a/src/omnicore/createpayload.h
+++ b/src/omnicore/createpayload.h
@@ -1,13 +1,15 @@
 #ifndef BITCOIN_OMNICORE_CREATEPAYLOAD_H
 #define BITCOIN_OMNICORE_CREATEPAYLOAD_H
 
-#include <string>
-#include <vector>
 #include <stdint.h>
+#include <string>
+#include <tuple>
+#include <vector>
 
 std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount);
 std::vector<unsigned char> CreatePayload_SendAll(uint8_t ecosystem);
 std::vector<unsigned char> CreatePayload_SendNonFungible(uint32_t propertyId, uint64_t tokenStart, uint64_t tokenEnd);
+std::vector<unsigned char> CreatePayload_SendToMany(uint32_t propertyId, std::vector<std::tuple<uint8_t, uint64_t>> outputValues);
 std::vector<unsigned char> CreatePayload_SetNonFungibleData(uint32_t propertyId, uint64_t tokenStart, uint64_t tokenEnd, uint8_t issuer, std::string& data);
 std::vector<unsigned char> CreatePayload_DExSell(uint32_t propertyId, uint64_t amountForSale, uint64_t amountDesired, uint8_t timeLimit, uint64_t minFee, uint8_t subAction);
 std::vector<unsigned char> CreatePayload_DExAccept(uint32_t propertyId, uint64_t amount);

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1076,7 +1076,11 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
             if (!(dest == ExodusAddress())) {
                 // saving for Class A processing or reference
                 GetScriptPushes(wtx.vout[n].scriptPubKey, script_data);
-                address_data.push_back(EncodeDestination(dest));
+                std::string address = EncodeDestination(dest);
+                address_data.push_back(address);
+                if (!address.empty()) {
+                    mp_tx.addValidStmAddress(n, address);
+                }
                 value_data.push_back(wtx.vout[n].nValue);
                 if (msc_debug_parser_data) PrintToLog("saving address_data #%d: %s:%s\n", n, EncodeDestination(dest), ScriptToAsmStr(wtx.vout[n].scriptPubKey));
             }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1063,7 +1063,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
     std::vector<std::string> address_data;
     std::vector<int64_t> value_data;
 
-    for (unsigned int n = 0; n < wtx.vout.size(); ++n) {
+    for (size_t n = 0; n < wtx.vout.size(); ++n) {
         txnouttype whichType;
         if (!GetOutputType(wtx.vout[n].scriptPubKey, whichType)) {
             continue;
@@ -1078,9 +1078,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                 GetScriptPushes(wtx.vout[n].scriptPubKey, script_data);
                 std::string address = EncodeDestination(dest);
                 address_data.push_back(address);
-                if (!address.empty()) {
-                    mp_tx.addValidStmAddress(n, address);
-                }
+                mp_tx.addValidStmAddress(n, address);
                 value_data.push_back(wtx.vout[n].nValue);
                 if (msc_debug_parser_data) PrintToLog("saving address_data #%d: %s:%s\n", n, EncodeDestination(dest), ScriptToAsmStr(wtx.vout[n].scriptPubKey));
             }

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -59,6 +59,7 @@ enum TransactionType {
   MSC_TYPE_SEND_TO_OWNERS             =  3,
   MSC_TYPE_SEND_ALL                   =  4,
   MSC_TYPE_SEND_NONFUNGIBLE           =  5,
+  MSC_TYPE_SEND_TO_MANY               =  7,
   MSC_TYPE_SAVINGS_MARK               = 10,
   MSC_TYPE_SAVINGS_COMPROMISED        = 11,
   MSC_TYPE_RATELIMITED_MARK           = 12,
@@ -119,6 +120,7 @@ enum TransactionType {
 #define PKT_ERROR_SEND_ALL    (-83000)
 #define PKT_ERROR_ANYDATA     (-84000)
 #define PKT_ERROR_NFT         (-85000)
+#define PKT_ERROR_SEND_MANY   (-86000)
 
 #define OMNI_PROPERTY_BTC   0
 #define OMNI_PROPERTY_MSC   1

--- a/src/omnicore/rpcpayload.cpp
+++ b/src/omnicore/rpcpayload.cpp
@@ -12,6 +12,8 @@
 
 #include <univalue.h>
 
+#include <stdint.h>
+
 using std::runtime_error;
 using namespace mastercore;
 
@@ -164,7 +166,7 @@ static UniValue omni_createpayload_sendtomany(const JSONRPCRequest& request)
         const UniValue& uvOutput = find_value(o, "output");
         const UniValue& uvAmount = find_value(o, "amount");
 
-        uint8_t output = uvOutput.get_int();
+        uint8_t output = ParseStmOutputIndex(uvOutput);
         uint64_t amount = ParseAmount(uvAmount, isPropertyDivisible(propertyId));
 
         outputValues.push_back(std::make_tuple(output, amount));

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -15,6 +15,7 @@
 #include <tinyformat.h>
 
 #include <stdint.h>
+#include <limits>
 #include <string>
 
 void RequireBalance(const std::string& address, uint32_t propertyId, int64_t amount)
@@ -261,5 +262,12 @@ void RequireNonFungibleTokenOwner(const std::string& address, uint32_t propertyI
     bool contiguous = mastercore::pDbNFT->IsRangeContiguous(propertyId, tokenStart, tokenEnd);
     if (rangeStartOwner != address || rangeEndOwner != address || !contiguous) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Sender does not own the range");
+    }
+}
+
+void RequireBoundedStmReceiverNumber(size_t numberOfReceivers)
+{
+    if (numberOfReceivers > std::numeric_limits<uint8_t>::max()) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Too many send-to-many receivers");
     }
 }

--- a/src/omnicore/rpcrequirements.cpp
+++ b/src/omnicore/rpcrequirements.cpp
@@ -15,7 +15,6 @@
 #include <tinyformat.h>
 
 #include <stdint.h>
-#include <limits>
 #include <string>
 
 void RequireBalance(const std::string& address, uint32_t propertyId, int64_t amount)
@@ -265,9 +264,9 @@ void RequireNonFungibleTokenOwner(const std::string& address, uint32_t propertyI
     }
 }
 
-void RequireBoundedStmReceiverNumber(size_t numberOfReceivers)
+void RequireBoundedStmReceiverNumber(size_t numberOfOutputs)
 {
-    if (numberOfReceivers > std::numeric_limits<uint8_t>::max()) {
+    if (numberOfOutputs > std::numeric_limits<uint8_t>::max() + 1) { // index = 0 included
         throw JSONRPCError(RPC_TYPE_ERROR, "Too many send-to-many receivers");
     }
 }

--- a/src/omnicore/rpcrequirements.h
+++ b/src/omnicore/rpcrequirements.h
@@ -29,6 +29,7 @@ void RequireSaneDExFee(const std::string& address, uint32_t propertyId);
 void RequireSaneNonFungibleRange(int64_t tokenStart, int64_t tokenEnd);
 void RequireHeightInChain(int blockHeight);
 void RequireNonFungibleTokenOwner(const std::string& address, uint32_t propertyId, int64_t tokenStart, int64_t tokenEnd);
+void RequireBoundedStmReceiverNumber(size_t numberOfReceivers);
 
 // TODO:
 // Checks for MetaDEx orders for cancel operations

--- a/src/omnicore/rpcrequirements.h
+++ b/src/omnicore/rpcrequirements.h
@@ -29,7 +29,7 @@ void RequireSaneDExFee(const std::string& address, uint32_t propertyId);
 void RequireSaneNonFungibleRange(int64_t tokenStart, int64_t tokenEnd);
 void RequireHeightInChain(int blockHeight);
 void RequireNonFungibleTokenOwner(const std::string& address, uint32_t propertyId, int64_t tokenStart, int64_t tokenEnd);
-void RequireBoundedStmReceiverNumber(size_t numberOfReceivers);
+void RequireBoundedStmReceiverNumber(size_t numberOfOutputs);
 
 // TODO:
 // Checks for MetaDEx orders for cancel operations

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -422,6 +422,127 @@ static UniValue omni_setnonfungibledata(const JSONRPCRequest& request)
     }
 }
 
+static UniValue omni_sendtomany(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    std::unique_ptr<interfaces::Wallet> pwallet = interfaces::MakeWallet(wallet);
+
+    RPCHelpMan{"omni_sendtomany",
+       "\nCreate and broadcast a send-to-many transaction, which allows to transfer tokens from one source to multiple receivers.\n",
+       {
+           {"fromaddress", RPCArg::Type::STR, RPCArg::Optional::NO, "the address to send from"},
+           {"propertyid", RPCArg::Type::NUM, RPCArg::Optional::NO, "the identifier of the tokens to send"},
+           {"mapping", RPCArg::Type::ARR, RPCArg::Optional::NO, "an array with the receiving address \"address\" and the \"amount\" to send",
+                {
+                    {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                        {
+                            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "the address of the receiver"},
+                            {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "the amount of tokens to send to this output"},
+                        },
+                    },
+                },
+            },
+       },
+       RPCResult{
+           RPCResult::Type::STR_HEX, "hash", "the hex-encoded transaction hash"
+       },
+       RPCExamples{
+           HelpExampleCli("omni_sendtomany", "\"3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY\" 1 '[{\"address\": \"37FaKponF7zqoMLUjEiko25pDiuVH5YLEa\", \"amount\": \"10.5\"}, {\"output\": \"1oQM6A7ZHpuuMZwJvTsLumUrut2GnFCok\", \"amount\": \"0.5\"}]'")
+           + HelpExampleRpc("omni_sendtomany", "\"3M9qvHKtgARhqcMtM5cRT9VaiDJ5PSfQGY\", 1, '[{\"address\": \"37FaKponF7zqoMLUjEiko25pDiuVH5YLEa\", \"amount\": \"10.5\"}, {\"output\": \"1oQM6A7ZHpuuMZwJvTsLumUrut2GnFCok\", \"amount\": \"0.5\"}]'")
+       }
+    }.Check(request);
+
+    std::string fromAddress = ParseAddress(request.params[0]);
+    uint32_t propertyId = ParsePropertyId(request.params[1]);
+
+    RequireBoundedStmReceiverNumber(request.params[2].size());
+
+    // ---
+    // dry run to get positions for send-to-many outputs
+    // ---
+
+    std::vector<std::string> receiverAddresses;
+    std::vector<std::tuple<uint8_t, uint64_t>> outputValues;
+
+    uint64_t amountToSend = 0;
+    uint8_t output = 1; // dummy position
+
+    for (unsigned int idx = 0; idx < request.params[2].size(); idx++) {
+        const UniValue& input = request.params[2][idx];
+        const UniValue& o = input.get_obj();
+
+        const UniValue& uvOutput = find_value(o, "address");
+        const UniValue& uvAmount = find_value(o, "amount");
+
+        std::string address = ParseAddress(uvOutput);
+        uint64_t amount = ParseAmount(uvAmount, isPropertyDivisible(propertyId));
+
+        amountToSend += amount;
+        receiverAddresses.push_back(address);
+        outputValues.push_back(std::make_tuple(output, amount));
+
+        output += 1;
+    }
+
+    std::vector<unsigned char> testPayload = CreatePayload_SendToMany(
+        propertyId,
+        outputValues);
+
+    int outputCount = GetDryPayloadOutputCount(fromAddress, "", testPayload, pwallet.get());
+
+    // perform checks
+    RequireExistingProperty(propertyId);
+    RequireBalance(fromAddress, propertyId, amountToSend);
+
+    if (outputCount < 0) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Error creating send-to-many payload");
+    }
+
+    // ---
+    // actual run
+    // --
+
+    receiverAddresses.clear();
+    outputValues.clear();
+    output = outputCount;
+
+    for (unsigned int idx = 0; idx < request.params[2].size(); idx++) {
+        const UniValue& input = request.params[2][idx];
+        const UniValue& o = input.get_obj();
+
+        const UniValue& uvOutput = find_value(o, "address");
+        const UniValue& uvAmount = find_value(o, "amount");
+
+        std::string address = ParseAddress(uvOutput);
+        uint64_t amount = ParseAmount(uvAmount, isPropertyDivisible(propertyId));
+
+        receiverAddresses.push_back(address);
+        outputValues.push_back(std::make_tuple(output, amount));
+
+        output += 1;
+    }
+
+    std::vector<unsigned char> payload = CreatePayload_SendToMany(
+        propertyId,
+        outputValues);
+
+    // request the wallet build the transaction (and if needed commit it)
+    uint256 txid;
+    std::string rawHex;
+    int result = WalletTxBuilder(fromAddress, receiverAddresses, "", 0, payload, txid, rawHex, autoCommit, pwallet.get());
+
+    // check error and return the txid (or raw hex depending on autocommit)
+    if (result != 0) {
+        throw JSONRPCError(result, error_str(result));
+    } else {
+        if (!autoCommit) {
+            return rawHex;
+        } else {
+            PendingAdd(txid, fromAddress, MSC_TYPE_SEND_TO_MANY, propertyId, amountToSend);
+            return txid.GetHex();
+        }
+    }
+}
 
 static UniValue omni_senddexsell(const JSONRPCRequest& request)
 {
@@ -2122,6 +2243,7 @@ static const CRPCCommand commands[] =
     { "omni layer (transaction creation)", "omni_sendrawtx",               &omni_sendrawtx,               {"fromaddress", "rawtransaction", "referenceaddress", "redeemaddress", "referenceamount"} },
     { "omni layer (transaction creation)", "omni_send",                    &omni_send,                    {"fromaddress", "toaddress", "propertyid", "amount", "redeemaddress", "referenceamount"} },
     { "omni layer (transaction creation)", "omni_senddexsell",             &omni_senddexsell,             {"fromaddress", "propertyidforsale", "amountforsale", "amountdesired", "paymentwindow", "minacceptfee", "action"} },
+    { "omni layer (transaction creation)", "omni_sendtomany",              &omni_sendtomany,              {"fromaddress", "propertyid", "mapping"} },
     { "omni layer (transaction creation)", "omni_sendnewdexorder",         &omni_sendnewdexorder,         {"fromaddress", "propertyidforsale", "amountforsale", "amountdesired", "paymentwindow", "minacceptfee"} },
     { "omni layer (transaction creation)", "omni_sendupdatedexorder",      &omni_sendupdatedexorder,      {"fromaddress", "propertyidforsale", "amountforsale", "amountdesired", "paymentwindow", "minacceptfee"} },
     { "omni layer (transaction creation)", "omni_sendcanceldexorder",      &omni_sendcanceldexorder,      {"fromaddress", "propertyidforsale"} },

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <tuple>
 
 // Namespaces
 using namespace mastercore;
@@ -193,6 +194,9 @@ void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txTyp
         case MSC_TYPE_SEND_ALL:
             populateRPCTypeSendAll(mp_obj, txobj, confirmations);
             break;
+        case MSC_TYPE_SEND_TO_MANY:
+            populateRPCTypeSendToMany(mp_obj, txobj);
+            break;
         case MSC_TYPE_TRADE_OFFER:
             populateRPCTypeTradeOffer(mp_obj, txobj);
             break;
@@ -271,6 +275,7 @@ bool showRefForTx(uint32_t txType)
 {
     switch (txType) {
         case MSC_TYPE_SIMPLE_SEND: return true;
+        case MSC_TYPE_SEND_TO_MANY: return false;
         case MSC_TYPE_SEND_TO_OWNERS: return false;
         case MSC_TYPE_TRADE_OFFER: return false;
         case MSC_TYPE_METADEX_TRADE: return false;
@@ -327,6 +332,35 @@ void populateRPCTypeSimpleSend(CMPTransaction& omniObj, UniValue& txobj)
         txobj.pushKV("divisible", isPropertyDivisible(propertyId));
         txobj.pushKV("amount", FormatMP(propertyId, omniObj.getAmount()));
     }
+}
+
+
+void populateRPCTypeSendToMany(CMPTransaction& omniObj, UniValue& txobj)
+{
+    uint32_t propertyId = omniObj.getProperty();
+    txobj.pushKV("propertyid", (uint64_t) propertyId);
+    txobj.pushKV("divisible", isPropertyDivisible(propertyId));
+
+    UniValue outputValues(UniValue::VARR);
+
+    for (const std::tuple<uint8_t, uint64_t>& entry : omniObj.getStmOutputValues()) {
+        
+        uint8_t output = std::get<0>(entry);
+        std::string amount = FormatMP(propertyId, std::get<1>(entry));
+        std::string destination;
+        bool valid = omniObj.getValidStmAddressAt(output, destination);
+
+        if (valid) {
+            UniValue outputEntry(UniValue::VOBJ);
+            outputEntry.pushKV("output", output);
+            outputEntry.pushKV("address", destination);
+            outputEntry.pushKV("amount", amount);
+            outputValues.push_back(outputEntry);
+        }
+    }
+
+    txobj.pushKV("receivers", outputValues);
+    txobj.pushKV("totalamount", FormatMP(propertyId, omniObj.getAmount()));
 }
 
 void populateRPCTypeSendToOwners(CMPTransaction& omniObj, UniValue& txobj, bool extendedDetails, std::string extendedDetailsFilter, interfaces::Wallet *iWallet)

--- a/src/omnicore/rpctxobject.cpp
+++ b/src/omnicore/rpctxobject.cpp
@@ -344,7 +344,6 @@ void populateRPCTypeSendToMany(CMPTransaction& omniObj, UniValue& txobj)
     UniValue outputValues(UniValue::VARR);
 
     for (const std::tuple<uint8_t, uint64_t>& entry : omniObj.getStmOutputValues()) {
-        
         uint8_t output = std::get<0>(entry);
         std::string amount = FormatMP(propertyId, std::get<1>(entry));
         std::string destination;

--- a/src/omnicore/rpctxobject.h
+++ b/src/omnicore/rpctxobject.h
@@ -19,6 +19,7 @@ int populateRPCTransactionObject(const CTransaction& tx, const uint256& blockHas
 void populateRPCTypeInfo(CMPTransaction& mp_obj, UniValue& txobj, uint32_t txType, bool extendedDetails, std::string extendedDetailsFilter, int confirmations, interfaces::Wallet* iWallet = nullptr);
 
 void populateRPCTypeSimpleSend(CMPTransaction& omniObj, UniValue& txobj);
+void populateRPCTypeSendToMany(CMPTransaction& omniObj, UniValue& txobj);
 void populateRPCTypeSendToOwners(CMPTransaction& omniObj, UniValue& txobj, bool extendedDetails, std::string extendedDetailsFilter, interfaces::Wallet* iWallet = nullptr);
 void populateRPCTypeSendAll(CMPTransaction& omniObj, UniValue& txobj, int confirmations);
 void populateRPCTypeTradeOffer(CMPTransaction& omniObj, UniValue& txobj);

--- a/src/omnicore/rpcvalues.cpp
+++ b/src/omnicore/rpcvalues.cpp
@@ -17,6 +17,7 @@
 
 #include <univalue.h>
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -244,4 +245,13 @@ std::vector<PrevTxsEntry> ParsePrevTxs(const UniValue& value)
     }
 
     return prevTxsParsed;
+}
+
+uint8_t ParseStmOutputIndex(const UniValue& value)
+{
+    int64_t index = value.get_int64();
+    if (index < 0 || index > std::numeric_limits<uint8_t>::max()) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Output index out of bounds (0..255)");
+    }
+    return static_cast<uint8_t>(index);
 }

--- a/src/omnicore/rpcvalues.h
+++ b/src/omnicore/rpcvalues.h
@@ -41,6 +41,7 @@ CPubKey ParsePubKeyOrAddress(interfaces::Wallet *iWallet, const UniValue& value)
 uint32_t ParseOutputIndex(const UniValue& value);
 /** Parses previous transaction outputs. */
 std::vector<PrevTxsEntry> ParsePrevTxs(const UniValue& value);
+uint8_t ParseStmOutputIndex(const UniValue& value);
 
 
 #endif // BITCOIN_OMNICORE_RPCVALUES_H

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -79,6 +79,8 @@ std::vector<TransactionRestriction> CConsensusParams::GetRestrictions() const
 
         { MSC_TYPE_SEND_NONFUNGIBLE,          MP_TX_PKT_V0,  false,   MSC_NONFUNGIBLE_BLOCK  },
         { MSC_TYPE_NONFUNGIBLE_DATA,          MP_TX_PKT_V0,  false,   MSC_NONFUNGIBLE_BLOCK  },
+
+        { MSC_TYPE_SEND_TO_MANY,              MP_TX_PKT_V0,  false,   MSC_SEND_TO_MANY_BLOCK  },
     };
 
     const size_t nSize = sizeof(vTxRestrictions) / sizeof(vTxRestrictions[0]);
@@ -255,6 +257,7 @@ CMainConsensusParams::CMainConsensusParams()
     MSC_ANYDATA_BLOCK = 0;
     MSC_NONFUNGIBLE_BLOCK = 999999;
     MSC_DELEGATED_ISSUANCE_BLOCK = 999999;
+    MSC_SEND_TO_MANY_BLOCK = 999999;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 394500;
     DEXMATH_FEATURE_BLOCK = 395000;
@@ -301,6 +304,7 @@ CTestNetConsensusParams::CTestNetConsensusParams()
     MSC_ANYDATA_BLOCK = 0;
     MSC_NONFUNGIBLE_BLOCK = 0;
     MSC_DELEGATED_ISSUANCE_BLOCK = 0;
+    MSC_SEND_TO_MANY_BLOCK = 0;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 0;
     DEXMATH_FEATURE_BLOCK = 0;
@@ -347,6 +351,7 @@ CRegTestConsensusParams::CRegTestConsensusParams()
     MSC_ANYDATA_BLOCK = 0;
     MSC_NONFUNGIBLE_BLOCK = 0;
     MSC_DELEGATED_ISSUANCE_BLOCK = 0;
+    MSC_SEND_TO_MANY_BLOCK = 0;
     // Other feature activations:
     GRANTEFFECTS_FEATURE_BLOCK = 999999;
     DEXMATH_FEATURE_BLOCK = 999999;
@@ -533,6 +538,9 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
         case FEATURE_DELEGATEDISSUANCE:
             MutableConsensusParams().MSC_DELEGATED_ISSUANCE_BLOCK = activationBlock;
         break;
+        case FEATURE_SEND_TO_MANY:
+            MutableConsensusParams().MSC_SEND_TO_MANY_BLOCK = activationBlock;
+        break;
         default:
             supported = false;
         break;
@@ -616,6 +624,9 @@ bool DeactivateFeature(uint16_t featureId, int transactionBlock)
         case FEATURE_DELEGATEDISSUANCE:
             MutableConsensusParams().MSC_DELEGATED_ISSUANCE_BLOCK = 999999;
         break;
+        case FEATURE_SEND_TO_MANY:
+            MutableConsensusParams().MSC_SEND_TO_MANY_BLOCK = 999999;
+        break;
         default:
             return false;
         break;
@@ -651,6 +662,7 @@ std::string GetFeatureName(uint16_t featureId)
         case FEATURE_NONFUNGIBLE: return "Uniquely identifiable tokens";
         case FEATURE_NONFUNGIBLE_ISSUER: return "NFT issuer data update by issuers only";
         case FEATURE_DELEGATEDISSUANCE: return "Activate delegated issuance of tokens";
+        case FEATURE_SEND_TO_MANY: return "Activate send-to-many transactions";
 
         default: return "Unknown feature";
     }
@@ -709,6 +721,9 @@ bool IsFeatureActivated(uint16_t featureId, int transactionBlock)
             break;
         case FEATURE_DELEGATEDISSUANCE:
             activationBlock = params.MSC_DELEGATED_ISSUANCE_BLOCK;
+        break;
+        case FEATURE_SEND_TO_MANY:
+            activationBlock = params.MSC_SEND_TO_MANY_BLOCK;
         break;
         default:
             return false;

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -44,6 +44,8 @@ const uint16_t FEATURE_NONFUNGIBLE = 16;
 const uint16_t FEATURE_DELEGATEDISSUANCE = 17;
 //! Feature identifier to enable NFT issuer data update by issuers only
 const uint16_t FEATURE_NONFUNGIBLE_ISSUER = 18;
+//! Feature identifier to enable send-to-many support
+const uint16_t FEATURE_SEND_TO_MANY = 19;
 
 //! When (propertyTotalTokens / OMNI_FEE_THRESHOLD) is reached fee distribution will occur
 const int64_t OMNI_FEE_THRESHOLD = 100000; // 0.001%
@@ -142,6 +144,8 @@ public:
     int MSC_NONFUNGIBLE_BLOCK;
     //! Block to enable delegation of token issuance
     int MSC_DELEGATED_ISSUANCE_BLOCK;
+    //! Block to enable send-to-many
+    int MSC_SEND_TO_MANY_BLOCK;
 
     //! Block to deactivate crowdsale participations when "granting tokens"
     int GRANTEFFECTS_FEATURE_BLOCK;

--- a/src/omnicore/test/create_payload_tests.cpp
+++ b/src/omnicore/test/create_payload_tests.cpp
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <vector>
 #include <string>
+#include <tuple>
 
 BOOST_FIXTURE_TEST_SUITE(omnicore_create_payload_tests, BasicTestingSetup)
 
@@ -50,6 +51,41 @@ BOOST_AUTO_TEST_CASE(payload_send_all)
         static_cast<uint8_t>(2));          // ecosystem: Test
 
     BOOST_CHECK_EQUAL(HexStr(vch), "0000000402");
+}
+
+BOOST_AUTO_TEST_CASE(payload_send_to_many_1)
+{
+    uint32_t propertyId = 1;
+    std::vector<std::tuple<uint8_t, uint64_t>> outputValues;
+
+    outputValues.push_back(std::make_tuple(static_cast<uint8_t>(1), static_cast<uint64_t>(100000000)));
+
+    // Send to many [type 7, version 0]
+    std::vector<unsigned char> vch = CreatePayload_SendToMany(
+        propertyId,                      // property: 31
+        outputValues);                   // outputs: see list above
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "000000070000000101010000000005f5e100");
+}
+
+
+BOOST_AUTO_TEST_CASE(payload_send_to_many_2)
+{
+    uint32_t propertyId = 31;
+    std::vector<std::tuple<uint8_t, uint64_t>> outputValues;
+
+    outputValues.push_back(std::make_tuple(static_cast<uint8_t>(1), static_cast<uint64_t>(2000000000)));
+    outputValues.push_back(std::make_tuple(static_cast<uint8_t>(2), static_cast<uint64_t>(1500000000)));
+    outputValues.push_back(std::make_tuple(static_cast<uint8_t>(4), static_cast<uint64_t>(3000000000)));
+
+    // Send to many [type 7, version 0]
+    std::vector<unsigned char> vch = CreatePayload_SendToMany(
+        propertyId,                      // property: 31
+        outputValues);                   // outputs: see list above
+
+    BOOST_CHECK_EQUAL(HexStr(vch),
+        "000000070000001f03010000000077359400020000000059682f000400000000b2d05e00");
 }
 
 BOOST_AUTO_TEST_CASE(payload_dex_offer)

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -35,6 +35,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 #include <vector>
 #include <tuple>
@@ -109,6 +110,37 @@ bool CMPTransaction::isOverrun(const char* p)
     ptrdiff_t pos = (char*) p - (char*) &pkt;
     return (pos > pkt_size);
 }
+
+// ** Returns number of STM receivers. */
+uint8_t CMPTransaction::getStmNumberOfReceivers() {
+    return numberOfSTMReceivers;
+}
+
+/** Returns output valies. */
+std::vector<std::tuple<uint8_t, uint64_t>> CMPTransaction::getStmOutputValues() {
+    return outputValuesForSTM;
+}
+
+/** Adds an address at position output. */
+void CMPTransaction::addValidStmAddress(size_t output, const std::string& address) {
+    if (output <= std::numeric_limits<uint8_t>::max()) {
+        if (!address.empty()) {
+            validOutputAddressesForSTM[output] = address;
+        }
+    }
+}
+
+/** Return an output address, if it's considered as valid Omni destination. */
+bool CMPTransaction::getValidStmAddressAt(uint8_t output, std::string& addressOut) {
+    if (validOutputAddressesForSTM.find(output) != validOutputAddressesForSTM.end()) {
+        addressOut = validOutputAddressesForSTM[output];
+        return true;
+    }
+
+    addressOut.clear();
+    return false;
+}
+
 
 // -------------------- PACKET PARSING -----------------------
 
@@ -1638,7 +1670,6 @@ int CMPTransaction::logicMath_SendToMany()
 
         std::string receiver;
         assert(getValidStmAddressAt(output, receiver));
-
         assert(update_tally_map(sender, property, -amount, BALANCE));
         assert(update_tally_map(receiver, property, amount, BALANCE));
     }

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <utility>
 #include <vector>
+#include <tuple>
 
 using boost::algorithm::token_compress_on;
 
@@ -50,6 +51,7 @@ std::string mastercore::strTransactionType(uint16_t txType)
         case MSC_TYPE_RESTRICTED_SEND: return "Restricted Send";
         case MSC_TYPE_SEND_TO_OWNERS: return "Send To Owners";
         case MSC_TYPE_SEND_ALL: return "Send All";
+        case MSC_TYPE_SEND_TO_MANY: return "Send To Many";
         case MSC_TYPE_SEND_NONFUNGIBLE: return "Unique Send";
         case MSC_TYPE_SAVINGS_MARK: return "Savings";
         case MSC_TYPE_SAVINGS_COMPROMISED: return "Savings COMPROMISED";
@@ -131,6 +133,9 @@ bool CMPTransaction::interpret_Transaction()
         case MSC_TYPE_SEND_NONFUNGIBLE:
             return interpret_SendNonFungible();
 
+        case MSC_TYPE_SEND_TO_MANY:
+            return interpret_SendToMany();
+
         case MSC_TYPE_TRADE_OFFER:
             return interpret_TradeOffer();
 
@@ -190,7 +195,7 @@ bool CMPTransaction::interpret_Transaction()
 
         case OMNICORE_MESSAGE_TYPE_DEACTIVATION:
             return interpret_Deactivation();
-            
+
         case MSC_TYPE_ANYDATA:
             return interpret_AnyData();
 
@@ -324,6 +329,53 @@ bool CMPTransaction::interpret_SendNonFungible()
         PrintToLog("\t      tokenstart: %d\n", nonfungible_token_start);
         PrintToLog("\t        tokenend: %d\n", nonfungible_token_end);
     }
+
+    return true;
+}
+
+/** Tx 7 */
+bool CMPTransaction::interpret_SendToMany()
+{
+    // minimum case without any recipients, still needs propertyid
+    if (pkt_size < 9) {
+        return false;
+    }
+    memcpy(&property, &pkt[4], 4);
+    SwapByteOrder32(property);
+
+    memcpy(&numberOfSTMReceivers, &pkt[8], 1);
+
+    // check total size for all receivers
+    if (pkt_size < (9 + (numberOfSTMReceivers * (1 + 8)))) {
+        return false;
+    }
+
+    if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
+        PrintToLog("\t        property: %d (%s)\n", property, strMPProperty(property));
+        PrintToLog("\t       receivers: %d\n", numberOfSTMReceivers);
+    }
+
+    size_t pos = 9;
+    for (uint8_t i = 0; i < numberOfSTMReceivers; ++i) {
+        uint8_t outputN = 0;
+        memcpy(&outputN, &pkt[pos], 1);
+
+        uint64_t valueN = 0;
+        memcpy(&valueN, &pkt[pos+1], 8);
+        SwapByteOrder64(valueN);
+
+        outputValuesForSTM.push_back(std::make_tuple(outputN, valueN));
+        nValue += valueN;
+
+        pos = pos + 9;
+
+        if ((!rpcOnly && msc_debug_packets) || msc_debug_packets_readonly) {
+            PrintToLog("\t               output: %d\n", outputN);
+            PrintToLog("\t               value: %s\n", FormatMP(property, valueN));
+        }
+    }
+
+    nNewValue = nValue;
 
     return true;
 }
@@ -1020,6 +1072,9 @@ int CMPTransaction::interpretPacket()
         case MSC_TYPE_SEND_NONFUNGIBLE:
             return logicMath_SendNonFungible();
 
+        case MSC_TYPE_SEND_TO_MANY:
+            return logicMath_SendToMany();
+
         case MSC_TYPE_TRADE_OFFER:
             return logicMath_TradeOffer();
 
@@ -1070,7 +1125,7 @@ int CMPTransaction::interpretPacket()
 
         case MSC_TYPE_UNFREEZE_PROPERTY_TOKENS:
             return logicMath_UnfreezeTokens(pindex);
-            
+
         case MSC_TYPE_ADD_DELEGATE:
             return logicMath_AddDelegate(pindex);
 
@@ -1498,6 +1553,95 @@ int CMPTransaction::logicMath_SendNonFungible()
     assert(update_tally_map(receiver, property, amount, BALANCE));
     bool success = pDbNFT->MoveNonFungibleTokens(property,nonfungible_token_start,nonfungible_token_end,sender,receiver);
     assert(success);
+
+    return 0;
+}
+
+
+/** Tx 7 */
+int CMPTransaction::logicMath_SendToMany()
+{
+    if (!IsTransactionTypeAllowed(block, property, type, version)) {
+        PrintToLog("%s(): rejected: type %d or version %d not permitted for property %d at block %d\n",
+                __func__,
+                type,
+                version,
+                property,
+                block);
+        return (PKT_ERROR_SEND_MANY -22);
+    }
+
+    if (isPropertyNonFungible(property)) {
+        PrintToLog("%s(): rejected: property %d is of type non-fungible\n", __func__, property);
+        return (PKT_ERROR_SEND_MANY -27);
+    }
+
+    if (nValue <= 0 || MAX_INT_8_BYTES < nValue) {
+        PrintToLog("%s(): rejected: value out of range or zero: %d", __func__, nValue);
+        return (PKT_ERROR_SEND_MANY -23);
+    }
+
+    if (!IsPropertyIdValid(property)) {
+        PrintToLog("%s(): rejected: property %d does not exist\n", __func__, property);
+        return (PKT_ERROR_SEND_MANY -24);
+    }
+
+    int64_t nBalance = GetTokenBalance(sender, property, BALANCE);
+    if (nBalance < (int64_t) nValue) {
+        PrintToLog("%s(): rejected: sender %s has insufficient balance of property %d [%s < %s]\n",
+                __func__,
+                sender,
+                property,
+                FormatMP(property, nBalance),
+                FormatMP(property, nValue));
+        return (PKT_ERROR_SEND_MANY -25);
+    }
+
+    // ------------------------------------------
+
+    uint64_t totalAmount = 0;
+    uint8_t totalOutputs = 0;
+
+    // Check if all outputs refer to valid destinations
+    for (const std::tuple<uint8_t, uint64_t>& entry : outputValuesForSTM) {
+        uint8_t output = std::get<0>(entry);
+        uint64_t amount = std::get<1>(entry);
+
+        std::string receiver;
+        if (!getValidStmAddressAt(output, receiver)) {
+            PrintToLog("%s(): rejected: output %d doesn't refer to valid destination\n", __func__, output);
+            return (PKT_ERROR_SEND_MANY -26);
+        }
+        if (receiver.empty()) {
+            PrintToLog("%s(): rejected: receiver of output %d doesn't refer to valid destination\n", __func__, output);
+            return (PKT_ERROR_SEND_MANY -27);
+        }
+
+        totalAmount += amount;
+        totalOutputs += 1;
+    }
+
+    if (totalAmount != nValue) {
+        PrintToLog("%s(): rejected: mismatch of total amounts [%d != %d]\n", __func__, totalAmount, nValue);
+        return (PKT_ERROR_SEND_MANY -28);
+    }
+
+    if (totalOutputs != numberOfSTMReceivers) {
+        PrintToLog("%s(): rejected: mismatch of number of valid receivers [%d != %d]\n", __func__, totalOutputs, numberOfSTMReceivers);
+        return (PKT_ERROR_SEND_MANY -29);
+    }
+
+    // Move the tokens
+    for (const std::tuple<uint8_t, uint64_t>& entry : outputValuesForSTM) {
+        uint8_t output = std::get<0>(entry);
+        uint64_t amount = std::get<1>(entry);
+
+        std::string receiver;
+        assert(getValidStmAddressAt(output, receiver));
+
+        assert(update_tally_map(sender, property, -amount, BALANCE));
+        assert(update_tally_map(receiver, property, amount, BALANCE));
+    }
 
     return 0;
 }

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -245,30 +245,17 @@ public:
     std::string getNonFungibleData() const { return nonfungible_data; }
 
     // Send To Many
-    uint8_t getStmNumberOfReceivers() const {
-        return numberOfSTMReceivers;
-    }
+    // ** Returns number of STM receivers. */
+    uint8_t getStmNumberOfReceivers();
 
     /** Returns output valies. */
-    std::vector<std::tuple<uint8_t, uint64_t>> getStmOutputValues() const {
-        return outputValuesForSTM;
-    }
+    std::vector<std::tuple<uint8_t, uint64_t>> getStmOutputValues();
 
     /** Adds an address at position output. */
-    void addValidStmAddress(uint8_t output, const std::string& address) {
-        validOutputAddressesForSTM[output] = address;
-    }
+    void addValidStmAddress(size_t output, const std::string& address);
 
     /** Return an output address, if it's considered as valid Omni destination. */
-    bool getValidStmAddressAt(uint8_t output, std::string& addressOut) {
-        if (validOutputAddressesForSTM.find(output) != validOutputAddressesForSTM.end()) {
-            addressOut = validOutputAddressesForSTM[output];
-            return true;
-        }
-
-        addressOut.clear();
-        return false;
-    }
+    bool getValidStmAddressAt(uint8_t output, std::string& addressOut);
 
     /** Creates a new CMPTransaction object. */
     CMPTransaction()

--- a/src/omnicore/wallettxbuilder.cpp
+++ b/src/omnicore/wallettxbuilder.cpp
@@ -39,10 +39,10 @@
 using mastercore::AddressToPubKey;
 using mastercore::UseEncodingClassC;
 
-/** Creates and sends a transaction. */
+/** Creates and sends a transaction with multiple receivers. */
 int WalletTxBuilder(
         const std::string& senderAddress,
-        const std::string& receiverAddress,
+        const std::vector<std::string>& receiverAddresses,
         const std::string& redemptionAddress,
         int64_t referenceAmount,
         const std::vector<unsigned char>& payload,
@@ -85,10 +85,14 @@ int WalletTxBuilder(
     }
 
     // Then add a paytopubkeyhash output for the recipient (if needed) - note we do this last as we want this to be the highest vout
-    if (!receiverAddress.empty()) {
-        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(receiverAddress));
-        outputAmount += 0 < referenceAmount ? referenceAmount : OmniGetDustThreshold(scriptPubKey);
-        vecSend.push_back(std::make_pair(scriptPubKey, 0 < referenceAmount ? referenceAmount : OmniGetDustThreshold(scriptPubKey)));
+    if (!receiverAddresses.empty()) {
+        for (const std::string& receiverAddress : receiverAddresses) {
+            CScript scriptPubKey = GetScriptForDestination(DecodeDestination(receiverAddress));
+            if (!scriptPubKey.empty()) {
+                outputAmount += 0 < referenceAmount ? referenceAmount : OmniGetDustThreshold(scriptPubKey);
+                vecSend.push_back(std::make_pair(scriptPubKey, 0 < referenceAmount ? referenceAmount : OmniGetDustThreshold(scriptPubKey)));
+            }
+        }
     }
 
     // Create CRecipients for outputs
@@ -124,7 +128,7 @@ int WalletTxBuilder(
         }
 
         // Ask the wallet to create the transaction (note mining fee determined by Bitcoin Core params)
-        int nChangePosInOut = -1;
+        int nChangePosInOut = vecRecipients.size();
         wtxNew = iWallet->createTransaction(vecRecipients, coinControl, true /* sign */, nChangePosInOut, nFeeRet, strFailReason, false, minFee);
 
         // TX creation was a success or fee no longer incremeneintg
@@ -157,7 +161,86 @@ int WalletTxBuilder(
 #else
     return MP_ERR_WALLET_ACCESS;
 #endif
+}
 
+/** Creates and sends a transaction. */
+int WalletTxBuilder(
+        const std::string& senderAddress,
+        const std::string& receiverAddress,
+        const std::string& redemptionAddress,
+        int64_t referenceAmount,
+        const std::vector<unsigned char>& payload,
+        uint256& retTxid,
+        std::string& retRawTx,
+        bool commit,
+        interfaces::Wallet* iWallet,
+        CAmount minFee)
+{
+    std::vector<std::string> receiverAddresses;
+    if (!receiverAddress.empty()) {
+        receiverAddresses.push_back(receiverAddress);
+    }
+
+    return WalletTxBuilder(
+            senderAddress,
+            receiverAddresses,
+            redemptionAddress,
+            referenceAmount,
+            payload,
+            retTxid,
+            retRawTx,
+            commit,
+            iWallet,
+            minFee);
+}
+
+
+int GetDryPayloadOutputCount(
+        const std::string& senderAddress,
+        const std::string& redemptionAddress,
+        const std::vector<unsigned char>& payload,
+        interfaces::Wallet* iWallet)
+{
+#ifdef ENABLE_WALLET
+    if (!iWallet) {
+        return MP_ERR_WALLET_ACCESS;
+    }
+
+    // Determine the class to send the transaction via - default is Class C
+    int omniTxClass = OMNI_CLASS_C;
+    if (!UseEncodingClassC(payload.size() + 1 /* OP_RETURN */ + 2 /* pushdata opcodes */)) {
+        omniTxClass = OMNI_CLASS_B;
+    }
+
+    std::vector<std::pair<CScript, int64_t> > vecSend;
+    CAmount outputAmount{0};
+
+    // Encode the data outputs
+    switch (omniTxClass) {
+        case OMNI_CLASS_B: {
+            CPubKey redeemingPubKey;
+            const std::string& sAddress = redemptionAddress.empty() ? senderAddress : redemptionAddress;
+            if (!AddressToPubKey(iWallet, sAddress, redeemingPubKey)) {
+                return MP_REDEMP_BAD_VALIDATION;
+            }
+            if (!OmniCore_Encode_ClassB(senderAddress, redeemingPubKey, payload, vecSend, &outputAmount)) {
+                return MP_ENCODING_ERROR;
+            }
+            break;
+        }
+        case OMNI_CLASS_C: {
+            if(!OmniCore_Encode_ClassC(payload, vecSend)) {
+                return MP_ENCODING_ERROR;
+            }
+            break;
+        }
+    }
+
+    return vecSend.size();
+
+#else
+    return MP_ERR_WALLET_ACCESS;
+#endif
 }
 
 #ifdef ENABLE_WALLET

--- a/src/omnicore/wallettxbuilder.h
+++ b/src/omnicore/wallettxbuilder.h
@@ -17,6 +17,7 @@ class Wallet;
 
 #include <stdint.h>
 #include <string>
+#include <tuple>
 #include <vector>
 
 /**
@@ -32,7 +33,31 @@ int WalletTxBuilder(
         std::string& retRawTx,
         bool commit,
         interfaces::Wallet* iWallet = nullptr,
-        CAmount min_fee = 0);
+        CAmount minFee = 0);
+
+/**
+ * Creates and sends a transaction with multiple receivers.
+ */
+int WalletTxBuilder(
+        const std::string& senderAddress,
+        const std::vector<std::string>& receiverAddresses,
+        const std::string& redemptionAddress,
+        int64_t referenceAmount,
+        const std::vector<unsigned char>& payload,
+        uint256& retTxid,
+        std::string& retRawTx,
+        bool commit,
+        interfaces::Wallet* iWallet = nullptr,
+        CAmount minFee = 0);
+
+/**
+ * Simulates the creation of a payload to count the required outputs.
+ */
+int GetDryPayloadOutputCount(
+        const std::string& senderAddress,
+        const std::string& redemptionAddress,
+        const std::vector<unsigned char>& payload,
+        interfaces::Wallet* iWallet);
 
 #ifdef ENABLE_WALLET
 /**

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -516,6 +516,7 @@ std::string TXHistoryDialog::shrinkTxType(int txType, bool *fundsMoved)
         case MSC_TYPE_RESTRICTED_SEND: displayType = "Rest. Send"; break;
         case MSC_TYPE_SEND_TO_OWNERS: displayType = "Send To Owners"; break;
         case MSC_TYPE_SEND_ALL: displayType = "Send All"; break;
+        case MSC_TYPE_SEND_TO_MANY: displayType = "Send To Many"; break;
         case MSC_TYPE_SAVINGS_MARK: displayType = "Mark Savings"; *fundsMoved = false; break;
         case MSC_TYPE_SAVINGS_COMPROMISED: ; displayType = "Lock Savings"; break;
         case MSC_TYPE_RATELIMITED_MARK: displayType = "Rate Limit"; break;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -228,6 +228,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_sendsto", 1, "propertyid" },
     { "omni_sendsto", 4, "distributionproperty" },
     { "omni_sendall", 2, "ecosystem" },
+    { "omni_sendtomany", 1, "propertyid" },
+    { "omni_sendtomany", 2, "mapping" },
     { "omni_sendtrade", 1, "propertyidforsale" },
     { "omni_sendtrade", 3, "propertiddesired" },
     { "omni_sendcanceltradesbyprice", 1, "propertyidforsale" },
@@ -296,6 +298,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     /* Omni Core - payload creation */
     { "omni_createpayload_simplesend", 0, "propertyid" },
     { "omni_createpayload_sendall", 0, "ecosystem" },
+    { "omni_createpayload_sendtomany", 0, "propertyid" },
+    { "omni_createpayload_sendtomany", 1, "mapping" },
     { "omni_createpayload_dexsell", 0, "propertyidforsale" },
     { "omni_createpayload_dexsell", 3, "paymentwindow" },
     { "omni_createpayload_dexsell", 5, "action" },


### PR DESCRIPTION
This change adds the ability to construct and send send-to-many transactions.

**What can you do?**

- Send send-to-many transactions
- Construct payloads for send-to-many transactions
- Parse and retrieve data of send-to-many transactions
- Balances are updated, when sending send-to-many transactions

**What's new?**

A new transaction type 7 is introduced to transfer multiple tokens of one property id to multiple receivers. [Check out this link for a more detailed view.](https://gist.github.com/dexX7/1138fd1ea084a9db56798e9bce50d0ef)

Two new RPCs were added to facilitate the new feature:

- [omni_sendtomany](https://github.com/OmniLayer/omnicore/blob/develop/src/omnicore/doc/rpc-api.md#omni_sendtomany) to send send-to-many transactions via the user's wallet.
- [omni_createpayload_sendtomany](https://github.com/OmniLayer/omnicore/blob/develop/src/omnicore/doc/rpc-api.md#omni_createpayload_sendtomany) to construct the plain payload. Note however, the rest of the transaction, in particular actually adding outputs for each receiver is still necessary.

**What else is affected?**

- [omni_gettransaction](https://github.com/OmniLayer/omnicore/blob/develop/src/omnicore/doc/rpc-api.md#omni_gettransaction) works! The new fields `receivers`, which provides a list for every receiver, and `totalamount` are most relevant for this transaction. See the examples below.
- The change output of Omni transactions is no longer random, but added to the end of the transaction.
- The transaction history window of the Qt client properly shows send to many transactions.

For more RPC examples, please visit [this link](https://gist.github.com/dexX7/ec0ab2b668db320b9f8534147add19bf)

---

**Example 1:**

You are a low level developer and want to manually craft transactions, then you can use the [raw transaction interface](https://github.com/OmniLayer/omnicore/blob/develop/src/omnicore/doc/rpc-api.md#raw-transactions) of Omni Core. To construct the payload for a send-to-many transaction:

```
omni_createpayload_sendtomany 31 '[{"output": 2, "amount": "10.5"}, {"output": 3, "amount": "0.5"}, {"output": 5, "amount": "15.0"}]'
```
```
000000070000001f0302000000003e95ba80030000000002faf080050000000059682f00
```

---

**Example 2:**

You have tokens in your wallet, which you want to transfer to two receivers, three units to one, five units to the other one:

```
omni_sendtomany "2N9UopnCBgbC6wAjMaiqrBZjmgNFiZccY7C" 3 '[{"address": "mnM5bS3qQTxZSHkgpp2LDcKYL5thWtqCD6", "amount": "3"}, {"address": "2N9UopnCBgbC6wAjMaiqrBZjmgNFiZccY7C", "amount": "5"}]'
```
```
55d9f3eb56a5de5afef6b1d5dcdc2300d26d0aafcacbbfe387cba0983e0644fa
```

---

**Example 3:**

To then retrieve information about the transaction, you can use [omni_gettransaction](https://github.com/OmniLayer/omnicore/blob/develop/src/omnicore/doc/rpc-api.md#omni_gettransaction), which has the new fields `receivers` and `totalamount`.

```
omni_gettransaction 55d9f3eb56a5de5afef6b1d5dcdc2300d26d0aafcacbbfe387cba0983e0644fa
```
```
{
  "txid": "55d9f3eb56a5de5afef6b1d5dcdc2300d26d0aafcacbbfe387cba0983e0644fa",
  "fee": "0.00002420",
  "sendingaddress": "2N9UopnCBgbC6wAjMaiqrBZjmgNFiZccY7C",
  "ismine": true,
  "version": 0,
  "type_int": 7,
  "type": "Send To Many",
  "propertyid": 3,
  "divisible": false,
  "receivers": [
    {
      "output": 1,
      "address": "mnM5bS3qQTxZSHkgpp2LDcKYL5thWtqCD6",
      "amount": "3"
    },
    {
      "output": 2,
      "address": "2N9UopnCBgbC6wAjMaiqrBZjmgNFiZccY7C",
      "amount": "5"
    }
  ],
  "totalamount": "8",
  "valid": false,
  "invalidreason": "Not enough funds in user address",
  "blockhash": "1ca23be7bee5dc915e76292e78aa1b42d75e4a3819d91871e69b24d292930687",
  "blocktime": 1648120618,
  "positioninblock": 2,
  "block": 112,
  "confirmations": 1
}
```

Please note, as mentioned above, the new transaction type doesn't affect consensus and balances, but can be used for testing.

---

**Example 4:**

Say you are a developer again and want to take a look at the above created transaction on a Bitcoin protocol level, then:

```
getrawtransaction 55d9f3eb56a5de5afef6b1d5dcdc2300d26d0aafcacbbfe387cba0983e0644fa 1
```
```
{
  "txid": "55d9f3eb56a5de5afef6b1d5dcdc2300d26d0aafcacbbfe387cba0983e0644fa",
  "hash": "d74b35b379f4796c918cc2475d4942f0a2e3caf9ae345488f56bac92384145ef",
  "version": 2,
  "size": 323,
  "vsize": 242,
  "weight": 965,
  "locktime": 0,
  "vin": [
    {
      "txid": "2a89b07484fe8aa2b3038d32e2888b9b30de4553e23136e324502a0f049ed6b1",
      "vout": 3,
      "scriptSig": {
        "asm": "00149cae6190b0802e646e93b9006b7239b036002ca0",
        "hex": "1600149cae6190b0802e646e93b9006b7239b036002ca0"
      },
      "txinwitness": [
        "30440220651224e5c625d8163cb6e2971f58b191109b5dc02fb821694ada765ab424b23602206cd8787258b3538f78f157ac6d1d520a21d3e1febda9477d77120e171d0225a301",
        "02d0c8e0f374949dae9c0855d56af23b4d64c3c128fe336cd36a5270b2898a9964"
      ],
      "sequence": 4294967294
    }
  ],
  "vout": [
    {
      "value": 0.00000000,
      "n": 0,
      "scriptPubKey": {
        "asm": "OP_RETURN 6f6d6e69000000070000000302010000000000000003020000000000000005",
        "hex": "6a1f6f6d6e69000000070000000302010000000000000003020000000000000005",
        "type": "nulldata"
      }
    },
    {
      "value": 0.00000546,
      "n": 1,
      "scriptPubKey": {
        "asm": "OP_DUP OP_HASH160 4aead0759e716330b6c76ffaa4be6d27124efcef OP_EQUALVERIFY OP_CHECKSIG",
        "hex": "76a9144aead0759e716330b6c76ffaa4be6d27124efcef88ac",
        "reqSigs": 1,
        "type": "pubkeyhash",
        "addresses": [
          "mnM5bS3qQTxZSHkgpp2LDcKYL5thWtqCD6"
        ]
      }
    },
    {
      "value": 0.00000540,
      "n": 2,
      "scriptPubKey": {
        "asm": "OP_HASH160 b213aa3f6789fa2dca904d41d2bc4877d8437aa4 OP_EQUAL",
        "hex": "a914b213aa3f6789fa2dca904d41d2bc4877d8437aa487",
        "reqSigs": 1,
        "type": "scripthash",
        "addresses": [
          "2N9UopnCBgbC6wAjMaiqrBZjmgNFiZccY7C"
        ]
      }
    },
    {
      "value": 4.99981210,
      "n": 3,
      "scriptPubKey": {
        "asm": "OP_HASH160 b213aa3f6789fa2dca904d41d2bc4877d8437aa4 OP_EQUAL",
        "hex": "a914b213aa3f6789fa2dca904d41d2bc4877d8437aa487",
        "reqSigs": 1,
        "type": "scripthash",
        "addresses": [
          "2N9UopnCBgbC6wAjMaiqrBZjmgNFiZccY7C"
        ]
      }
    }
  ],
  "hex": "02000000000101b1d69e040f2a5024e33631e25345de309b8b88e2328d03b3a28afe8474b0892a03000000171600149cae6190b0802e646e93b9006b7239b036002ca0feffffff040000000000000000216a1f6f6d6e6900000007000000030201000000000000000302000000000000000522020000000000001976a9144aead0759e716330b6c76ffaa4be6d27124efcef88ac1c0200000000000017a914b213aa3f6789fa2dca904d41d2bc4877d8437aa4879a1bcd1d0000000017a914b213aa3f6789fa2dca904d41d2bc4877d8437aa487024730440220651224e5c625d8163cb6e2971f58b191109b5dc02fb821694ada765ab424b23602206cd8787258b3538f78f157ac6d1d520a21d3e1febda9477d77120e171d0225a3012102d0c8e0f374949dae9c0855d56af23b4d64c3c128fe336cd36a5270b2898a996400000000",
  "blockhash": "1ca23be7bee5dc915e76292e78aa1b42d75e4a3819d91871e69b24d292930687",
  "confirmations": 1,
  "time": 1648120618,
  "blocktime": 1648120618
}
```

The above examples were created locally in regtest mode.
