### PR TITLE
Add blocktime to MetaDEx RPCs

### DIFF
--- a/src/omnicore/dbtradelist.cpp
+++ b/src/omnicore/dbtradelist.cpp
@@ -5,9 +5,12 @@
 #include <omnicore/sp.h>
 
 #include <amount.h>
+#include <chain.h>
+#include <chainparams.h>
 #include <fs.h>
 #include <uint256.h>
 #include <util/strencodings.h>
+#include <validation.h>
 #include <tinyformat.h>
 
 #include <univalue.h>
@@ -170,6 +173,10 @@ bool CMPTradeList::getMatchingTrades(const uint256& txid, uint32_t propertyId, U
         UniValue trade(UniValue::VOBJ);
         trade.pushKV("txid", matchTxid);
         trade.pushKV("block", blockNum);
+        CBlockIndex* pBlockIndex = ::ChainActive()[blockNum];
+        if (pBlockIndex != nullptr) {
+            trade.pushKV("blocktime", pBlockIndex->GetBlockTime());
+        }
         if (prop1 == propertyId) {
             trade.pushKV("address", address1);
             trade.pushKV("amountsold", strAmount1);
@@ -295,6 +302,10 @@ void CMPTradeList::getTradesForPair(uint32_t propertyIdSideA, uint32_t propertyI
 
         UniValue trade(UniValue::VOBJ);
         trade.pushKV("block", blockNum);
+        CBlockIndex* pBlockIndex = ::ChainActive()[blockNum];
+        if (pBlockIndex != nullptr) {
+            trade.pushKV("blocktime", pBlockIndex->GetBlockTime());
+        }
         trade.pushKV("unitprice", unitPriceStr);
         trade.pushKV("inverseprice", inversePriceStr);
         trade.pushKV("sellertxid", sellerTxid.GetHex());

--- a/src/omnicore/doc/rpc-api.md
+++ b/src/omnicore/doc/rpc-api.md
@@ -1775,6 +1775,7 @@ Get detailed information and trade matches for orders on the distributed token e
     {
       "txid" : "hash",                              // (string) the hash of the transaction that was matched against
       "block" : nnnnnn,                             // (number) the index of the block that contains this transaction
+      "blocktime" : nnnnnnnnnn,                     // (number) the timestamp of the block that contains the match
       "address" : "address",                        // (string) the Bitcoin address of the other trader
       "amountsold" : "n.nnnnnnnn",                  // (string) the number of tokens sold in this trade
       "amountreceived" : "n.nnnnnnnn"               // (string) the number of tokens traded in exchange
@@ -1851,6 +1852,7 @@ Retrieves the history of trades on the distributed token exchange for the specif
 [                                     // (array of JSON objects)
   {
     "block" : nnnnnn,                     // (number) the index of the block that contains the trade match
+    "blocktime" : nnnnnnnnnn,             // (number) the timestamp of the block that contains the match
     "unitprice" : "n.nnnnnnnnnnn..." ,    // (string) the unit price used to execute this trade (received/sold)
     "inverseprice" : "n.nnnnnnnnnnn...",  // (string) the inverse unit price (sold/received)
     "sellertxid" : "hash",                // (string) the hash of the transaction of the seller
@@ -1912,6 +1914,7 @@ Retrieves the history of orders on the distributed exchange for the supplied add
       {
         "txid" : "hash",                              // (string) the hash of the transaction that was matched against
         "block" : nnnnnn,                             // (number) the index of the block that contains this transaction
+        "blocktime" : nnnnnnnnnn,                     // (number) the timestamp of the block that contains the match
         "address" : "address",                        // (string) the Bitcoin address of the other trader
         "amountsold" : "n.nnnnnnnn",                  // (string) the number of tokens sold in this trade
         "amountreceived" : "n.nnnnnnnn"               // (string) the number of tokens traded in exchange

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -1966,6 +1966,7 @@ static UniValue omni_gettradehistoryforaddress(const JSONRPCRequest& request)
                        {
                            {RPCResult::Type::STR_HEX, "txid", "the hash of the transaction that was matched against"},
                            {RPCResult::Type::NUM, "block", "the index of the block that contains this transaction"},
+                           {RPCResult::Type::NUM, "blocktime", "the timestamp of the block that contains the match"},
                            {RPCResult::Type::STR, "address", "the Bitcoin address of the other trader"},
                            {RPCResult::Type::STR_AMOUNT, "amountsold", "the number of tokens sold in this trade"},
                            {RPCResult::Type::STR_AMOUNT, "amountreceived", "the number of tokens traded in exchange"},
@@ -2027,6 +2028,7 @@ static UniValue omni_gettradehistoryforpair(const JSONRPCRequest& request)
                {RPCResult::Type::OBJ, "", "",
                {
                    {RPCResult::Type::NUM, "block", "the index of the block that contains the trade match"},
+                   {RPCResult::Type::NUM, "blocktime", "the timestamp of the block that contains the match"},
                    {RPCResult::Type::STR_AMOUNT, "unitprice", "the unit price used to execute this trade (received/sold)"},
                    {RPCResult::Type::STR_AMOUNT, "inverseprice", "the inverse unit price (sold/received)"},
                    {RPCResult::Type::STR_HEX, "sellertxid", "the hash of the transaction of the seller"},
@@ -2730,6 +2732,7 @@ static UniValue omni_gettrade(const JSONRPCRequest& request)
                    {
                        {RPCResult::Type::STR_HEX, "txid", "the hash of the transaction that was matched against"},
                        {RPCResult::Type::NUM, "block", "the index of the block that contains this transaction"},
+                       {RPCResult::Type::NUM, "blocktime", "the timestamp of the block that contains the match"},
                        {RPCResult::Type::STR, "address", "the Bitcoin address of the other trader"},
                        {RPCResult::Type::STR_AMOUNT, "amountsold", "the number of tokens sold in this trade"},
                        {RPCResult::Type::STR_AMOUNT, "amountreceived", "the number of tokens traded in exchange"},


### PR DESCRIPTION
This pull request adds `blocktime` to `omni_gettrade`, `omni_gettradehistoryforaddress` and `omni_gettradehistoryforpair`.

This resolves #1264.