### PR TITLE
Update omnicore-rpc-tests.sh to use OMNIJ_BRANCH env variable  to checkout a custom branch/tag

### DIFF
--- a/test/pull-tester/omnicore-rpc-tests.sh
+++ b/test/pull-tester/omnicore-rpc-tests.sh
@@ -21,7 +21,12 @@ DATADIR="$TESTDIR/.bitcoin"
 # Start clean
 rm -rf "$BUILDDIR/test/tmp"
 
-git clone https://github.com/OmniLayer/OmniJ.git $TESTDIR
+if [ -z "$OMNIJ_BRANCH" ]; then
+  OMNIJ_BRANCH="master";
+fi
+
+git clone --branch $OMNIJ_BRANCH https://github.com/OmniLayer/OmniJ.git $TESTDIR
+
 mkdir -p "$DATADIR/regtest"
 touch "$DATADIR/regtest/omnicore.log"
 cd $TESTDIR || exit


### PR DESCRIPTION
The default behavior is to checkout OmniJ `master` branch, but you can set the environment variable `OMNIJ_BRANCH` to either a branch or a tag and that branch/commit will be checked out in the clone repository instead.

This can be used to use a specific OmniJ version for running the tests.

For example:
```
export OMNIJ_BRANCH=v0.6.3
./omnicore-rpc-tests.sh
```