### PR TITLE
Store every 100 blocks persistence storage after IBD

### DIFF
--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -25,9 +25,10 @@ class Coin;
 #include <set>
 #include <unordered_map>
 
-// Also store the state every 10000 blocks to be able to recover
-// from a crash or shutdown during reparse more quickly
-int const STORE_EVERY_N_BLOCK = 10000;
+// Store the state every 100 blocks to handle reorg
+int const STORE_EVERY_N_BLOCK = 100;
+// Store the state every 10000 blocks during initial block download
+int const STORE_EVERY_N_BLOCK_IDB = 10000;
 // Don't store the state every block on mainnet until block 770000
 // was reached, can be set with -omniskipstoringstate.
 int const DONT_STORE_MAINNET_STATE_UNTIL = 770000;

--- a/src/omnicore/persistence.cpp
+++ b/src/omnicore/persistence.cpp
@@ -521,8 +521,10 @@ bool IsPersistenceEnabled(int blockHeight)
     }
 
     int nMinHeight = GetWrapModeHeight();
+    int nStoreEveryBlock = ::ChainstateActive().IsInitialBlockDownload() ?
+                            STORE_EVERY_N_BLOCK_IDB : STORE_EVERY_N_BLOCK;
     // if too far away from the top -- do not write
-    return blockHeight > nMinHeight && (blockHeight % STORE_EVERY_N_BLOCK == 0);
+    return blockHeight > nMinHeight && (blockHeight % nStoreEveryBlock == 0);
 }
 
 /**


### PR DESCRIPTION
#1296 limit persistence storage to once on every 10k blocks, that's not ideal in case of reorg so this PR fix the issue storing records in 100 blocks after initial block download