### PR TITLE
Add option to skip storing state of earlier blocks during sync

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -586,6 +586,7 @@ void SetupServerArgs()
     gArgs.AddArg("-omnitxcache", "The maximum number of transactions in the input transaction cache (default: 500000)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omniprogressfrequency", "Time in seconds after which the initial scanning progress is reported (default: 30)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omniseedblockfilter", "Set skipping of blocks without Omni transactions during initial scan (default: 1)", false, OptionsCategory::OMNI);
+    gArgs.AddArg("-omniskipstoringstate", "Don't store state during initial synchronization until block n (faster, but may have to restart syncing after a shutdown)(default: 622000)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omnilogfile", "The path of the log file (default: omnicore.log)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omnidebug=<category>", "Enable or disable log categories, can be \"all\" or \"none\"", false, OptionsCategory::OMNI);
     gArgs.AddArg("-autocommit", "Enable or disable broadcasting of transactions, when creating transactions (default: 1)", false, OptionsCategory::OMNI);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -586,7 +586,7 @@ void SetupServerArgs()
     gArgs.AddArg("-omnitxcache", "The maximum number of transactions in the input transaction cache (default: 500000)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omniprogressfrequency", "Time in seconds after which the initial scanning progress is reported (default: 30)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omniseedblockfilter", "Set skipping of blocks without Omni transactions during initial scan (default: 1)", false, OptionsCategory::OMNI);
-    gArgs.AddArg("-omniskipstoringstate", "Don't store state during initial synchronization until block n (faster, but may have to restart syncing after a shutdown)(default: 622000)", false, OptionsCategory::OMNI);
+    gArgs.AddArg("-omniskipstoringstate", "Don't store state during initial synchronization until block n (faster, but may have to restart syncing after a shutdown)(default: 770000)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omnilogfile", "The path of the log file (default: omnicore.log)", false, OptionsCategory::OMNI);
     gArgs.AddArg("-omnidebug=<category>", "Enable or disable log categories, can be \"all\" or \"none\"", false, OptionsCategory::OMNI);
     gArgs.AddArg("-autocommit", "Enable or disable broadcasting of transactions, when creating transactions (default: 1)", false, OptionsCategory::OMNI);

--- a/src/omnicore/doc/configuration.md
+++ b/src/omnicore/doc/configuration.md
@@ -43,6 +43,7 @@ More information about the general configuration and Bitcoin Core specific optio
 | `omnitxcache`                | number       | `500000`       | the maximum number of transactions in the input transaction cache               |
 | `omniprogressfrequency`      | number       | `30`           | time in seconds after which the initial scanning progress is reported           |
 | `omniseedblockfilter`        | boolean      | `1`            | set skipping of blocks without Omni transactions during initial scan            |
+| `omniskipstoringstate`       | number       | `622000`       | don't store state during initial synchronization until block n (faster, but may have to restart syncing after a shutdown) |
 | `omnishowblockconsensushash` | number       | `0`            | calculate and log the consensus hash for the specified block                    |
 | `experimental-btc-balances`  | boolean      | `0`            | maintain a full address index to query any Bitcoin balance                      |
 

--- a/src/omnicore/doc/configuration.md
+++ b/src/omnicore/doc/configuration.md
@@ -43,7 +43,7 @@ More information about the general configuration and Bitcoin Core specific optio
 | `omnitxcache`                | number       | `500000`       | the maximum number of transactions in the input transaction cache               |
 | `omniprogressfrequency`      | number       | `30`           | time in seconds after which the initial scanning progress is reported           |
 | `omniseedblockfilter`        | boolean      | `1`            | set skipping of blocks without Omni transactions during initial scan            |
-| `omniskipstoringstate`       | number       | `622000`       | don't store state during initial synchronization until block n (faster, but may have to restart syncing after a shutdown) |
+| `omniskipstoringstate`       | number       | `770000`       | don't store state during initial synchronization until block n (faster, but may have to restart syncing after a shutdown) |
 | `omnishowblockconsensushash` | number       | `0`            | calculate and log the consensus hash for the specified block                    |
 | `experimental-btc-balances`  | boolean      | `0`            | maintain a full address index to query any Bitcoin balance                      |
 

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -25,14 +25,14 @@ class Coin;
 #include <set>
 #include <unordered_map>
 
-// Keep the state of the last 50 blocks to roll back quickly
+// Keep the state of the last 100 blocks to roll back quickly
 // in case of a block reorganization
-int const MAX_STATE_HISTORY = 200;
+int const MAX_STATE_HISTORY = 100;
 // Also store the state every 5000 blocks to be able to recover
 // from a crash or shutdown during reparse more quickly
 int const STORE_EVERY_N_BLOCK = 5000;
 // Don't store the state every block on mainnet until block 622000
-// was reached
+// was reached, can be set with -omniskipstoringstate.
 int const DONT_STORE_MAINNET_STATE_UNTIL = 622000;
 
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -31,9 +31,9 @@ int const MAX_STATE_HISTORY = 100;
 // Also store the state every 5000 blocks to be able to recover
 // from a crash or shutdown during reparse more quickly
 int const STORE_EVERY_N_BLOCK = 5000;
-// Don't store the state every block on mainnet until block 622000
+// Don't store the state every block on mainnet until block 770000
 // was reached, can be set with -omniskipstoringstate.
-int const DONT_STORE_MAINNET_STATE_UNTIL = 622000;
+int const DONT_STORE_MAINNET_STATE_UNTIL = 770000;
 
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 

--- a/src/omnicore/persistence.cpp
+++ b/src/omnicore/persistence.cpp
@@ -507,8 +507,10 @@ static void prune_state_files(const CBlockIndex* topIndex)
  */
 static int GetWrapModeHeight()
 {
+    static int nSkipBlocksUntil = gArgs.GetArg("-omniskipstoringstate", DONT_STORE_MAINNET_STATE_UNTIL);
+    
     if (MainNet()) {
-        return DONT_STORE_MAINNET_STATE_UNTIL;
+        return nSkipBlocksUntil;
     } else {
         return 0;
     }


### PR DESCRIPTION
The new configuration option "-omniskipstoringstate" allows to set a block until which state is only stored to disk every 5000 blocks.

If using this option with a more recent block, this can speed up the initial synchronization/parsing of the Omni state. However, if there is an expected or unexpected shutdown before reaching this point, the most frequent state will be lost and has to be reparsed.