### PR TITLE
avoid overriding other targets every time in debug levels setting iterator

### DIFF
--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -236,7 +236,7 @@ void InitDebugLogLevels()
     for (const auto& d : debugLevels) {
         auto none = d == "none";
         auto all = d == "all";
-#define ENABLE_LOG(x) msc_debug_##x = none ? false : (all || d == #x)
+#define ENABLE_LOG(x) msc_debug_##x = none ? false : (all || d == #x || msc_debug_##x)
         ENABLE_LOG(parser_data);
         ENABLE_LOG(parser_readonly);
         ENABLE_LOG(parser_dex);


### PR DESCRIPTION
In the debug levels setting function, every time we iterate the targets, other targets will change to false due to `d != #x`. We need to set the other targets to its former value.