### PR TITLE
rpc-api.md: omni_listtransactions 1st param is address

### DIFF
--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -1310,7 +1310,7 @@ List wallet transactions, optionally filtered by an address and block boundaries
 
 | Name                | Type    | Presence | Description                                                                                  |
 |---------------------|---------|----------|----------------------------------------------------------------------------------------------|
-| `txid`              | string  | optional | address filter (default: `"*"`)                                                              |
+| `address`           | string  | optional | address filter (default: `"*"`)                                                              |
 | `count`             | number  | optional | show at most n transactions (default: `10`)                                                  |
 | `skip`              | number  | optional | skip the first n transactions (default: `0`)                                                 |
 | `startblock`        | number  | optional | first block to begin the search (default: `0`)                                               |


### PR DESCRIPTION
Fix minor documentation error in `omni_listtransactions`

Change name of first parameter to `address` to match output of `help omni_listtransactions`