### PR TITLE
Nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,64 @@
+name: Nightly build
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  build_x64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Guix and locales
+        run: |
+          sudo apt install guix
+          guix pull --keep-going --fallback
+          guix package --search-paths -p "${HOME}/.config/guix/current"
+          guix install glibc-locales
+          echo GUIX_PROFILE="${HOME}/.config/guix/current" >> "${GITHUB_ENV}"
+          echo GUIX_LOCPATH="${HOME}/.guix-profile/lib/locale" >> "${GITHUB_ENV}"
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
+      - name: Build packages
+        run: |
+          mkdir -p "$PWD/SDKs"
+          wget https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
+          tar -C "$PWD/SDKs" -xaf Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
+          export SDK_PATH="$PWD/SDKs"
+          env HOSTS='x86_64-linux-gnu x86_64-w64-mingw32 x86_64-apple-darwin' ${GITHUB_WORKSPACE}/contrib/guix/guix-build
+      - name: Publish builds
+        uses: pyTooling/Actions/releaser@main
+        with:
+          tag: nightly
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            **/*-x86_64-linux-gnu.tar.gz
+            **/*-win64.zip
+            **/*-x86_64-apple-darwin.tar.gz
+
+  build_ARM:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Guix and locales
+        run: |
+          sudo apt install guix
+          guix pull --keep-going --fallback
+          guix package --search-paths -p "${HOME}/.config/guix/current"
+          guix install glibc-locales
+          echo GUIX_PROFILE="${HOME}/.config/guix/current" >> "${GITHUB_ENV}"
+          echo GUIX_LOCPATH="${HOME}/.guix-profile/lib/locale" >> "${GITHUB_ENV}"
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
+      - name: Build packages
+        run: |
+          mkdir -p "$PWD/SDKs"
+          wget https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
+          tar -C "$PWD/SDKs" -xaf Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
+          export SDK_PATH="$PWD/SDKs"
+          env HOSTS='aarch64-linux-gnu arm64-apple-darwin' ${GITHUB_WORKSPACE}/contrib/guix/guix-build
+      - name: Publish builds
+        uses: pyTooling/Actions/releaser@main
+        with:
+          tag: nightly
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            **/*-aarch64-linux-gnu.tar.gz
+            **/*-arm64-apple-darwin.tar.gz

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -440,7 +440,7 @@ EOF
                                  ${BASE_CACHE:+--share="$BASE_CACHE"} \
                                  ${SDK_PATH:+--share="$SDK_PATH"} \
                                  --cores="$JOBS" \
-                                 --keep-failed \
+                                 --keep-going \
                                  --fallback \
                                  --link-profile \
                                  --root="$(profiledir_for_host "${HOST}")" \

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -355,7 +355,7 @@ EOF
                                  --expose="$(git -C "$DETACHED_SIGS_REPO" rev-parse --git-common-dir)" \
                                  ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
                                  --cores="$JOBS" \
-                                 --keep-failed \
+                                 --keep-going \
                                  --fallback \
                                  --link-profile \
                                  --root="$(profiledir_for_host "${HOST}" codesigned)" \

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -53,7 +53,7 @@ time-machine() {
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
                       --commit=998eda3067c7d21e0d9bb3310d2f5a14b8f1c681 \
                       --cores="$JOBS" \
-                      --keep-failed \
+                      --keep-going \
                       --fallback \
                       ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
                       ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_TIMEMACHINE_FLAGS} \
@@ -66,7 +66,7 @@ time-machine() {
 ################
 
 VERSION="${FORCE_VERSION:-$(git_head_version)}"
-DISTNAME="${DISTNAME:-bitcoin-${VERSION}}"
+DISTNAME="${DISTNAME:-omnicore-${VERSION}}"
 
 version_base_prefix="${PWD}/guix-build-"
 VERSION_BASE="${version_base_prefix}${VERSION}"  # TOP


### PR DESCRIPTION
A tag `nightly` (it could have different name) needs to be created among others. The following action will be triggered on every push in `develop` branch and will upload artefacts to the tag. In order action to have permission to upload the artefacts in Settings -> Actions -> General -> Workflow permissions -> Read/Write permissions should be selected.
GitHub job time is limited to 360 min the fifthlet takes more, so action is split to two jobs, x64 and arm.
Derivation may fail randomly and/or for slow connection, it's pretty annoying that's why [--keep-going](https://manpages.debian.org/testing/guix/guix-pull.1.en.html#k) is preferred over [--keep-failed](https://manpages.debian.org/testing/guix/guix-pull.1.en.html#K)

Here is how it looks on my fork https://github.com/bvbfan/omnicore/releases/tag/nightly