### PR TITLE
Add NFT rollback data in case of reorg

### DIFF
--- a/src/omnicore/dbbase.cpp
+++ b/src/omnicore/dbbase.cpp
@@ -1,5 +1,5 @@
-#include <omnicore/dbbase.h>
 
+#include <omnicore/dbbase.h>
 #include <omnicore/log.h>
 
 #include <fs.h>
@@ -36,7 +36,7 @@ void CDBBase::Clear()
     CDBaseIterator it{NewIterator()};
 
     for (; it; ++it) {
-        batch.Delete(it->key());
+        batch.Delete(it.Key());
         ++n;
     }
 

--- a/src/omnicore/dbtradelist.cpp
+++ b/src/omnicore/dbtradelist.cpp
@@ -173,8 +173,7 @@ bool CMPTradeList::getMatchingTrades(const uint256& txid, uint32_t propertyId, U
         UniValue trade(UniValue::VOBJ);
         trade.pushKV("txid", matchTxid);
         trade.pushKV("block", blockNum);
-        CBlockIndex* pBlockIndex = ::ChainActive()[blockNum];
-        if (pBlockIndex != nullptr) {
+        if (auto pBlockIndex = WITH_LOCK(cs_main, return ::ChainActive()[blockNum])) {
             trade.pushKV("blocktime", pBlockIndex->GetBlockTime());
         }
         if (prop1 == propertyId) {
@@ -302,8 +301,7 @@ void CMPTradeList::getTradesForPair(uint32_t propertyIdSideA, uint32_t propertyI
 
         UniValue trade(UniValue::VOBJ);
         trade.pushKV("block", blockNum);
-        CBlockIndex* pBlockIndex = ::ChainActive()[blockNum];
-        if (pBlockIndex != nullptr) {
+        if (auto pBlockIndex = WITH_LOCK(cs_main, return ::ChainActive()[blockNum])) {
             trade.pushKV("blocktime", pBlockIndex->GetBlockTime());
         }
         trade.pushKV("unitprice", unitPriceStr);

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -407,8 +407,7 @@ int64_t CMPMetaDEx::getAmountToFill() const
 
 int64_t CMPMetaDEx::getBlockTime() const
 {
-    CBlockIndex* pblockindex = ::ChainActive()[block];
-    return pblockindex->GetBlockTime();
+    return WITH_LOCK(cs_main, return ::ChainActive()[block]->GetBlockTime());
 }
 
 void CMPMetaDEx::setAmountRemaining(int64_t amount, const std::string& label)

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -1659,6 +1659,7 @@ void RewindDBsAndState(int nHeight, int nBlockPrev = 0, bool fInitialParse = fal
         pDbStoList->deleteAboveBlock(nHeight);
         pDbFeeCache->RollBackCache(nHeight);
         pDbFeeHistory->RollBackHistory(nHeight);
+        pDbNFT->RollBackAboveBlock(nHeight);
         reorgRecoveryMaxHeight = 0;
 
         nWaterlineBlock = ConsensusParams().GENESIS_BLOCK - 1;
@@ -2129,7 +2130,8 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
         }
 
         // request nftdb sanity check
-        pDbNFT->SanityCheck();
+        bool sanityCheck = true;
+        pDbNFT->WriteBlockCache(nBlockNow, sanityCheck);
 
         // request checkpoint verification
         checkpointValid = VerifyCheckpoint(nBlockNow, pBlockIndex->GetBlockHash());

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -2009,6 +2009,12 @@ static UniValue omni_gettradehistoryforaddress(const JSONRPCRequest& request)
         pDbTradeList->getTradesForAddress(address, vecTransactions, propertyId);
     }
 
+#ifdef ENABLE_WALLET
+    if (wallet && !vecTransactions.empty()) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+#endif
+
     // Populate the address trade history into JSON objects until we have processed count transactions
     UniValue response(UniValue::VARR);
     uint32_t processed = 0;
@@ -2335,6 +2341,12 @@ static UniValue omni_gettransaction(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[0], "txid");
 
+#ifdef ENABLE_WALLET
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+#endif
+
     UniValue txobj(UniValue::VOBJ);
     int populateResult = populateRPCTransactionObject(hash, txobj, "", false, "", pWallet.get());
     if (populateResult != 0) PopulateFailure(populateResult);
@@ -2399,6 +2411,10 @@ static UniValue omni_listtransactions(const JSONRPCRequest& request)
     int64_t nEndBlock = 999999999;
     if (request.params.size() > 4) nEndBlock = request.params[4].get_int64();
     if (nEndBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative end block");
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // obtain a sorted list of Omni layer wallet transactions (including STO receipts and pending)
     std::map<std::string,uint256> walletTransactions = FetchWalletOmniTransactions(*pWallet, nFrom+nCount, nStartBlock, nEndBlock);
@@ -2693,6 +2709,12 @@ static UniValue omni_getsto(const JSONRPCRequest& request)
     std::string filterAddress;
     if (request.params.size() > 1) filterAddress = ParseAddressOrWildcard(request.params[1]);
 
+#ifdef ENABLE_WALLET
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+#endif
+
     UniValue txobj(UniValue::VOBJ);
     int populateResult = populateRPCTransactionObject(hash, txobj, "", true, filterAddress, pWallet.get());
     if (populateResult != 0) PopulateFailure(populateResult);
@@ -2759,6 +2781,12 @@ static UniValue omni_gettrade(const JSONRPCRequest& request)
     }.Check(request);
 
     uint256 hash = ParseHashV(request.params[0], "txid");
+
+#ifdef ENABLE_WALLET
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+#endif
 
     UniValue txobj(UniValue::VOBJ);
     int populateResult = populateRPCTransactionObject(hash, txobj, "", true, "", pWallet.get());

--- a/src/omnicore/rpcrawtx.cpp
+++ b/src/omnicore/rpcrawtx.cpp
@@ -15,6 +15,9 @@
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <wallet/rpcwallet.h>
+#ifdef ENABLE_WALLET
+#include <wallet/wallet.h>
+#endif
 
 #include <univalue.h>
 
@@ -93,6 +96,12 @@ static UniValue omni_decodetransaction(const JSONRPCRequest& request)
     if (request.params.size() > 2) {
         blockHeight = request.params[2].get_int();
     }
+
+#ifdef ENABLE_WALLET
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+#endif
 
     UniValue txObj(UniValue::VOBJ);
     int populateResult = -3331;

--- a/src/omnicore/rpctx.cpp
+++ b/src/omnicore/rpctx.cpp
@@ -36,9 +36,7 @@
 #include <stdexcept>
 #include <string>
 
-using std::runtime_error;
 using namespace mastercore;
-
 
 static UniValue omni_funded_send(const JSONRPCRequest& request)
 {
@@ -77,6 +75,10 @@ static UniValue omni_funded_send(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SimpleSend(propertyId, amount);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // create the raw transaction
     uint256 retTxid;
@@ -120,6 +122,10 @@ static UniValue omni_funded_sendall(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SendAll(ecosystem);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // create the raw transaction
     uint256 retTxid;
     int result = CreateFundedTransaction(fromAddress, toAddress, feeAddress, payload, retTxid, pwallet.get(), *g_rpc_node);
@@ -158,6 +164,10 @@ static UniValue omni_sendrawtx(const JSONRPCRequest& request)
     std::string toAddress = (request.params.size() > 2) ? ParseAddressOrEmpty(request.params[2]): "";
     std::string redeemAddress = (request.params.size() > 3) ? ParseAddressOrEmpty(request.params[3]): "";
     int64_t referenceAmount = (request.params.size() > 4) ? ParseAmount(request.params[4], true): 0;
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     //some sanity checking of the data supplied?
     uint256 newTX;
@@ -216,6 +226,10 @@ static UniValue omni_send(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SimpleSend(propertyId, amount);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -269,6 +283,10 @@ static UniValue omni_sendall(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SendAll(ecosystem);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -335,6 +353,10 @@ static UniValue omni_sendnonfungible(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SendNonFungible(propertyId, tokenStart, tokenEnd);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -412,6 +434,10 @@ static UniValue omni_setnonfungibledata(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SetNonFungibleData(propertyId, tokenStart, tokenEnd, issuer, data);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -536,6 +562,10 @@ static UniValue omni_sendtomany(const JSONRPCRequest& request)
         propertyId,
         outputValues);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -624,6 +654,10 @@ static UniValue omni_senddexsell(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_DExSell(propertyIdForSale, amountForSale, amountDesired, paymentWindow, minAcceptFee, action);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -696,6 +730,10 @@ static UniValue omni_senddexaccept(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_DExAccept(propertyId, amount);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -761,6 +799,10 @@ static UniValue omni_sendnewdexorder(const JSONRPCRequest& request)
         paymentWindow,
         minAcceptFee,
         action);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -828,6 +870,10 @@ static UniValue omni_sendupdatedexorder(const JSONRPCRequest& request)
         minAcceptFee,
         action);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -888,6 +934,10 @@ static UniValue omni_sendcanceldexorder(const JSONRPCRequest& request)
         paymentWindow,
         minAcceptFee,
         action);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -972,6 +1022,10 @@ static UniValue omni_senddexpay(const JSONRPCRequest& request)
         }
     }
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     uint256 txid;
     int result = CreateDExTransaction(pwallet.get(), buyerAddress, sellerAddress, nAmount, txid);
 
@@ -1039,6 +1093,10 @@ static UniValue omni_sendissuancecrowdsale(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceVariable(ecosystem, type, previousId, category, subcategory, name, url, data, propertyIdDesired, numTokens, deadline, earlyBonus, issuerPercentage);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -1101,6 +1159,10 @@ static UniValue omni_sendissuancefixed(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceFixed(ecosystem, type, previousId, category, subcategory, name, url, data, amount);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1167,6 +1229,10 @@ static UniValue omni_sendissuancemanaged(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_IssuanceManaged(ecosystem, type, previousId, category, subcategory, name, url, data);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -1219,6 +1285,10 @@ static UniValue omni_sendsto(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_SendToOwners(propertyId, amount, distributionPropertyId);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1276,6 +1346,10 @@ static UniValue omni_sendgrant(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_Grant(propertyId, amount, info);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -1329,6 +1403,10 @@ static UniValue omni_sendrevoke(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_Revoke(propertyId, amount, memo);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -1378,6 +1456,10 @@ static UniValue omni_sendclosecrowdsale(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_CloseCrowdsale(propertyId);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1436,6 +1518,10 @@ static UniValue omni_sendtrade(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExTrade(propertyIdForSale, amountForSale, propertyIdDesired, amountDesired);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -1493,6 +1579,10 @@ static UniValue omni_sendcanceltradesbyprice(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExCancelPrice(propertyIdForSale, amountForSale, propertyIdDesired, amountDesired);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1553,6 +1643,10 @@ static UniValue omni_sendcanceltradesbypair(const JSONRPCRequest& request)
     std::string rawHex;
     int result = WalletTxBuilder(fromAddress, "", "", 0, payload, txid, rawHex, autoCommit, pwallet.get());
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // check error and return the txid (or raw hex depending on autocommit)
     if (result != 0) {
         throw JSONRPCError(result, error_str(result));
@@ -1595,6 +1689,10 @@ static UniValue omni_sendcancelalltrades(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_MetaDExCancelEcosystem(ecosystem);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1647,6 +1745,10 @@ static UniValue omni_sendchangeissuer(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_ChangeIssuer(propertyId);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -1695,6 +1797,10 @@ static UniValue omni_sendenablefreezing(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_EnableFreezing(propertyId);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1745,6 +1851,10 @@ static UniValue omni_senddisablefreezing(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_DisableFreezing(propertyId);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1799,6 +1909,10 @@ static UniValue omni_sendfreeze(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_FreezeTokens(propertyId, amount, refAddress);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     // Note: no ref address is sent to WalletTxBuilder as the ref address is contained within the payload
@@ -1855,6 +1969,10 @@ static UniValue omni_sendunfreeze(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_UnfreezeTokens(propertyId, amount, refAddress);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     // Note: no ref address is sent to WalletTxBuilder as the ref address is contained within the payload
     uint256 txid;
@@ -1906,6 +2024,10 @@ static UniValue omni_sendadddelegate(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_AddDelegate(propertyId);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -1960,6 +2082,10 @@ static UniValue omni_sendremovedelegate(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_RemoveDelegate(propertyId);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -2008,6 +2134,10 @@ static UniValue omni_sendanydata(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_AnyData(data);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -2058,6 +2188,10 @@ static UniValue omni_sendactivation(const JSONRPCRequest& request)
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_ActivateFeature(featureId, activationBlock, minClientVersion);
 
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
+
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
     std::string rawHex;
@@ -2102,6 +2236,10 @@ static UniValue omni_senddeactivation(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_DeactivateFeature(featureId);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;
@@ -2159,6 +2297,10 @@ static UniValue omni_sendalert(const JSONRPCRequest& request)
 
     // create a payload for the transaction
     std::vector<unsigned char> payload = CreatePayload_OmniCoreAlert(alertType, expiryValue, alertMessage);
+
+    if (wallet) {
+        wallet->BlockUntilSyncedToCurrentChain();
+    }
 
     // request the wallet build the transaction (and if needed commit it)
     uint256 txid;

--- a/src/omnicore/test/nftdb_tests.cpp
+++ b/src/omnicore/test/nftdb_tests.cpp
@@ -118,4 +118,58 @@ BOOST_AUTO_TEST_CASE(nftdb_test_sequence)
     BOOST_CHECK_EQUAL("Bob", UITDb->GetNonFungibleTokenValueInRange(50, 2300, 2400));
 }
 
+BOOST_AUTO_TEST_CASE(nftdb_test_rollback)
+{
+    LOCK(cs_tally);
+    std::unique_ptr<CMPNonFungibleTokensDB> UITDb{new CMPNonFungibleTokensDB(GetDataDir() / "OMNI_nftdb_rollback", true)};
+
+    std::pair<int64_t, int64_t> testA = UITDb->CreateNonFungibleTokens(50, 1000, "David", "");
+    BOOST_CHECK_EQUAL(1, testA.first);
+    BOOST_CHECK_EQUAL(1000, testA.second);
+    BOOST_CHECK_EQUAL("David", UITDb->GetNonFungibleTokenValueInRange(50, 1, 1000));
+
+    UITDb->WriteBlockCache(1);
+
+    BOOST_CHECK(UITDb->MoveNonFungibleTokens(50, 1, 1000, "David", "Charles"));
+    BOOST_CHECK_EQUAL("Charles", UITDb->GetNonFungibleTokenValueInRange(50, 1, 1000));
+
+    UITDb->WriteBlockCache(2);
+
+    // rollback above block 2
+    UITDb->RollBackAboveBlock(2);
+    BOOST_CHECK_EQUAL("David", UITDb->GetNonFungibleTokenValueInRange(50, 1, 1000));
+
+    std::pair<int64_t, int64_t> testB = UITDb->CreateNonFungibleTokens(50, 1000, "Alice", "");
+    BOOST_CHECK_EQUAL(1001, testB.first);
+    BOOST_CHECK_EQUAL(2000, testB.second);
+    BOOST_CHECK_EQUAL("Alice", UITDb->GetNonFungibleTokenValueInRange(50, 1001, 2000));
+
+    UITDb->WriteBlockCache(2);
+
+    std::pair<int64_t, int64_t> testE = UITDb->CreateNonFungibleTokens(50, 1000, "David", "");
+    BOOST_CHECK_EQUAL(2001, testE.first);
+    BOOST_CHECK_EQUAL(3000, testE.second);
+    BOOST_CHECK_EQUAL("David", UITDb->GetNonFungibleTokenValueInRange(50, 2001, 3000));
+    BOOST_CHECK(UITDb->GetNonFungibleTokenValueInRange(50, 2000, 2001).empty());
+
+    UITDb->WriteBlockCache(3);
+
+    BOOST_CHECK(UITDb->MoveNonFungibleTokens(50, 2001, 2100, "David", "Charles"));
+    BOOST_CHECK_EQUAL("Charles", UITDb->GetNonFungibleTokenValueInRange(50, 2001, 2100));
+    BOOST_CHECK_EQUAL("David", UITDb->GetNonFungibleTokenValueInRange(50, 2101, 3000));
+    BOOST_CHECK(UITDb->GetNonFungibleTokenValueInRange(50, 2001, 3000).empty());
+
+    UITDb->WriteBlockCache(4);
+
+    // rollback above block 4
+    UITDb->RollBackAboveBlock(4);
+    BOOST_CHECK_EQUAL("David", UITDb->GetNonFungibleTokenValueInRange(50, 2001, 3000));
+
+    // rollback above block 2
+    UITDb->RollBackAboveBlock(2);
+    BOOST_CHECK(UITDb->GetNonFungibleTokenValueInRange(50, 2001, 3000).empty());
+    BOOST_CHECK(UITDb->GetNonFungibleTokenValueInRange(50, 1001, 2000).empty());
+    BOOST_CHECK_EQUAL("David", UITDb->GetNonFungibleTokenValueInRange(50, 1, 1000));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/omnicore/walletutils.cpp
+++ b/src/omnicore/walletutils.cpp
@@ -206,7 +206,7 @@ int64_t SelectCoins(interfaces::Wallet& iWallet, const std::string& fromAddress,
 {
     // total output funds collected
     int64_t nTotal = 0;
-    int nHeight = ::ChainActive().Height();
+    int nHeight = mastercore::GetHeight();
 
     std::map<uint256, interfaces::WalletTxStatus> tx_status;
     const std::vector<interfaces::WalletTx>& transactions = iWallet.getWalletTxsDetails(tx_status);
@@ -286,7 +286,7 @@ int64_t SelectAllCoins(interfaces::Wallet& iWallet, const std::string& fromAddre
 {
     // total output funds collected
     int64_t nTotal = 0;
-    int nHeight = ::ChainActive().Height();
+    int nHeight = mastercore::GetHeight();
 
     std::map<uint256, interfaces::WalletTxStatus> tx_status;
     const std::vector<interfaces::WalletTx>& transactions = iWallet.getWalletTxsDetails(tx_status);

--- a/test/functional/omni_nonfungibletokens.py
+++ b/test/functional/omni_nonfungibletokens.py
@@ -674,7 +674,7 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
         rawtx = self.nodes[1].omni_createrawtx_opreturn(rawtx, payload)
         signed_rawtx = self.nodes[1].signrawtransactionwithwallet(rawtx)
         txid = self.nodes[1].sendrawtransaction(signed_rawtx['hex'])
-        self.nodes[1].generate(1)
+        blockhash = self.nodes[1].generate(1)[0]
 
         # Check transaction is valid
         result = self.nodes[1].omni_gettransaction(txid)
@@ -720,6 +720,15 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
         # Check issuer data same as before by non-issuer
         result = self.nodes[1].omni_getnonfungibletokendata(property_id, 102)
         assert_equal(result[0]['holderdata'], 'Test non-issuer update')
+
+        # reorg
+        self.nodes[0].invalidateblock(blockhash)
+        self.nodes[0].clearmempool()
+        self.nodes[0].generate(15)
+        self.sync_all()
+
+        result = self.nodes[1].omni_getnonfungibletokendata(property_id, 102)
+        assert_equal(result[0]['holderdata'], 'New holderdata')
 
 if __name__ == '__main__':
     OmniNonFungibleTokensTest().main()


### PR DESCRIPTION
* Add ability to store keys by prefix
* Add ability iterator to use prefix
* Store block rollback data, restored on reorg
* Faster `SanityCheck` on block data changes
* Unit and functional tests